### PR TITLE
fix: restore touch selection for PWA combobox drawers

### DIFF
--- a/client/src/components/exercise-combobox.test.tsx
+++ b/client/src/components/exercise-combobox.test.tsx
@@ -1,8 +1,11 @@
 import { createEvent, fireEvent, render, screen } from '@testing-library/react';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ExerciseCombobox } from '@/components/exercise-combobox';
 
 let mediaQueryMatches = false;
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+const originalMatchMedia = globalThis.matchMedia;
 
 beforeAll(() => {
   class ResizeObserverMock {
@@ -41,6 +44,44 @@ beforeEach(() => {
   mediaQueryMatches = false;
 });
 
+afterAll(() => {
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    value: originalResizeObserver,
+    writable: true,
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    value: originalScrollIntoView,
+    writable: true,
+  });
+
+  Object.defineProperty(globalThis, 'matchMedia', {
+    value: originalMatchMedia,
+    writable: true,
+  });
+});
+
+function touchStart(target: Element, x = 8, y = 12) {
+  fireEvent.touchStart(target, {
+    touches: [{ clientX: x, clientY: y }],
+    changedTouches: [{ clientX: x, clientY: y }],
+  });
+}
+
+function touchEnd(target: Element, x = 8, y = 12) {
+  const event = createEvent.touchEnd(target, {
+    changedTouches: [{ clientX: x, clientY: y }],
+  });
+
+  fireEvent(target, event);
+  return event;
+}
+
+function touchTap(target: Element, x = 8, y = 12) {
+  touchStart(target, x, y);
+  return touchEnd(target, x, y);
+}
+
 async function renderMobileExerciseCombobox(onCreate = vi.fn()) {
   render(
     <ExerciseCombobox
@@ -71,33 +112,19 @@ describe('ExerciseCombobox create row', () => {
   it('creates an option on touch release in the mobile drawer path', async () => {
     const { createRow, onCreate } = await renderMobileExerciseCombobox();
 
-    fireEvent.touchStart(createRow, {
-      touches: [{ clientX: 8, clientY: 12 }],
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
-
-    const touchEnd = createEvent.touchEnd(createRow, {
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
-
-    fireEvent(createRow, touchEnd);
+    const releasedTouch = touchTap(createRow);
 
     expect(onCreate).toHaveBeenCalledTimes(1);
     expect(onCreate).toHaveBeenCalledWith('Bench');
-    expect(touchEnd.defaultPrevented).toBe(true);
+    expect(releasedTouch.defaultPrevented).toBe(true);
   });
 
   it('does not create an option after touch tracking is canceled', async () => {
     const { createRow, onCreate } = await renderMobileExerciseCombobox();
 
-    fireEvent.touchStart(createRow, {
-      touches: [{ clientX: 8, clientY: 12 }],
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
+    touchStart(createRow);
     fireEvent.touchCancel(createRow);
-    fireEvent.touchEnd(createRow, {
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
+    touchEnd(createRow);
 
     expect(onCreate).not.toHaveBeenCalled();
   });
@@ -105,13 +132,7 @@ describe('ExerciseCombobox create row', () => {
   it('does not create a duplicate option after a follow-up click', async () => {
     const { createRow, onCreate } = await renderMobileExerciseCombobox();
 
-    fireEvent.touchStart(createRow, {
-      touches: [{ clientX: 8, clientY: 12 }],
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
-    fireEvent.touchEnd(createRow, {
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
+    touchTap(createRow);
     fireEvent.click(createRow);
 
     expect(onCreate).toHaveBeenCalledTimes(1);

--- a/client/src/components/exercise-combobox.test.tsx
+++ b/client/src/components/exercise-combobox.test.tsx
@@ -1,0 +1,104 @@
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ExerciseCombobox } from '@/components/exercise-combobox';
+
+let mediaQueryMatches = false;
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    value: ResizeObserverMock,
+    writable: true,
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    value: () => {},
+    writable: true,
+  });
+
+  Object.defineProperty(globalThis, 'matchMedia', {
+    value: (query: string) =>
+      ({
+        matches: mediaQueryMatches,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList,
+    writable: true,
+  });
+});
+
+beforeEach(() => {
+  mediaQueryMatches = false;
+});
+
+async function renderMobileExerciseCombobox(onCreate = vi.fn()) {
+  render(
+    <ExerciseCombobox
+      options={[{ id: 1, name: 'Squat' }]}
+      selected=""
+      onChange={vi.fn()}
+      onCreate={onCreate}
+    />
+  );
+
+  const trigger = screen.getByText('Select exercise...').closest('button');
+
+  if (!trigger) {
+    throw new Error('Expected exercise combobox trigger button');
+  }
+
+  fireEvent.click(trigger);
+  fireEvent.change(screen.getByPlaceholderText('Search exercises...'), {
+    target: { value: 'Bench' },
+  });
+
+  const [createRow] = await screen.findAllByText('Create "Bench"');
+
+  return { createRow, onCreate };
+}
+
+describe('ExerciseCombobox create row', () => {
+  it('creates an option on touch release in the mobile drawer path', async () => {
+    const { createRow, onCreate } = await renderMobileExerciseCombobox();
+
+    fireEvent.touchStart(createRow, {
+      touches: [{ clientX: 8, clientY: 12 }],
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+
+    const touchEnd = createEvent.touchEnd(createRow, {
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+
+    fireEvent(createRow, touchEnd);
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate).toHaveBeenCalledWith('Bench');
+    expect(touchEnd.defaultPrevented).toBe(true);
+  });
+
+  it('does not create an option after touch tracking is canceled', async () => {
+    const { createRow, onCreate } = await renderMobileExerciseCombobox();
+
+    fireEvent.touchStart(createRow, {
+      touches: [{ clientX: 8, clientY: 12 }],
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+    fireEvent.touchCancel(createRow);
+    fireEvent.touchEnd(createRow, {
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/exercise-combobox.test.tsx
+++ b/client/src/components/exercise-combobox.test.tsx
@@ -101,4 +101,19 @@ describe('ExerciseCombobox create row', () => {
 
     expect(onCreate).not.toHaveBeenCalled();
   });
+
+  it('does not create a duplicate option after a follow-up click', async () => {
+    const { createRow, onCreate } = await renderMobileExerciseCombobox();
+
+    fireEvent.touchStart(createRow, {
+      touches: [{ clientX: 8, clientY: 12 }],
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+    fireEvent.touchEnd(createRow, {
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+    fireEvent.click(createRow);
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
 });

--- a/client/src/components/exercise-combobox.tsx
+++ b/client/src/components/exercise-combobox.tsx
@@ -1,6 +1,14 @@
 import { type KeyboardEvent, useEffect, useState } from 'react';
 import { Check, ChevronsUpDown, CirclePlus } from 'lucide-react';
 import { useMediaQuery } from '@/hooks/use-media-query';
+import {
+  beginTouchTapTracking,
+  cancelTouchTapTracking,
+  finishTouchTapTracking,
+  hasRecentTouchActivation,
+  markRecentTouchActivation,
+  updateTouchTapTracking,
+} from '@/lib/touch-activation';
 import { Button } from '@/components/ui/button';
 import {
   Command,
@@ -42,8 +50,57 @@ function CommandAddItem({
   return (
     <div
       tabIndex={0}
+      onClickCapture={(event) => {
+        if (!hasRecentTouchActivation(event.currentTarget, event.timeStamp)) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+      }}
       onClick={onCreate}
+      onPointerDown={(event) => {
+        if (event.pointerType !== 'touch') {
+          return;
+        }
+
+        beginTouchTapTracking(event.currentTarget, event);
+      }}
+      onPointerMove={(event) => {
+        if (event.pointerType !== 'touch') {
+          return;
+        }
+
+        updateTouchTapTracking(event.currentTarget, event);
+      }}
+      onPointerCancel={(event) => {
+        if (event.pointerType !== 'touch') {
+          return;
+        }
+
+        cancelTouchTapTracking(event.currentTarget);
+      }}
+      onPointerUp={(event) => {
+        if (event.pointerType !== 'touch') {
+          return;
+        }
+
+        if (!finishTouchTapTracking(event.currentTarget, event)) {
+          return;
+        }
+
+        markRecentTouchActivation(event.currentTarget, event.timeStamp);
+        onCreate();
+      }}
+      onTouchStart={(event) => beginTouchTapTracking(event.currentTarget, event)}
+      onTouchMove={(event) => updateTouchTapTracking(event.currentTarget, event)}
+      onTouchCancel={(event) => cancelTouchTapTracking(event.currentTarget)}
       onTouchEnd={(event) => {
+        if (!finishTouchTapTracking(event.currentTarget, event)) {
+          return;
+        }
+
+        markRecentTouchActivation(event.currentTarget, event.timeStamp);
         event.preventDefault();
         onCreate();
       }}

--- a/client/src/components/exercise-combobox.tsx
+++ b/client/src/components/exercise-combobox.tsx
@@ -43,12 +43,16 @@ function CommandAddItem({
     <div
       tabIndex={0}
       onClick={onCreate}
+      onTouchEnd={(event) => {
+        event.preventDefault();
+        onCreate();
+      }}
       onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
         if (event.key === 'Enter') {
           onCreate();
         }
       }}
-      className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 focus:outline-none"
+      className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 focus:outline-none touch-manipulation"
     >
       <CirclePlus className="mr-2 h-4 w-4" />
       Create "{query}"

--- a/client/src/components/exercise-combobox.tsx
+++ b/client/src/components/exercise-combobox.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, useEffect, useState } from 'react';
+import { type ComponentProps, type KeyboardEvent, useEffect, useState } from 'react';
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useMediaQuery } from '@/hooks/use-media-query';
 import { Button } from '@/components/ui/button';
@@ -17,8 +17,20 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import {
+  activateTouchTap,
+  beginTouchTapTracking,
+  cancelTouchTapTracking,
+  shouldSuppressTouchClick,
+  updateTouchTapTracking,
+} from '@/lib/touch-activation';
 import { cn } from '@/lib/utils';
 import type { ExerciseOption } from '@/lib/api/exercises';
+
+type CommandItemTouchHandlers = Pick<
+  ComponentProps<typeof CommandItem>,
+  'onClickCapture' | 'onTouchCancel' | 'onTouchEnd' | 'onTouchMove' | 'onTouchStart'
+>;
 
 interface ComboboxProps {
   options: ExerciseOption[]; // Can include both DB exercises and manually created ones
@@ -39,6 +51,7 @@ function ExerciseList({
   setOpen,
   onChange,
   onCreate,
+  touchEnabled,
 }: {
   options: ExerciseOption[]; // Can include both DB exercises and manually created ones
   selected: ExerciseOption['name'];
@@ -48,6 +61,7 @@ function ExerciseList({
   setOpen: (open: boolean) => void;
   onChange: (option: ExerciseOption) => void;
   onCreate?: (label: ExerciseOption['name']) => void;
+  touchEnabled: boolean;
 }) {
   function handleSelect(option: ExerciseOption) {
     if (onChange) {
@@ -64,6 +78,31 @@ function ExerciseList({
       setQuery('');
     }
   }
+
+  const touchActivationHandlers: CommandItemTouchHandlers = touchEnabled
+    ? {
+        onClickCapture: (event) => {
+          if (!shouldSuppressTouchClick(event.currentTarget, event.timeStamp)) {
+            return;
+          }
+
+          event.preventDefault();
+          event.stopPropagation();
+        },
+        onTouchStart: (event) => {
+          beginTouchTapTracking(event.currentTarget, event);
+        },
+        onTouchMove: (event) => {
+          updateTouchTapTracking(event.currentTarget, event);
+        },
+        onTouchCancel: (event) => {
+          cancelTouchTapTracking(event.currentTarget);
+        },
+        onTouchEnd: (event) => {
+          activateTouchTap(event.currentTarget, event);
+        },
+      }
+    : {};
 
   return (
     <Command
@@ -87,7 +126,11 @@ function ExerciseList({
       />
       <CommandEmpty className="flex pl-1 py-1 w-full">
         {query && canCreate && (
-          <CommandAddItem query={query} onCreate={handleCreate} />
+          <CommandAddItem
+            query={query}
+            onCreate={handleCreate}
+            touchEnabled={touchEnabled}
+          />
         )}
       </CommandEmpty>
       <CommandList>
@@ -101,7 +144,11 @@ function ExerciseList({
           )}
           {/* Create option - shown when there are existing options but query doesn't match */}
           {options.length > 0 && canCreate && (
-            <CommandAddItem query={query} onCreate={handleCreate} />
+            <CommandAddItem
+              query={query}
+              onCreate={handleCreate}
+              touchEnabled={touchEnabled}
+            />
           )}
           {/* Select options */}
           {options.map((option) => (
@@ -116,7 +163,8 @@ function ExerciseList({
                   handleSelect(option);
                 }
               }}
-              className={cn('cursor-pointer')}
+              {...touchActivationHandlers}
+              className={cn('cursor-pointer', touchEnabled && 'touch-manipulation')}
             >
               <Check
                 className={cn(
@@ -187,6 +235,7 @@ export function ExerciseCombobox({
             setOpen={setOpen}
             onChange={onChange}
             onCreate={onCreate}
+            touchEnabled={false}
           />
         </PopoverContent>
       </Popover>
@@ -207,6 +256,7 @@ export function ExerciseCombobox({
             setOpen={setOpen}
             onChange={onChange}
             onCreate={onCreate}
+            touchEnabled
           />
         </div>
       </DrawerContent>

--- a/client/src/components/exercise-combobox.tsx
+++ b/client/src/components/exercise-combobox.tsx
@@ -1,15 +1,8 @@
 import { type KeyboardEvent, useEffect, useState } from 'react';
-import { Check, ChevronsUpDown, CirclePlus } from 'lucide-react';
+import { Check, ChevronsUpDown } from 'lucide-react';
 import { useMediaQuery } from '@/hooks/use-media-query';
-import {
-  beginTouchTapTracking,
-  cancelTouchTapTracking,
-  finishTouchTapTracking,
-  hasRecentTouchActivation,
-  markRecentTouchActivation,
-  updateTouchTapTracking,
-} from '@/lib/touch-activation';
 import { Button } from '@/components/ui/button';
+import { CommandAddItem } from '@/components/ui/command-add-item';
 import {
   Command,
   CommandEmpty,
@@ -35,86 +28,6 @@ interface ComboboxProps {
   disabled?: boolean;
   onChange: (option: ExerciseOption) => void;
   onCreate?: (label: ExerciseOption['name']) => void;
-}
-
-/**
- * CommandItem to create a new query content
- */
-function CommandAddItem({
-  query,
-  onCreate,
-}: {
-  query: string;
-  onCreate: () => void;
-}) {
-  return (
-    <div
-      tabIndex={0}
-      onClickCapture={(event) => {
-        if (!hasRecentTouchActivation(event.currentTarget, event.timeStamp)) {
-          return;
-        }
-
-        event.preventDefault();
-        event.stopPropagation();
-      }}
-      onClick={onCreate}
-      onPointerDown={(event) => {
-        if (event.pointerType !== 'touch') {
-          return;
-        }
-
-        beginTouchTapTracking(event.currentTarget, event);
-      }}
-      onPointerMove={(event) => {
-        if (event.pointerType !== 'touch') {
-          return;
-        }
-
-        updateTouchTapTracking(event.currentTarget, event);
-      }}
-      onPointerCancel={(event) => {
-        if (event.pointerType !== 'touch') {
-          return;
-        }
-
-        cancelTouchTapTracking(event.currentTarget);
-      }}
-      onPointerUp={(event) => {
-        if (event.pointerType !== 'touch') {
-          return;
-        }
-
-        if (!finishTouchTapTracking(event.currentTarget, event)) {
-          return;
-        }
-
-        markRecentTouchActivation(event.currentTarget, event.timeStamp);
-        onCreate();
-      }}
-      onTouchStart={(event) => beginTouchTapTracking(event.currentTarget, event)}
-      onTouchMove={(event) => updateTouchTapTracking(event.currentTarget, event)}
-      onTouchCancel={(event) => cancelTouchTapTracking(event.currentTarget)}
-      onTouchEnd={(event) => {
-        if (!finishTouchTapTracking(event.currentTarget, event)) {
-          return;
-        }
-
-        markRecentTouchActivation(event.currentTarget, event.timeStamp);
-        event.preventDefault();
-        onCreate();
-      }}
-      onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
-        if (event.key === 'Enter') {
-          onCreate();
-        }
-      }}
-      className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 focus:outline-none touch-manipulation"
-    >
-      <CirclePlus className="mr-2 h-4 w-4" />
-      Create "{query}"
-    </div>
-  );
 }
 
 function ExerciseList({

--- a/client/src/components/generic-combobox.test.tsx
+++ b/client/src/components/generic-combobox.test.tsx
@@ -93,25 +93,36 @@ describe('GenericCombobox create row', () => {
     expect(touchEnd.defaultPrevented).toBe(true);
   });
 
-  it('does not create an option after a pointer drag gesture', async () => {
+  it('does not create an option after a touch drag gesture', async () => {
     const { createRow, onCreate } = await renderGenericCombobox({ isDesktop: true });
 
-    fireEvent.pointerDown(createRow, {
-      pointerType: 'touch',
-      clientX: 8,
-      clientY: 12,
+    fireEvent.touchStart(createRow, {
+      touches: [{ clientX: 8, clientY: 12 }],
+      changedTouches: [{ clientX: 8, clientY: 12 }],
     });
-    fireEvent.pointerMove(createRow, {
-      pointerType: 'touch',
-      clientX: 8,
-      clientY: 40,
+    fireEvent.touchMove(createRow, {
+      touches: [{ clientX: 8, clientY: 40 }],
+      changedTouches: [{ clientX: 8, clientY: 40 }],
     });
-    fireEvent.pointerUp(createRow, {
-      pointerType: 'touch',
-      clientX: 8,
-      clientY: 40,
+    fireEvent.touchEnd(createRow, {
+      changedTouches: [{ clientX: 8, clientY: 40 }],
     });
 
     expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it('does not create a duplicate option after a follow-up click', async () => {
+    const { createRow, onCreate } = await renderGenericCombobox();
+
+    fireEvent.touchStart(createRow, {
+      touches: [{ clientX: 8, clientY: 12 }],
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+    fireEvent.touchEnd(createRow, {
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+    fireEvent.click(createRow);
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/components/generic-combobox.test.tsx
+++ b/client/src/components/generic-combobox.test.tsx
@@ -1,0 +1,117 @@
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GenericCombobox } from '@/components/generic-combobox';
+
+let mediaQueryMatches = false;
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    value: ResizeObserverMock,
+    writable: true,
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    value: () => {},
+    writable: true,
+  });
+
+  Object.defineProperty(globalThis, 'matchMedia', {
+    value: (query: string) =>
+      ({
+        matches: mediaQueryMatches,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList,
+    writable: true,
+  });
+});
+
+beforeEach(() => {
+  mediaQueryMatches = false;
+});
+
+async function renderGenericCombobox({
+  isDesktop = false,
+  onCreate = vi.fn(),
+}: {
+  isDesktop?: boolean;
+  onCreate?: ReturnType<typeof vi.fn>;
+} = {}) {
+  mediaQueryMatches = isDesktop;
+
+  render(
+    <GenericCombobox
+      options={[{ name: 'Squat' }]}
+      selected=""
+      ariaLabel="Exercise type"
+      inputAriaLabel="Search options"
+      onChange={vi.fn()}
+      onCreate={onCreate}
+    />
+  );
+
+  fireEvent.click(screen.getByRole('combobox', { name: 'Exercise type' }));
+  fireEvent.change(screen.getByPlaceholderText('Search options...'), {
+    target: { value: 'Bench' },
+  });
+
+  const [createRow] = await screen.findAllByRole('option', {
+    name: 'Create "Bench"',
+  });
+
+  return { createRow, onCreate };
+}
+
+describe('GenericCombobox create row', () => {
+  it('creates an option on touch release in the mobile drawer path', async () => {
+    const { createRow, onCreate } = await renderGenericCombobox();
+
+    fireEvent.touchStart(createRow, {
+      touches: [{ clientX: 8, clientY: 12 }],
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+
+    const touchEnd = createEvent.touchEnd(createRow, {
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+
+    fireEvent(createRow, touchEnd);
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate).toHaveBeenCalledWith('Bench');
+    expect(touchEnd.defaultPrevented).toBe(true);
+  });
+
+  it('does not create an option after a pointer drag gesture', async () => {
+    const { createRow, onCreate } = await renderGenericCombobox({ isDesktop: true });
+
+    fireEvent.pointerDown(createRow, {
+      pointerType: 'touch',
+      clientX: 8,
+      clientY: 12,
+    });
+    fireEvent.pointerMove(createRow, {
+      pointerType: 'touch',
+      clientX: 8,
+      clientY: 40,
+    });
+    fireEvent.pointerUp(createRow, {
+      pointerType: 'touch',
+      clientX: 8,
+      clientY: 40,
+    });
+
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/generic-combobox.test.tsx
+++ b/client/src/components/generic-combobox.test.tsx
@@ -1,8 +1,11 @@
 import { createEvent, fireEvent, render, screen } from '@testing-library/react';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GenericCombobox } from '@/components/generic-combobox';
 
 let mediaQueryMatches = false;
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+const originalMatchMedia = globalThis.matchMedia;
 
 beforeAll(() => {
   class ResizeObserverMock {
@@ -41,11 +44,51 @@ beforeEach(() => {
   mediaQueryMatches = false;
 });
 
+afterAll(() => {
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    value: originalResizeObserver,
+    writable: true,
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    value: originalScrollIntoView,
+    writable: true,
+  });
+
+  Object.defineProperty(globalThis, 'matchMedia', {
+    value: originalMatchMedia,
+    writable: true,
+  });
+});
+
+function touchStart(target: Element, x = 8, y = 12) {
+  fireEvent.touchStart(target, {
+    touches: [{ clientX: x, clientY: y }],
+    changedTouches: [{ clientX: x, clientY: y }],
+  });
+}
+
+function touchEnd(target: Element, x = 8, y = 12) {
+  const event = createEvent.touchEnd(target, {
+    changedTouches: [{ clientX: x, clientY: y }],
+  });
+
+  fireEvent(target, event);
+  return event;
+}
+
+function touchTap(target: Element, x = 8, y = 12) {
+  touchStart(target, x, y);
+  return touchEnd(target, x, y);
+}
+
 async function renderGenericCombobox({
   isDesktop = false,
+  onChange = vi.fn(),
   onCreate = vi.fn(),
 }: {
   isDesktop?: boolean;
+  onChange?: ReturnType<typeof vi.fn>;
   onCreate?: ReturnType<typeof vi.fn>;
 } = {}) {
   mediaQueryMatches = isDesktop;
@@ -56,71 +99,104 @@ async function renderGenericCombobox({
       selected=""
       ariaLabel="Exercise type"
       inputAriaLabel="Search options"
-      onChange={vi.fn()}
+      onChange={onChange}
       onCreate={onCreate}
     />
   );
 
   fireEvent.click(screen.getByRole('combobox', { name: 'Exercise type' }));
-  fireEvent.change(screen.getByPlaceholderText('Search options...'), {
-    target: { value: 'Bench' },
-  });
 
-  const [createRow] = await screen.findAllByRole('option', {
-    name: 'Create "Bench"',
-  });
-
-  return { createRow, onCreate };
+  return { onChange, onCreate };
 }
 
-describe('GenericCombobox create row', () => {
-  it('creates an option on touch release in the mobile drawer path', async () => {
-    const { createRow, onCreate } = await renderGenericCombobox();
+describe('GenericCombobox touch activation', () => {
+  it('selects an existing option on touch release in the mobile drawer path', async () => {
+    const onChange = vi.fn();
+    await renderGenericCombobox({ onChange });
 
-    fireEvent.touchStart(createRow, {
-      touches: [{ clientX: 8, clientY: 12 }],
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
+    const option = await screen.findByRole('option', { name: 'Squat' });
+    const releasedTouch = touchTap(option);
 
-    const touchEnd = createEvent.touchEnd(createRow, {
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
-
-    fireEvent(createRow, touchEnd);
-
-    expect(onCreate).toHaveBeenCalledTimes(1);
-    expect(onCreate).toHaveBeenCalledWith('Bench');
-    expect(touchEnd.defaultPrevented).toBe(true);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ name: 'Squat' });
+    expect(releasedTouch.defaultPrevented).toBe(true);
   });
 
-  it('does not create an option after a touch drag gesture', async () => {
-    const { createRow, onCreate } = await renderGenericCombobox({ isDesktop: true });
+  it('does not select an existing option after a drag gesture', async () => {
+    const onChange = vi.fn();
+    await renderGenericCombobox({ onChange });
 
-    fireEvent.touchStart(createRow, {
-      touches: [{ clientX: 8, clientY: 12 }],
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
-    fireEvent.touchMove(createRow, {
+    const option = await screen.findByRole('option', { name: 'Squat' });
+
+    touchStart(option);
+    fireEvent.touchMove(option, {
       touches: [{ clientX: 8, clientY: 40 }],
       changedTouches: [{ clientX: 8, clientY: 40 }],
     });
-    fireEvent.touchEnd(createRow, {
-      changedTouches: [{ clientX: 8, clientY: 40 }],
+    touchEnd(option, 8, 40);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not select an existing option twice after a follow-up click', async () => {
+    const onChange = vi.fn();
+    await renderGenericCombobox({ onChange });
+
+    const option = await screen.findByRole('option', { name: 'Squat' });
+
+    touchTap(option);
+    fireEvent.click(option);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates an option on touch release in the mobile drawer path', async () => {
+    const { onCreate } = await renderGenericCombobox();
+
+    fireEvent.change(screen.getByPlaceholderText('Search options...'), {
+      target: { value: 'Bench' },
     });
+
+    const [createRow] = await screen.findAllByRole('option', {
+      name: 'Create "Bench"',
+    });
+    const releasedTouch = touchTap(createRow);
+
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate).toHaveBeenCalledWith('Bench');
+    expect(releasedTouch.defaultPrevented).toBe(true);
+  });
+
+  it('does not create an option after touch tracking is canceled', async () => {
+    const { onCreate } = await renderGenericCombobox();
+
+    fireEvent.change(screen.getByPlaceholderText('Search options...'), {
+      target: { value: 'Bench' },
+    });
+
+    const [createRow] = await screen.findAllByRole('option', {
+      name: 'Create "Bench"',
+    });
+
+    touchStart(createRow);
+    fireEvent.touchCancel(createRow);
+    touchEnd(createRow);
 
     expect(onCreate).not.toHaveBeenCalled();
   });
 
   it('does not create a duplicate option after a follow-up click', async () => {
-    const { createRow, onCreate } = await renderGenericCombobox();
+    const { onCreate } = await renderGenericCombobox();
 
-    fireEvent.touchStart(createRow, {
-      touches: [{ clientX: 8, clientY: 12 }],
-      changedTouches: [{ clientX: 8, clientY: 12 }],
+    fireEvent.change(screen.getByPlaceholderText('Search options...'), {
+      target: { value: 'Bench' },
     });
-    fireEvent.touchEnd(createRow, {
-      changedTouches: [{ clientX: 8, clientY: 12 }],
+
+    const [createRow] = await screen.findAllByRole('option', {
+      name: 'Create "Bench"',
     });
+
+    touchTap(createRow);
     fireEvent.click(createRow);
 
     expect(onCreate).toHaveBeenCalledTimes(1);

--- a/client/src/components/generic-combobox.tsx
+++ b/client/src/components/generic-combobox.tsx
@@ -1,6 +1,14 @@
 import { type KeyboardEvent, useEffect, useState } from 'react';
 import { Check, ChevronsUpDown, CirclePlus } from 'lucide-react';
 import { useMediaQuery } from '@/hooks/use-media-query';
+import {
+  beginTouchTapTracking,
+  cancelTouchTapTracking,
+  finishTouchTapTracking,
+  hasRecentTouchActivation,
+  markRecentTouchActivation,
+  updateTouchTapTracking,
+} from '@/lib/touch-activation';
 import { Button } from '@/components/ui/button';
 import {
   Command,
@@ -54,8 +62,57 @@ function CommandAddItem({
       role="option"
       aria-label={`Create "${query}"`}
       tabIndex={0}
+      onClickCapture={(event) => {
+        if (!hasRecentTouchActivation(event.currentTarget, event.timeStamp)) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+      }}
       onClick={onCreate}
+      onPointerDown={(event) => {
+        if (event.pointerType !== 'touch') {
+          return;
+        }
+
+        beginTouchTapTracking(event.currentTarget, event);
+      }}
+      onPointerMove={(event) => {
+        if (event.pointerType !== 'touch') {
+          return;
+        }
+
+        updateTouchTapTracking(event.currentTarget, event);
+      }}
+      onPointerCancel={(event) => {
+        if (event.pointerType !== 'touch') {
+          return;
+        }
+
+        cancelTouchTapTracking(event.currentTarget);
+      }}
+      onPointerUp={(event) => {
+        if (event.pointerType !== 'touch') {
+          return;
+        }
+
+        if (!finishTouchTapTracking(event.currentTarget, event)) {
+          return;
+        }
+
+        markRecentTouchActivation(event.currentTarget, event.timeStamp);
+        onCreate();
+      }}
+      onTouchStart={(event) => beginTouchTapTracking(event.currentTarget, event)}
+      onTouchMove={(event) => updateTouchTapTracking(event.currentTarget, event)}
+      onTouchCancel={(event) => cancelTouchTapTracking(event.currentTarget)}
       onTouchEnd={(event) => {
+        if (!finishTouchTapTracking(event.currentTarget, event)) {
+          return;
+        }
+
+        markRecentTouchActivation(event.currentTarget, event.timeStamp);
         event.preventDefault();
         onCreate();
       }}

--- a/client/src/components/generic-combobox.tsx
+++ b/client/src/components/generic-combobox.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, useEffect, useState } from 'react';
+import { type ComponentProps, type KeyboardEvent, useEffect, useState } from 'react';
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useMediaQuery } from '@/hooks/use-media-query';
 import { Button } from '@/components/ui/button';
@@ -17,7 +17,19 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import {
+  activateTouchTap,
+  beginTouchTapTracking,
+  cancelTouchTapTracking,
+  shouldSuppressTouchClick,
+  updateTouchTapTracking,
+} from '@/lib/touch-activation';
 import { cn } from '@/lib/utils';
+
+type CommandItemTouchHandlers = Pick<
+  ComponentProps<typeof CommandItem>,
+  'onClickCapture' | 'onTouchCancel' | 'onTouchEnd' | 'onTouchMove' | 'onTouchStart'
+>;
 
 interface ComboboxProps<T extends { name: string }> {
   /** Array of options to display in the combobox */
@@ -51,6 +63,7 @@ function GenericList<T extends { name: string }>({
   onChange,
   onCreate,
   inputAriaLabel,
+  touchEnabled,
 }: {
   options: T[];
   selected: string;
@@ -62,6 +75,7 @@ function GenericList<T extends { name: string }>({
   onChange: (option: T) => void;
   onCreate?: (label: string) => void;
   inputAriaLabel?: string;
+  touchEnabled: boolean;
 }) {
   function handleSelect(option: T) {
     if (onChange) {
@@ -78,6 +92,31 @@ function GenericList<T extends { name: string }>({
       setQuery('');
     }
   }
+
+  const touchActivationHandlers: CommandItemTouchHandlers = touchEnabled
+    ? {
+        onClickCapture: (event) => {
+          if (!shouldSuppressTouchClick(event.currentTarget, event.timeStamp)) {
+            return;
+          }
+
+          event.preventDefault();
+          event.stopPropagation();
+        },
+        onTouchStart: (event) => {
+          beginTouchTapTracking(event.currentTarget, event);
+        },
+        onTouchMove: (event) => {
+          updateTouchTapTracking(event.currentTarget, event);
+        },
+        onTouchCancel: (event) => {
+          cancelTouchTapTracking(event.currentTarget);
+        },
+        onTouchEnd: (event) => {
+          activateTouchTap(event.currentTarget, event);
+        },
+      }
+    : {};
 
   return (
     <Command
@@ -103,7 +142,11 @@ function GenericList<T extends { name: string }>({
       />
       <CommandEmpty className="flex pl-1 py-1 w-full">
         {query && canCreate && (
-          <CommandAddItem query={query} onCreate={handleCreate} />
+          <CommandAddItem
+            query={query}
+            onCreate={handleCreate}
+            touchEnabled={touchEnabled}
+          />
         )}
       </CommandEmpty>
       <CommandList>
@@ -121,7 +164,11 @@ function GenericList<T extends { name: string }>({
           )}
           {/* Create option - shown when there are existing options but query doesn't match */}
           {options.length > 0 && allowCreate && canCreate && (
-            <CommandAddItem query={query} onCreate={handleCreate} />
+            <CommandAddItem
+              query={query}
+              onCreate={handleCreate}
+              touchEnabled={touchEnabled}
+            />
           )}
           {/* Select options */}
           {options.map((option) => (
@@ -136,7 +183,8 @@ function GenericList<T extends { name: string }>({
                   handleSelect(option);
                 }
               }}
-              className={cn('cursor-pointer')}
+              {...touchActivationHandlers}
+              className={cn('cursor-pointer', touchEnabled && 'touch-manipulation')}
             >
               <Check
                 className={cn(
@@ -213,6 +261,7 @@ export function GenericCombobox<T extends { name: string }>({
           onChange={onChange}
           onCreate={onCreate}
           inputAriaLabel={inputAriaLabel}
+          touchEnabled={false}
           />
         </PopoverContent>
       </Popover>
@@ -235,6 +284,7 @@ export function GenericCombobox<T extends { name: string }>({
           onChange={onChange}
           onCreate={onCreate}
           inputAriaLabel={inputAriaLabel}
+          touchEnabled
           />
         </div>
       </DrawerContent>

--- a/client/src/components/generic-combobox.tsx
+++ b/client/src/components/generic-combobox.tsx
@@ -1,15 +1,8 @@
 import { type KeyboardEvent, useEffect, useState } from 'react';
-import { Check, ChevronsUpDown, CirclePlus } from 'lucide-react';
+import { Check, ChevronsUpDown } from 'lucide-react';
 import { useMediaQuery } from '@/hooks/use-media-query';
-import {
-  beginTouchTapTracking,
-  cancelTouchTapTracking,
-  finishTouchTapTracking,
-  hasRecentTouchActivation,
-  markRecentTouchActivation,
-  updateTouchTapTracking,
-} from '@/lib/touch-activation';
 import { Button } from '@/components/ui/button';
+import { CommandAddItem } from '@/components/ui/command-add-item';
 import {
   Command,
   CommandEmpty,
@@ -45,88 +38,6 @@ interface ComboboxProps<T extends { name: string }> {
   onChange: (option: T) => void;
   /** Callback function called when a new option is created */
   onCreate?: (label: string) => void;
-}
-
-/**
- * CommandItem to create a new query content
- */
-function CommandAddItem({
-  query,
-  onCreate,
-}: {
-  query: string;
-  onCreate: () => void;
-}) {
-  return (
-    <div
-      role="option"
-      aria-label={`Create "${query}"`}
-      tabIndex={0}
-      onClickCapture={(event) => {
-        if (!hasRecentTouchActivation(event.currentTarget, event.timeStamp)) {
-          return;
-        }
-
-        event.preventDefault();
-        event.stopPropagation();
-      }}
-      onClick={onCreate}
-      onPointerDown={(event) => {
-        if (event.pointerType !== 'touch') {
-          return;
-        }
-
-        beginTouchTapTracking(event.currentTarget, event);
-      }}
-      onPointerMove={(event) => {
-        if (event.pointerType !== 'touch') {
-          return;
-        }
-
-        updateTouchTapTracking(event.currentTarget, event);
-      }}
-      onPointerCancel={(event) => {
-        if (event.pointerType !== 'touch') {
-          return;
-        }
-
-        cancelTouchTapTracking(event.currentTarget);
-      }}
-      onPointerUp={(event) => {
-        if (event.pointerType !== 'touch') {
-          return;
-        }
-
-        if (!finishTouchTapTracking(event.currentTarget, event)) {
-          return;
-        }
-
-        markRecentTouchActivation(event.currentTarget, event.timeStamp);
-        onCreate();
-      }}
-      onTouchStart={(event) => beginTouchTapTracking(event.currentTarget, event)}
-      onTouchMove={(event) => updateTouchTapTracking(event.currentTarget, event)}
-      onTouchCancel={(event) => cancelTouchTapTracking(event.currentTarget)}
-      onTouchEnd={(event) => {
-        if (!finishTouchTapTracking(event.currentTarget, event)) {
-          return;
-        }
-
-        markRecentTouchActivation(event.currentTarget, event.timeStamp);
-        event.preventDefault();
-        onCreate();
-      }}
-      onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
-        if (event.key === 'Enter') {
-          onCreate();
-        }
-      }}
-      className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 focus:outline-none touch-manipulation"
-    >
-      <CirclePlus className="mr-2 h-4 w-4" />
-      Create "{query}"
-    </div>
-  );
 }
 
 function GenericList<T extends { name: string }>({

--- a/client/src/components/generic-combobox.tsx
+++ b/client/src/components/generic-combobox.tsx
@@ -55,12 +55,16 @@ function CommandAddItem({
       aria-label={`Create "${query}"`}
       tabIndex={0}
       onClick={onCreate}
+      onTouchEnd={(event) => {
+        event.preventDefault();
+        onCreate();
+      }}
       onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
         if (event.key === 'Enter') {
           onCreate();
         }
       }}
-      className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 focus:outline-none"
+      className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 focus:outline-none touch-manipulation"
     >
       <CirclePlus className="mr-2 h-4 w-4" />
       Create "{query}"

--- a/client/src/components/ui/command-add-item.tsx
+++ b/client/src/components/ui/command-add-item.tsx
@@ -1,52 +1,65 @@
-import { type KeyboardEvent } from 'react';
+import { type HTMLAttributes, type KeyboardEvent } from 'react';
 import { CirclePlus } from 'lucide-react';
 import {
   activateTouchTap,
   beginTouchTapTracking,
   cancelTouchTapTracking,
-  hasRecentTouchActivation,
+  shouldSuppressTouchClick,
   updateTouchTapTracking,
 } from '@/lib/touch-activation';
+
+type TouchActivationHandlers = Pick<
+  HTMLAttributes<HTMLDivElement>,
+  'onClickCapture' | 'onTouchCancel' | 'onTouchEnd' | 'onTouchMove' | 'onTouchStart'
+>;
 
 export function CommandAddItem({
   query,
   onCreate,
+  touchEnabled = false,
 }: {
   query: string;
   onCreate: () => void;
+  touchEnabled?: boolean;
 }) {
+  const touchActivationHandlers: TouchActivationHandlers = touchEnabled
+    ? {
+        onClickCapture: (event) => {
+          if (!shouldSuppressTouchClick(event.currentTarget, event.timeStamp)) {
+            return;
+          }
+
+          event.preventDefault();
+          event.stopPropagation();
+        },
+        onTouchStart: (event) => {
+          beginTouchTapTracking(event.currentTarget, event);
+        },
+        onTouchMove: (event) => {
+          updateTouchTapTracking(event.currentTarget, event);
+        },
+        onTouchCancel: (event) => {
+          cancelTouchTapTracking(event.currentTarget);
+        },
+        onTouchEnd: (event) => {
+          activateTouchTap(event.currentTarget, event);
+        },
+      }
+    : {};
+
   return (
     <div
       role="option"
       aria-label={`Create "${query}"`}
       tabIndex={0}
-      onClickCapture={(event) => {
-        if (!hasRecentTouchActivation(event.currentTarget, event.timeStamp)) {
-          return;
-        }
-
-        event.preventDefault();
-        event.stopPropagation();
-      }}
       onClick={onCreate}
-      onTouchStart={(event) => {
-        beginTouchTapTracking(event.currentTarget, event);
-      }}
-      onTouchMove={(event) => {
-        updateTouchTapTracking(event.currentTarget, event);
-      }}
-      onTouchCancel={(event) => {
-        cancelTouchTapTracking(event.currentTarget);
-      }}
-      onTouchEnd={(event) => {
-        activateTouchTap(event.currentTarget, event);
-      }}
+      {...touchActivationHandlers}
       onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
         if (event.key === 'Enter') {
           onCreate();
         }
       }}
-      className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 focus:outline-none touch-manipulation"
+      className={`flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 focus:outline-none${touchEnabled ? ' touch-manipulation' : ''}`}
     >
       <CirclePlus className="mr-2 h-4 w-4" />
       Create "{query}"

--- a/client/src/components/ui/command-add-item.tsx
+++ b/client/src/components/ui/command-add-item.tsx
@@ -1,0 +1,55 @@
+import { type KeyboardEvent } from 'react';
+import { CirclePlus } from 'lucide-react';
+import {
+  activateTouchTap,
+  beginTouchTapTracking,
+  cancelTouchTapTracking,
+  hasRecentTouchActivation,
+  updateTouchTapTracking,
+} from '@/lib/touch-activation';
+
+export function CommandAddItem({
+  query,
+  onCreate,
+}: {
+  query: string;
+  onCreate: () => void;
+}) {
+  return (
+    <div
+      role="option"
+      aria-label={`Create "${query}"`}
+      tabIndex={0}
+      onClickCapture={(event) => {
+        if (!hasRecentTouchActivation(event.currentTarget, event.timeStamp)) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onClick={onCreate}
+      onTouchStart={(event) => {
+        beginTouchTapTracking(event.currentTarget, event);
+      }}
+      onTouchMove={(event) => {
+        updateTouchTapTracking(event.currentTarget, event);
+      }}
+      onTouchCancel={(event) => {
+        cancelTouchTapTracking(event.currentTarget);
+      }}
+      onTouchEnd={(event) => {
+        activateTouchTap(event.currentTarget, event);
+      }}
+      onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Enter') {
+          onCreate();
+        }
+      }}
+      className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 focus:outline-none touch-manipulation"
+    >
+      <CirclePlus className="mr-2 h-4 w-4" />
+      Create "{query}"
+    </div>
+  );
+}

--- a/client/src/components/ui/command.test.tsx
+++ b/client/src/components/ui/command.test.tsx
@@ -57,9 +57,48 @@ describe('CommandList', () => {
       </Command>
     );
 
-    fireEvent.touchEnd(getByRole('option', { name: 'Squat' }));
+    const option = getByRole('option', { name: 'Squat' });
+
+    fireEvent.touchStart(option, {
+      touches: [{ clientX: 8, clientY: 12 }],
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+    fireEvent.touchEnd(option, {
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
 
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith('squat');
+  });
+
+  it('does not select an item after a drag gesture', () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(
+      <Command>
+        <CommandList>
+          <CommandGroup>
+            <CommandItem value="squat" onSelect={onSelect}>
+              Squat
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    );
+
+    const option = getByRole('option', { name: 'Squat' });
+
+    fireEvent.touchStart(option, {
+      touches: [{ clientX: 8, clientY: 12 }],
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+    fireEvent.touchMove(option, {
+      touches: [{ clientX: 8, clientY: 40 }],
+      changedTouches: [{ clientX: 8, clientY: 40 }],
+    });
+    fireEvent.touchEnd(option, {
+      changedTouches: [{ clientX: 8, clientY: 40 }],
+    });
+
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/ui/command.test.tsx
+++ b/client/src/components/ui/command.test.tsx
@@ -1,6 +1,9 @@
-import { createEvent, fireEvent, render } from '@testing-library/react';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
+
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
 
 beforeAll(() => {
   class ResizeObserverMock {
@@ -42,122 +45,16 @@ describe('CommandList', () => {
     expect(list).toHaveClass('overscroll-contain');
     expect(list).toHaveClass('touch-pan-y');
   });
+});
 
-  it('selects an item on touch release', () => {
-    const onSelect = vi.fn();
-    const { getByRole } = render(
-      <Command>
-        <CommandList>
-          <CommandGroup>
-            <CommandItem value="squat" onSelect={onSelect}>
-              Squat
-            </CommandItem>
-          </CommandGroup>
-        </CommandList>
-      </Command>
-    );
-
-    const option = getByRole('option', { name: 'Squat' });
-
-    fireEvent.touchStart(option, {
-      touches: [{ clientX: 8, clientY: 12 }],
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
-    fireEvent.touchEnd(option, {
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
-
-    expect(onSelect).toHaveBeenCalledTimes(1);
-    expect(onSelect).toHaveBeenCalledWith('squat');
+afterAll(() => {
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    value: originalResizeObserver,
+    writable: true,
   });
 
-  it('does not select an item after a drag gesture', () => {
-    const onSelect = vi.fn();
-    const { getByRole } = render(
-      <Command>
-        <CommandList>
-          <CommandGroup>
-            <CommandItem value="squat" onSelect={onSelect}>
-              Squat
-            </CommandItem>
-          </CommandGroup>
-        </CommandList>
-      </Command>
-    );
-
-    const option = getByRole('option', { name: 'Squat' });
-
-    fireEvent.touchStart(option, {
-      touches: [{ clientX: 8, clientY: 12 }],
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
-    fireEvent.touchMove(option, {
-      touches: [{ clientX: 8, clientY: 40 }],
-      changedTouches: [{ clientX: 8, clientY: 40 }],
-    });
-    fireEvent.touchEnd(option, {
-      changedTouches: [{ clientX: 8, clientY: 40 }],
-    });
-
-    expect(onSelect).not.toHaveBeenCalled();
-  });
-
-  it('does not select an item after a follow-up click from the same touch', () => {
-    const onSelect = vi.fn();
-    const { getByRole } = render(
-      <Command>
-        <CommandList>
-          <CommandGroup>
-            <CommandItem value="squat" onSelect={onSelect}>
-              Squat
-            </CommandItem>
-          </CommandGroup>
-        </CommandList>
-      </Command>
-    );
-
-    const option = getByRole('option', { name: 'Squat' });
-
-    fireEvent.touchStart(option, {
-      touches: [{ clientX: 8, clientY: 12 }],
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
-    fireEvent.touchEnd(option, {
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
-    fireEvent.click(option);
-
-    expect(onSelect).toHaveBeenCalledTimes(1);
-  });
-
-  it('prevents the touchend default after a touch selection', () => {
-    const onSelect = vi.fn();
-    const { getByRole } = render(
-      <Command>
-        <CommandList>
-          <CommandGroup>
-            <CommandItem value="squat" onSelect={onSelect}>
-              Squat
-            </CommandItem>
-          </CommandGroup>
-        </CommandList>
-      </Command>
-    );
-
-    const option = getByRole('option', { name: 'Squat' });
-
-    fireEvent.touchStart(option, {
-      touches: [{ clientX: 8, clientY: 12 }],
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
-
-    const touchEnd = createEvent.touchEnd(option, {
-      changedTouches: [{ clientX: 8, clientY: 12 }],
-    });
-
-    fireEvent(option, touchEnd);
-
-    expect(onSelect).toHaveBeenCalledTimes(1);
-    expect(touchEnd.defaultPrevented).toBe(true);
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    value: originalScrollIntoView,
+    writable: true,
   });
 });

--- a/client/src/components/ui/command.test.tsx
+++ b/client/src/components/ui/command.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { createEvent, fireEvent, render } from '@testing-library/react';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
 
@@ -100,5 +100,71 @@ describe('CommandList', () => {
     });
 
     expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('does not select an item after a pointer drag gesture', () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(
+      <Command>
+        <CommandList>
+          <CommandGroup>
+            <CommandItem value="squat" onSelect={onSelect}>
+              Squat
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    );
+
+    const option = getByRole('option', { name: 'Squat' });
+
+    fireEvent.pointerDown(option, {
+      pointerType: 'touch',
+      clientX: 8,
+      clientY: 12,
+    });
+    fireEvent.pointerMove(option, {
+      pointerType: 'touch',
+      clientX: 8,
+      clientY: 40,
+    });
+    fireEvent.pointerUp(option, {
+      pointerType: 'touch',
+      clientX: 8,
+      clientY: 40,
+    });
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('prevents the touchend default after a touch selection', () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(
+      <Command>
+        <CommandList>
+          <CommandGroup>
+            <CommandItem value="squat" onSelect={onSelect}>
+              Squat
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    );
+
+    const option = getByRole('option', { name: 'Squat' });
+
+    fireEvent.touchStart(option, {
+      touches: [{ clientX: 8, clientY: 12 }],
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+
+    const touchEnd = createEvent.touchEnd(option, {
+      changedTouches: [{ clientX: 8, clientY: 12 }],
+    });
+
+    fireEvent(option, touchEnd);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(touchEnd.defaultPrevented).toBe(true);
   });
 });

--- a/client/src/components/ui/command.test.tsx
+++ b/client/src/components/ui/command.test.tsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
 
 beforeAll(() => {
@@ -41,5 +41,25 @@ describe('CommandList', () => {
 
     expect(list).toHaveClass('overscroll-contain');
     expect(list).toHaveClass('touch-pan-y');
+  });
+
+  it('selects an item on touch release', () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(
+      <Command>
+        <CommandList>
+          <CommandGroup>
+            <CommandItem value="squat" onSelect={onSelect}>
+              Squat
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    );
+
+    fireEvent.touchEnd(getByRole('option', { name: 'Squat' }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('squat');
   });
 });

--- a/client/src/components/ui/command.test.tsx
+++ b/client/src/components/ui/command.test.tsx
@@ -102,7 +102,7 @@ describe('CommandList', () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
-  it('does not select an item after a pointer drag gesture', () => {
+  it('does not select an item after a follow-up click from the same touch', () => {
     const onSelect = vi.fn();
     const { getByRole } = render(
       <Command>
@@ -118,23 +118,16 @@ describe('CommandList', () => {
 
     const option = getByRole('option', { name: 'Squat' });
 
-    fireEvent.pointerDown(option, {
-      pointerType: 'touch',
-      clientX: 8,
-      clientY: 12,
+    fireEvent.touchStart(option, {
+      touches: [{ clientX: 8, clientY: 12 }],
+      changedTouches: [{ clientX: 8, clientY: 12 }],
     });
-    fireEvent.pointerMove(option, {
-      pointerType: 'touch',
-      clientX: 8,
-      clientY: 40,
+    fireEvent.touchEnd(option, {
+      changedTouches: [{ clientX: 8, clientY: 12 }],
     });
-    fireEvent.pointerUp(option, {
-      pointerType: 'touch',
-      clientX: 8,
-      clientY: 40,
-    });
+    fireEvent.click(option);
 
-    expect(onSelect).not.toHaveBeenCalled();
+    expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
   it('prevents the touchend default after a touch selection', () => {

--- a/client/src/components/ui/command.tsx
+++ b/client/src/components/ui/command.tsx
@@ -3,6 +3,14 @@ import * as ReactDOM from "react-dom"
 import { Command as CommandPrimitive } from "cmdk"
 import { SearchIcon } from "lucide-react"
 
+import {
+  beginTouchTapTracking,
+  cancelTouchTapTracking,
+  finishTouchTapTracking,
+  hasRecentTouchActivation,
+  markRecentTouchActivation,
+  updateTouchTapTracking,
+} from "@/lib/touch-activation"
 import { cn } from "@/lib/utils"
 import {
   Dialog,
@@ -13,28 +21,17 @@ import {
 } from "@/components/ui/dialog"
 
 const COMMAND_ITEM_SELECT_EVENT = "cmdk-item-select"
-const COMMAND_TOUCH_SELECT_ATTR = "data-command-touch-select"
-const TOUCH_SELECT_SUPPRESSION_MS = 750
-
-function hasRecentTouchSelection(target: HTMLElement, timeStamp: number) {
-  const lastTouchSelection = Number(target.getAttribute(COMMAND_TOUCH_SELECT_ATTR))
-
-  return (
-    Number.isFinite(lastTouchSelection) &&
-    timeStamp - lastTouchSelection < TOUCH_SELECT_SUPPRESSION_MS
-  )
-}
 
 function dispatchCommandItemSelect(target: EventTarget | null, timeStamp: number) {
   if (!(target instanceof HTMLElement)) {
     return
   }
 
-  if (hasRecentTouchSelection(target, timeStamp)) {
+  if (hasRecentTouchActivation(target, timeStamp)) {
     return
   }
 
-  target.setAttribute(COMMAND_TOUCH_SELECT_ATTR, String(timeStamp))
+  markRecentTouchActivation(target, timeStamp)
 
   ReactDOM.flushSync(() => {
     target.dispatchEvent(new Event(COMMAND_ITEM_SELECT_EVENT))
@@ -172,7 +169,13 @@ function CommandSeparator({
 function CommandItem({
   className,
   onClickCapture,
+  onPointerCancel,
+  onPointerDown,
+  onPointerMove,
   onPointerUp,
+  onTouchCancel,
+  onTouchMove,
+  onTouchStart,
   onTouchEnd,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Item>) {
@@ -188,13 +191,40 @@ function CommandItem({
 
         if (
           event.defaultPrevented ||
-          !hasRecentTouchSelection(event.currentTarget, event.timeStamp)
+          !hasRecentTouchActivation(event.currentTarget, event.timeStamp)
         ) {
           return
         }
 
         event.preventDefault()
         event.stopPropagation()
+      }}
+      onPointerDown={(event) => {
+        onPointerDown?.(event)
+
+        if (event.defaultPrevented || event.pointerType !== "touch") {
+          return
+        }
+
+        beginTouchTapTracking(event.currentTarget, event)
+      }}
+      onPointerMove={(event) => {
+        onPointerMove?.(event)
+
+        if (event.defaultPrevented || event.pointerType !== "touch") {
+          return
+        }
+
+        updateTouchTapTracking(event.currentTarget, event)
+      }}
+      onPointerCancel={(event) => {
+        onPointerCancel?.(event)
+
+        if (event.defaultPrevented || event.pointerType !== "touch") {
+          return
+        }
+
+        cancelTouchTapTracking(event.currentTarget)
       }}
       onPointerUp={(event) => {
         onPointerUp?.(event)
@@ -203,12 +233,47 @@ function CommandItem({
           return
         }
 
+        if (!finishTouchTapTracking(event.currentTarget, event)) {
+          return
+        }
+
         dispatchCommandItemSelect(event.currentTarget, event.timeStamp)
+      }}
+      onTouchStart={(event) => {
+        onTouchStart?.(event)
+
+        if (event.defaultPrevented) {
+          return
+        }
+
+        beginTouchTapTracking(event.currentTarget, event)
+      }}
+      onTouchMove={(event) => {
+        onTouchMove?.(event)
+
+        if (event.defaultPrevented) {
+          return
+        }
+
+        updateTouchTapTracking(event.currentTarget, event)
+      }}
+      onTouchCancel={(event) => {
+        onTouchCancel?.(event)
+
+        if (event.defaultPrevented) {
+          return
+        }
+
+        cancelTouchTapTracking(event.currentTarget)
       }}
       onTouchEnd={(event) => {
         onTouchEnd?.(event)
 
         if (event.defaultPrevented) {
+          return
+        }
+
+        if (!finishTouchTapTracking(event.currentTarget, event)) {
           return
         }
 

--- a/client/src/components/ui/command.tsx
+++ b/client/src/components/ui/command.tsx
@@ -169,6 +169,10 @@ function CommandSeparator({
 function CommandItem({
   className,
   onClickCapture,
+  onPointerCancelCapture,
+  onPointerDownCapture,
+  onPointerMoveCapture,
+  onPointerUpCapture,
   onPointerCancel,
   onPointerDown,
   onPointerMove,
@@ -199,7 +203,8 @@ function CommandItem({
         event.preventDefault()
         event.stopPropagation()
       }}
-      onPointerDown={(event) => {
+      onPointerDownCapture={(event) => {
+        onPointerDownCapture?.(event)
         onPointerDown?.(event)
 
         if (event.defaultPrevented || event.pointerType !== "touch") {
@@ -208,7 +213,8 @@ function CommandItem({
 
         beginTouchTapTracking(event.currentTarget, event)
       }}
-      onPointerMove={(event) => {
+      onPointerMoveCapture={(event) => {
+        onPointerMoveCapture?.(event)
         onPointerMove?.(event)
 
         if (event.defaultPrevented || event.pointerType !== "touch") {
@@ -217,7 +223,8 @@ function CommandItem({
 
         updateTouchTapTracking(event.currentTarget, event)
       }}
-      onPointerCancel={(event) => {
+      onPointerCancelCapture={(event) => {
+        onPointerCancelCapture?.(event)
         onPointerCancel?.(event)
 
         if (event.defaultPrevented || event.pointerType !== "touch") {
@@ -226,7 +233,8 @@ function CommandItem({
 
         cancelTouchTapTracking(event.currentTarget)
       }}
-      onPointerUp={(event) => {
+      onPointerUpCapture={(event) => {
+        onPointerUpCapture?.(event)
         onPointerUp?.(event)
 
         if (event.defaultPrevented || event.pointerType !== "touch") {
@@ -239,6 +247,10 @@ function CommandItem({
 
         dispatchCommandItemSelect(event.currentTarget, event.timeStamp)
       }}
+      onPointerDown={undefined}
+      onPointerMove={undefined}
+      onPointerCancel={undefined}
+      onPointerUp={undefined}
       onTouchStart={(event) => {
         onTouchStart?.(event)
 
@@ -277,6 +289,7 @@ function CommandItem({
           return
         }
 
+        event.preventDefault()
         dispatchCommandItemSelect(event.currentTarget, event.timeStamp)
       }}
       {...props}

--- a/client/src/components/ui/command.tsx
+++ b/client/src/components/ui/command.tsx
@@ -1,14 +1,12 @@
 import * as React from "react"
-import * as ReactDOM from "react-dom"
 import { Command as CommandPrimitive } from "cmdk"
 import { SearchIcon } from "lucide-react"
 
 import {
+  activateTouchTap,
   beginTouchTapTracking,
   cancelTouchTapTracking,
-  finishTouchTapTracking,
   hasRecentTouchActivation,
-  markRecentTouchActivation,
   updateTouchTapTracking,
 } from "@/lib/touch-activation"
 import { cn } from "@/lib/utils"
@@ -19,24 +17,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-
-const COMMAND_ITEM_SELECT_EVENT = "cmdk-item-select"
-
-function dispatchCommandItemSelect(target: EventTarget | null, timeStamp: number) {
-  if (!(target instanceof HTMLElement)) {
-    return
-  }
-
-  if (hasRecentTouchActivation(target, timeStamp)) {
-    return
-  }
-
-  markRecentTouchActivation(target, timeStamp)
-
-  ReactDOM.flushSync(() => {
-    target.dispatchEvent(new Event(COMMAND_ITEM_SELECT_EVENT))
-  })
-}
 
 function Command({
   className,
@@ -169,14 +149,6 @@ function CommandSeparator({
 function CommandItem({
   className,
   onClickCapture,
-  onPointerCancelCapture,
-  onPointerDownCapture,
-  onPointerMoveCapture,
-  onPointerUpCapture,
-  onPointerCancel,
-  onPointerDown,
-  onPointerMove,
-  onPointerUp,
   onTouchCancel,
   onTouchMove,
   onTouchStart,
@@ -203,54 +175,6 @@ function CommandItem({
         event.preventDefault()
         event.stopPropagation()
       }}
-      onPointerDownCapture={(event) => {
-        onPointerDownCapture?.(event)
-        onPointerDown?.(event)
-
-        if (event.defaultPrevented || event.pointerType !== "touch") {
-          return
-        }
-
-        beginTouchTapTracking(event.currentTarget, event)
-      }}
-      onPointerMoveCapture={(event) => {
-        onPointerMoveCapture?.(event)
-        onPointerMove?.(event)
-
-        if (event.defaultPrevented || event.pointerType !== "touch") {
-          return
-        }
-
-        updateTouchTapTracking(event.currentTarget, event)
-      }}
-      onPointerCancelCapture={(event) => {
-        onPointerCancelCapture?.(event)
-        onPointerCancel?.(event)
-
-        if (event.defaultPrevented || event.pointerType !== "touch") {
-          return
-        }
-
-        cancelTouchTapTracking(event.currentTarget)
-      }}
-      onPointerUpCapture={(event) => {
-        onPointerUpCapture?.(event)
-        onPointerUp?.(event)
-
-        if (event.defaultPrevented || event.pointerType !== "touch") {
-          return
-        }
-
-        if (!finishTouchTapTracking(event.currentTarget, event)) {
-          return
-        }
-
-        dispatchCommandItemSelect(event.currentTarget, event.timeStamp)
-      }}
-      onPointerDown={undefined}
-      onPointerMove={undefined}
-      onPointerCancel={undefined}
-      onPointerUp={undefined}
       onTouchStart={(event) => {
         onTouchStart?.(event)
 
@@ -285,12 +209,7 @@ function CommandItem({
           return
         }
 
-        if (!finishTouchTapTracking(event.currentTarget, event)) {
-          return
-        }
-
-        event.preventDefault()
-        dispatchCommandItemSelect(event.currentTarget, event.timeStamp)
+        activateTouchTap(event.currentTarget, event)
       }}
       {...props}
     />

--- a/client/src/components/ui/command.tsx
+++ b/client/src/components/ui/command.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import * as ReactDOM from "react-dom"
 import { Command as CommandPrimitive } from "cmdk"
 import { SearchIcon } from "lucide-react"
 
@@ -10,6 +11,35 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+
+const COMMAND_ITEM_SELECT_EVENT = "cmdk-item-select"
+const COMMAND_TOUCH_SELECT_ATTR = "data-command-touch-select"
+const TOUCH_SELECT_SUPPRESSION_MS = 750
+
+function hasRecentTouchSelection(target: HTMLElement, timeStamp: number) {
+  const lastTouchSelection = Number(target.getAttribute(COMMAND_TOUCH_SELECT_ATTR))
+
+  return (
+    Number.isFinite(lastTouchSelection) &&
+    timeStamp - lastTouchSelection < TOUCH_SELECT_SUPPRESSION_MS
+  )
+}
+
+function dispatchCommandItemSelect(target: EventTarget | null, timeStamp: number) {
+  if (!(target instanceof HTMLElement)) {
+    return
+  }
+
+  if (hasRecentTouchSelection(target, timeStamp)) {
+    return
+  }
+
+  target.setAttribute(COMMAND_TOUCH_SELECT_ATTR, String(timeStamp))
+
+  ReactDOM.flushSync(() => {
+    target.dispatchEvent(new Event(COMMAND_ITEM_SELECT_EVENT))
+  })
+}
 
 function Command({
   className,
@@ -141,15 +171,49 @@ function CommandSeparator({
 
 function CommandItem({
   className,
+  onClickCapture,
+  onPointerUp,
+  onTouchEnd,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Item>) {
   return (
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-hidden select-none touch-manipulation data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
+      onClickCapture={(event) => {
+        onClickCapture?.(event)
+
+        if (
+          event.defaultPrevented ||
+          !hasRecentTouchSelection(event.currentTarget, event.timeStamp)
+        ) {
+          return
+        }
+
+        event.preventDefault()
+        event.stopPropagation()
+      }}
+      onPointerUp={(event) => {
+        onPointerUp?.(event)
+
+        if (event.defaultPrevented || event.pointerType !== "touch") {
+          return
+        }
+
+        dispatchCommandItemSelect(event.currentTarget, event.timeStamp)
+      }}
+      onTouchEnd={(event) => {
+        onTouchEnd?.(event)
+
+        if (event.defaultPrevented) {
+          return
+        }
+
+        dispatchCommandItemSelect(event.currentTarget, event.timeStamp)
+      }}
       {...props}
     />
   )

--- a/client/src/components/ui/command.tsx
+++ b/client/src/components/ui/command.tsx
@@ -2,13 +2,6 @@ import * as React from "react"
 import { Command as CommandPrimitive } from "cmdk"
 import { SearchIcon } from "lucide-react"
 
-import {
-  activateTouchTap,
-  beginTouchTapTracking,
-  cancelTouchTapTracking,
-  hasRecentTouchActivation,
-  updateTouchTapTracking,
-} from "@/lib/touch-activation"
 import { cn } from "@/lib/utils"
 import {
   Dialog,
@@ -148,69 +141,15 @@ function CommandSeparator({
 
 function CommandItem({
   className,
-  onClickCapture,
-  onTouchCancel,
-  onTouchMove,
-  onTouchStart,
-  onTouchEnd,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Item>) {
   return (
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-hidden select-none touch-manipulation data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
-      onClickCapture={(event) => {
-        onClickCapture?.(event)
-
-        if (
-          event.defaultPrevented ||
-          !hasRecentTouchActivation(event.currentTarget, event.timeStamp)
-        ) {
-          return
-        }
-
-        event.preventDefault()
-        event.stopPropagation()
-      }}
-      onTouchStart={(event) => {
-        onTouchStart?.(event)
-
-        if (event.defaultPrevented) {
-          return
-        }
-
-        beginTouchTapTracking(event.currentTarget, event)
-      }}
-      onTouchMove={(event) => {
-        onTouchMove?.(event)
-
-        if (event.defaultPrevented) {
-          return
-        }
-
-        updateTouchTapTracking(event.currentTarget, event)
-      }}
-      onTouchCancel={(event) => {
-        onTouchCancel?.(event)
-
-        if (event.defaultPrevented) {
-          return
-        }
-
-        cancelTouchTapTracking(event.currentTarget)
-      }}
-      onTouchEnd={(event) => {
-        onTouchEnd?.(event)
-
-        if (event.defaultPrevented) {
-          return
-        }
-
-        activateTouchTap(event.currentTarget, event)
-      }}
       {...props}
     />
   )

--- a/client/src/lib/touch-activation.test.ts
+++ b/client/src/lib/touch-activation.test.ts
@@ -1,0 +1,43 @@
+import {
+  beginTouchTapTracking,
+  finishTouchTapTracking,
+  hasRecentTouchActivation,
+  markRecentTouchActivation,
+  updateTouchTapTracking,
+} from '@/lib/touch-activation';
+import { describe, expect, it } from 'vitest';
+
+function createTouchEvent(x: number, y: number) {
+  return {
+    touches: [{ clientX: x, clientY: y }],
+    changedTouches: [{ clientX: x, clientY: y }],
+  } as unknown as TouchEvent;
+}
+
+describe('touch activation helpers', () => {
+  it('treats a short touch as a tap', () => {
+    const element = document.createElement('div');
+
+    beginTouchTapTracking(element, createTouchEvent(10, 20));
+
+    expect(finishTouchTapTracking(element, createTouchEvent(14, 24))).toBe(true);
+  });
+
+  it('treats a moved touch as a drag', () => {
+    const element = document.createElement('div');
+
+    beginTouchTapTracking(element, createTouchEvent(10, 20));
+    updateTouchTapTracking(element, createTouchEvent(10, 42));
+
+    expect(finishTouchTapTracking(element, createTouchEvent(10, 42))).toBe(false);
+  });
+
+  it('tracks recent touch activation windows', () => {
+    const element = document.createElement('div');
+
+    markRecentTouchActivation(element, 100);
+
+    expect(hasRecentTouchActivation(element, 200)).toBe(true);
+    expect(hasRecentTouchActivation(element, 900)).toBe(false);
+  });
+});

--- a/client/src/lib/touch-activation.test.ts
+++ b/client/src/lib/touch-activation.test.ts
@@ -1,4 +1,5 @@
 import {
+  activateTouchTap,
   beginTouchTapTracking,
   cancelTouchTapTracking,
   finishTouchTapTracking,
@@ -6,7 +7,7 @@ import {
   markRecentTouchActivation,
   updateTouchTapTracking,
 } from '@/lib/touch-activation';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 function createTouchEvent(x: number, y: number) {
   return {
@@ -49,5 +50,25 @@ describe('touch activation helpers', () => {
 
     expect(hasRecentTouchActivation(element, 200)).toBe(true);
     expect(hasRecentTouchActivation(element, 900)).toBe(false);
+  });
+
+  it('activates a tap with a real click and records the activation window', () => {
+    const element = document.createElement('button');
+    const clickSpy = vi.fn();
+    const preventDefault = vi.fn();
+
+    element.addEventListener('click', clickSpy);
+    beginTouchTapTracking(element, createTouchEvent(10, 20));
+
+    expect(
+      activateTouchTap(element, {
+        ...createTouchEvent(10, 20),
+        preventDefault,
+        timeStamp: 100,
+      } as unknown as TouchEvent)
+    ).toBe(true);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(hasRecentTouchActivation(element, 200)).toBe(true);
   });
 });

--- a/client/src/lib/touch-activation.test.ts
+++ b/client/src/lib/touch-activation.test.ts
@@ -5,6 +5,7 @@ import {
   finishTouchTapTracking,
   hasRecentTouchActivation,
   markRecentTouchActivation,
+  shouldSuppressTouchClick,
   updateTouchTapTracking,
 } from '@/lib/touch-activation';
 import { describe, expect, it, vi } from 'vitest';
@@ -14,6 +15,38 @@ function createTouchEvent(x: number, y: number) {
     touches: [{ clientX: x, clientY: y }],
     changedTouches: [{ clientX: x, clientY: y }],
   } as unknown as TouchEvent;
+}
+
+function dispatchClick(element: HTMLElement, timeStamp: number) {
+  const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+  Object.defineProperty(event, 'timeStamp', {
+    configurable: true,
+    value: timeStamp,
+  });
+
+  element.dispatchEvent(event);
+}
+
+function createTouchTarget(tagName: 'button' | 'div') {
+  const element = document.createElement(tagName);
+  const clickSpy = vi.fn();
+
+  element.addEventListener(
+    'click',
+    (event) => {
+      if (!shouldSuppressTouchClick(event.currentTarget, event.timeStamp)) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    true
+  );
+  element.addEventListener('click', clickSpy);
+
+  return { clickSpy, element };
 }
 
 describe('touch activation helpers', () => {
@@ -52,12 +85,10 @@ describe('touch activation helpers', () => {
     expect(hasRecentTouchActivation(element, 900)).toBe(false);
   });
 
-  it('activates a tap with a real click and records the activation window', () => {
-    const element = document.createElement('button');
-    const clickSpy = vi.fn();
+  it('allows repeated quick taps on the same selectable item while suppressing follow-up clicks', () => {
+    const { clickSpy, element } = createTouchTarget('button');
     const preventDefault = vi.fn();
 
-    element.addEventListener('click', clickSpy);
     beginTouchTapTracking(element, createTouchEvent(10, 20));
 
     expect(
@@ -70,5 +101,41 @@ describe('touch activation helpers', () => {
     expect(preventDefault).toHaveBeenCalledTimes(1);
     expect(clickSpy).toHaveBeenCalledTimes(1);
     expect(hasRecentTouchActivation(element, 200)).toBe(true);
+
+    dispatchClick(element, 200);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    beginTouchTapTracking(element, createTouchEvent(10, 20));
+    expect(
+      activateTouchTap(element, {
+        ...createTouchEvent(10, 20),
+        preventDefault,
+        timeStamp: 250,
+      } as unknown as TouchEvent)
+    ).toBe(true);
+    expect(clickSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows repeated quick taps on the create row while suppressing follow-up clicks', () => {
+    const { clickSpy, element } = createTouchTarget('div');
+
+    beginTouchTapTracking(element, createTouchEvent(10, 20));
+    activateTouchTap(element, {
+      ...createTouchEvent(10, 20),
+      preventDefault: vi.fn(),
+      timeStamp: 100,
+    } as unknown as TouchEvent);
+
+    dispatchClick(element, 200);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    beginTouchTapTracking(element, createTouchEvent(10, 20));
+    activateTouchTap(element, {
+      ...createTouchEvent(10, 20),
+      preventDefault: vi.fn(),
+      timeStamp: 250,
+    } as unknown as TouchEvent);
+
+    expect(clickSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/client/src/lib/touch-activation.test.ts
+++ b/client/src/lib/touch-activation.test.ts
@@ -1,5 +1,6 @@
 import {
   beginTouchTapTracking,
+  cancelTouchTapTracking,
   finishTouchTapTracking,
   hasRecentTouchActivation,
   markRecentTouchActivation,
@@ -30,6 +31,15 @@ describe('touch activation helpers', () => {
     updateTouchTapTracking(element, createTouchEvent(10, 42));
 
     expect(finishTouchTapTracking(element, createTouchEvent(10, 42))).toBe(false);
+  });
+
+  it('does not treat a canceled touch as a tap', () => {
+    const element = document.createElement('div');
+
+    beginTouchTapTracking(element, createTouchEvent(10, 20));
+    cancelTouchTapTracking(element);
+
+    expect(finishTouchTapTracking(element, createTouchEvent(10, 20))).toBe(false);
   });
 
   it('tracks recent touch activation windows', () => {

--- a/client/src/lib/touch-activation.ts
+++ b/client/src/lib/touch-activation.ts
@@ -1,4 +1,5 @@
 const RECENT_TOUCH_ACTIVATION_ATTR = 'data-recent-touch-activation';
+const PENDING_TOUCH_CLICK_ATTR = 'data-pending-touch-click';
 const TOUCH_START_X_ATTR = 'data-touch-start-x';
 const TOUCH_START_Y_ATTR = 'data-touch-start-y';
 const TOUCH_MOVED_ATTR = 'data-touch-moved';
@@ -40,6 +41,19 @@ function clearTouchTapTracking(target: HTMLElement) {
   target.removeAttribute(TOUCH_START_X_ATTR);
   target.removeAttribute(TOUCH_START_Y_ATTR);
   target.removeAttribute(TOUCH_MOVED_ATTR);
+}
+
+function markPendingTouchClick(target: HTMLElement) {
+  target.setAttribute(PENDING_TOUCH_CLICK_ATTR, 'true');
+}
+
+function consumePendingTouchClick(target: HTMLElement) {
+  if (target.getAttribute(PENDING_TOUCH_CLICK_ATTR) !== 'true') {
+    return false;
+  }
+
+  target.removeAttribute(PENDING_TOUCH_CLICK_ATTR);
+  return true;
 }
 
 function readTouchStart(target: HTMLElement) {
@@ -87,6 +101,21 @@ export function markRecentTouchActivation(
   }
 
   target.setAttribute(RECENT_TOUCH_ACTIVATION_ATTR, String(timeStamp));
+}
+
+export function shouldSuppressTouchClick(
+  target: EventTarget | null,
+  timeStamp: number
+) {
+  if (!isElement(target)) {
+    return false;
+  }
+
+  if (consumePendingTouchClick(target)) {
+    return false;
+  }
+
+  return hasRecentTouchActivation(target, timeStamp);
 }
 
 export function beginTouchTapTracking(
@@ -170,7 +199,14 @@ export function activateTouchTap(
   }
 
   event.preventDefault();
-  target.click();
+  markPendingTouchClick(target);
+
+  try {
+    target.click();
+  } finally {
+    target.removeAttribute(PENDING_TOUCH_CLICK_ATTR);
+  }
+
   markRecentTouchActivation(target, event.timeStamp);
   return true;
 }

--- a/client/src/lib/touch-activation.ts
+++ b/client/src/lib/touch-activation.ts
@@ -1,0 +1,167 @@
+const RECENT_TOUCH_ACTIVATION_ATTR = 'data-recent-touch-activation';
+const TOUCH_START_X_ATTR = 'data-touch-start-x';
+const TOUCH_START_Y_ATTR = 'data-touch-start-y';
+const TOUCH_MOVED_ATTR = 'data-touch-moved';
+const TOUCH_TAP_MAX_DISTANCE_PX = 10;
+const RECENT_TOUCH_ACTIVATION_MS = 750;
+
+type TouchPoint = {
+  clientX: number;
+  clientY: number;
+};
+
+type TouchListLike = {
+  0?: TouchPoint;
+  length: number;
+};
+
+type PointerTouchLikeEvent = Pick<PointerEvent, 'pointerType' | 'clientX' | 'clientY'>;
+type TouchLikeEvent = {
+  touches: TouchListLike;
+  changedTouches: TouchListLike;
+};
+
+function isElement(target: EventTarget | null): target is HTMLElement {
+  return target instanceof HTMLElement;
+}
+
+function readTouchPoint(
+  event: PointerTouchLikeEvent | TouchLikeEvent
+) {
+  if ('pointerType' in event) {
+    if (event.pointerType !== 'touch') {
+      return null;
+    }
+
+    return { x: event.clientX, y: event.clientY };
+  }
+
+  const touch = event.changedTouches[0] ?? event.touches[0];
+
+  if (!touch) {
+    return null;
+  }
+
+  return { x: touch.clientX, y: touch.clientY };
+}
+
+function clearTouchTapTracking(target: HTMLElement) {
+  target.removeAttribute(TOUCH_START_X_ATTR);
+  target.removeAttribute(TOUCH_START_Y_ATTR);
+  target.removeAttribute(TOUCH_MOVED_ATTR);
+}
+
+function readTouchStart(target: HTMLElement) {
+  const startX = Number(target.getAttribute(TOUCH_START_X_ATTR));
+  const startY = Number(target.getAttribute(TOUCH_START_Y_ATTR));
+
+  if (!Number.isFinite(startX) || !Number.isFinite(startY)) {
+    return null;
+  }
+
+  return { x: startX, y: startY };
+}
+
+function exceededTapDistance(
+  start: { x: number; y: number },
+  current: { x: number; y: number }
+) {
+  return Math.hypot(current.x - start.x, current.y - start.y) > TOUCH_TAP_MAX_DISTANCE_PX;
+}
+
+export function hasRecentTouchActivation(
+  target: EventTarget | null,
+  timeStamp: number
+) {
+  if (!isElement(target)) {
+    return false;
+  }
+
+  const lastTouchActivation = Number(
+    target.getAttribute(RECENT_TOUCH_ACTIVATION_ATTR)
+  );
+
+  return (
+    Number.isFinite(lastTouchActivation) &&
+    timeStamp - lastTouchActivation < RECENT_TOUCH_ACTIVATION_MS
+  );
+}
+
+export function markRecentTouchActivation(
+  target: EventTarget | null,
+  timeStamp: number
+) {
+  if (!isElement(target)) {
+    return;
+  }
+
+  target.setAttribute(RECENT_TOUCH_ACTIVATION_ATTR, String(timeStamp));
+}
+
+export function beginTouchTapTracking(
+  target: EventTarget | null,
+  event: PointerTouchLikeEvent | TouchLikeEvent
+) {
+  if (!isElement(target)) {
+    return;
+  }
+
+  const point = readTouchPoint(event);
+
+  if (!point) {
+    return;
+  }
+
+  target.setAttribute(TOUCH_START_X_ATTR, String(point.x));
+  target.setAttribute(TOUCH_START_Y_ATTR, String(point.y));
+  target.setAttribute(TOUCH_MOVED_ATTR, 'false');
+}
+
+export function updateTouchTapTracking(
+  target: EventTarget | null,
+  event: PointerTouchLikeEvent | TouchLikeEvent
+) {
+  if (!isElement(target)) {
+    return;
+  }
+
+  const point = readTouchPoint(event);
+  const start = readTouchStart(target);
+
+  if (!point || !start) {
+    return;
+  }
+
+  if (exceededTapDistance(start, point)) {
+    target.setAttribute(TOUCH_MOVED_ATTR, 'true');
+  }
+}
+
+export function cancelTouchTapTracking(target: EventTarget | null) {
+  if (!isElement(target)) {
+    return;
+  }
+
+  clearTouchTapTracking(target);
+}
+
+export function finishTouchTapTracking(
+  target: EventTarget | null,
+  event: PointerTouchLikeEvent | TouchLikeEvent
+) {
+  if (!isElement(target)) {
+    return false;
+  }
+
+  const point = readTouchPoint(event);
+  const start = readTouchStart(target);
+  const moved = target.getAttribute(TOUCH_MOVED_ATTR) === 'true';
+
+  clearTouchTapTracking(target);
+
+  if (!point || !start || moved) {
+    return false;
+  }
+
+  return !exceededTapDistance(start, point);
+}

--- a/client/src/lib/touch-activation.ts
+++ b/client/src/lib/touch-activation.ts
@@ -15,27 +15,18 @@ type TouchListLike = {
   length: number;
 };
 
-type PointerTouchLikeEvent = Pick<PointerEvent, 'pointerType' | 'clientX' | 'clientY'>;
 type TouchLikeEvent = {
   touches: TouchListLike;
   changedTouches: TouchListLike;
 };
+type TouchTapEndEvent = TouchLikeEvent &
+  Pick<TouchEvent, 'preventDefault' | 'timeStamp'>;
 
 function isElement(target: EventTarget | null): target is HTMLElement {
   return target instanceof HTMLElement;
 }
 
-function readTouchPoint(
-  event: PointerTouchLikeEvent | TouchLikeEvent
-) {
-  if ('pointerType' in event) {
-    if (event.pointerType !== 'touch') {
-      return null;
-    }
-
-    return { x: event.clientX, y: event.clientY };
-  }
-
+function readTouchPoint(event: TouchLikeEvent) {
   const touch = event.changedTouches[0] ?? event.touches[0];
 
   if (!touch) {
@@ -100,7 +91,7 @@ export function markRecentTouchActivation(
 
 export function beginTouchTapTracking(
   target: EventTarget | null,
-  event: PointerTouchLikeEvent | TouchLikeEvent
+  event: TouchLikeEvent
 ) {
   if (!isElement(target)) {
     return;
@@ -119,7 +110,7 @@ export function beginTouchTapTracking(
 
 export function updateTouchTapTracking(
   target: EventTarget | null,
-  event: PointerTouchLikeEvent | TouchLikeEvent
+  event: TouchLikeEvent
 ) {
   if (!isElement(target)) {
     return;
@@ -147,7 +138,7 @@ export function cancelTouchTapTracking(target: EventTarget | null) {
 
 export function finishTouchTapTracking(
   target: EventTarget | null,
-  event: PointerTouchLikeEvent | TouchLikeEvent
+  event: TouchLikeEvent
 ) {
   if (!isElement(target)) {
     return false;
@@ -164,4 +155,22 @@ export function finishTouchTapTracking(
   }
 
   return !exceededTapDistance(start, point);
+}
+
+export function activateTouchTap(
+  target: EventTarget | null,
+  event: TouchTapEndEvent
+) {
+  if (!finishTouchTapTracking(target, event)) {
+    return false;
+  }
+
+  if (!isElement(target)) {
+    return false;
+  }
+
+  event.preventDefault();
+  target.click();
+  markRecentTouchActivation(target, event.timeStamp);
+  return true;
 }


### PR DESCRIPTION
## Summary
- restore touch selection for cmdk items inside mobile combobox drawers
- suppress duplicate follow-up clicks after touch selection
- add regression coverage for touch-based command item selection

## Testing
- bun run lint
- bun run tsc
- bun run test
- bun run build