### PR TITLE
fix: avoid stack auth hook in demo mobile nav

### DIFF
--- a/client/src/components/demo-header.tsx
+++ b/client/src/components/demo-header.tsx
@@ -44,7 +44,7 @@ export function DemoHeader() {
         </div>
       </header>
 
-      <MobileBottomNav includeChat />
+      <MobileBottomNav includeChat isAuthenticated={false} />
     </>
   );
 }

--- a/client/src/components/mobile-bottom-nav.test.tsx
+++ b/client/src/components/mobile-bottom-nav.test.tsx
@@ -4,7 +4,7 @@ import { MobileBottomNav } from '@/components/mobile-bottom-nav';
 
 vi.mock('@/components/mobile-nav-drawer', () => ({
   MobileNavDrawer: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="mobile-nav-drawer">{children}</div>
+    <>{children}</>
   ),
 }));
 

--- a/client/src/components/mobile-bottom-nav.test.tsx
+++ b/client/src/components/mobile-bottom-nav.test.tsx
@@ -9,11 +9,19 @@ vi.mock('@/components/mobile-nav-drawer', () => ({
 }));
 
 vi.mock('@/components/custom-user-button', () => ({
-  CustomUserButton: () => <div data-testid="custom-user-button">user</div>,
+  CustomUserButton: () => (
+    <button type="button" aria-label="Signed-in user menu">
+      user
+    </button>
+  ),
 }));
 
 vi.mock('@/components/guest-user-button', () => ({
-  GuestUserButton: () => <div data-testid="guest-user-button">guest</div>,
+  GuestUserButton: () => (
+    <button type="button" aria-label="Guest user menu">
+      guest
+    </button>
+  ),
 }));
 
 beforeAll(() => {
@@ -45,14 +53,22 @@ describe('MobileBottomNav', () => {
   it('renders the guest button in demo mode', async () => {
     render(<MobileBottomNav includeChat isAuthenticated={false} />);
 
-    expect(await screen.findByTestId('guest-user-button')).toBeInTheDocument();
-    expect(screen.queryByTestId('custom-user-button')).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Guest user menu' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Signed-in user menu' })
+    ).not.toBeInTheDocument();
   });
 
   it('renders the signed-in button for authenticated sessions', async () => {
     render(<MobileBottomNav includeChat isAuthenticated />);
 
-    expect(await screen.findByTestId('custom-user-button')).toBeInTheDocument();
-    expect(screen.queryByTestId('guest-user-button')).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Signed-in user menu' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Guest user menu' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/mobile-bottom-nav.test.tsx
+++ b/client/src/components/mobile-bottom-nav.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MobileBottomNav } from '@/components/mobile-bottom-nav';
+
+vi.mock('@/components/mobile-nav-drawer', () => ({
+  MobileNavDrawer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="mobile-nav-drawer">{children}</div>
+  ),
+}));
+
+vi.mock('@/components/custom-user-button', () => ({
+  CustomUserButton: () => <div data-testid="custom-user-button">user</div>,
+}));
+
+vi.mock('@/components/guest-user-button', () => ({
+  GuestUserButton: () => <div data-testid="guest-user-button">guest</div>,
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches:
+        query === '(pointer: coarse)' ||
+        query === '(max-width: 1024px)',
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+});
+
+beforeEach(() => {
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    configurable: true,
+    value: 1,
+  });
+});
+
+describe('MobileBottomNav', () => {
+  it('renders the guest button in demo mode', async () => {
+    render(<MobileBottomNav includeChat isAuthenticated={false} />);
+
+    expect(await screen.findByTestId('guest-user-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('custom-user-button')).not.toBeInTheDocument();
+  });
+
+  it('renders the signed-in button for authenticated sessions', async () => {
+    render(<MobileBottomNav includeChat isAuthenticated />);
+
+    expect(await screen.findByTestId('custom-user-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('guest-user-button')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/mobile-bottom-nav.tsx
+++ b/client/src/components/mobile-bottom-nav.tsx
@@ -3,9 +3,11 @@ import { Menu } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { MobileNavDrawer } from './mobile-nav-drawer';
 import { CustomUserButton } from './custom-user-button';
+import { GuestUserButton } from './guest-user-button';
 
 interface MobileBottomNavProps {
   includeChat?: boolean;
+  isAuthenticated?: boolean;
 }
 
 function shouldUseBottomNav() {
@@ -21,7 +23,10 @@ function shouldUseBottomNav() {
   return (coarsePointer || touchPoints) && (standalone || mobileViewport);
 }
 
-export function MobileBottomNav({ includeChat = false }: MobileBottomNavProps) {
+export function MobileBottomNav({
+  includeChat = false,
+  isAuthenticated = true,
+}: MobileBottomNavProps) {
   const [enabled, setEnabled] = useState(false);
 
   useEffect(() => {
@@ -61,7 +66,7 @@ export function MobileBottomNav({ includeChat = false }: MobileBottomNavProps) {
           </Button>
         </MobileNavDrawer>
 
-        <CustomUserButton />
+        {isAuthenticated ? <CustomUserButton /> : <GuestUserButton />}
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- avoid rendering the auth-only user button from the mobile bottom nav in demo mode
- pass explicit auth state from the demo header into the mobile nav
- add a regression test covering guest vs authenticated mobile nav rendering

## Testing
- bun run test -- src/components/mobile-bottom-nav.test.tsx
- bun run lint
- bun run tsc