### PR TITLE
chore: standardize server env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ client/tests/e2e/.auth/
 .env
 server/.env
 server/.env.local
+# Legacy local env file name; keep ignored so old secrets never appear in git status.
 server/.setenv.sh
 server/setenv.sh
 client/.env

--- a/server/Makefile
+++ b/server/Makefile
@@ -18,7 +18,7 @@ DB_SERVICE ?= postgres
 DB_READY_TIMEOUT ?= 90
 AIR_CMD ?= air
 DB_DATA_DIR ?= _db-data
-ENV_FILE ?= $(if $(wildcard .setenv.sh),.setenv.sh,$(if $(wildcard setenv.sh),setenv.sh,setenv.sh))
+ENV_FILE ?= setenv.sh
 
 help:
 	@echo "Available commands:"
@@ -100,7 +100,7 @@ test-short: ## Start local DB and run short test suite
 	fi
 	@if [ ! -f "$(ENV_FILE)" ]; then \
 		echo "ERROR: expected env file at $$(pwd)/$(ENV_FILE)"; \
-		echo "Create .setenv.sh or setenv.sh with DB_USER, DB_PASSWORD, DB_NAME, and DATABASE_URL before running make test-short."; \
+		echo "Create setenv.sh with DB_USER, DB_PASSWORD, DB_NAME, and DATABASE_URL before running make test-short."; \
 		exit 1; \
 	fi
 	. ./$(ENV_FILE); \

--- a/server/README.md
+++ b/server/README.md
@@ -44,8 +44,7 @@ If you prefer to run steps individually:
 1. Load environment variables:
 
 ```bash
-source ./.setenv.sh
-# or: source ./setenv.sh
+source ./setenv.sh
 ```
 
 2. Start database:
@@ -80,7 +79,7 @@ Expected env var: `GEMINI_API_KEY` or `GOOGLE_API_KEY`
 
 Optional env var: `GEMINI_MODEL` (defaults to `googleai/gemini-2.5-flash`)
 
-The command respects existing shell env first, then loads `server/.env` and `server/setenv.sh` (or `server/.setenv.sh`) if present. It sends one real Genkit request to Gemini, times out after 20 seconds, and prints a short model response to stdout.
+The command respects existing shell env first, then loads `server/.env` and `server/setenv.sh` if present. It sends one real Genkit request to Gemini, times out after 20 seconds, and prints a short model response to stdout.
 
 ### AI Chat Runtime
 
@@ -92,8 +91,8 @@ The live API chat runtime uses the same model default as the smoke test:
 
 For local development, keep using the existing server env workflow:
 
-1. Put values in your shell, `server/.env`, `server/.setenv.sh`, or `server/setenv.sh`
-2. Source `.setenv.sh` or `setenv.sh` (or otherwise export env) before `go run ./cmd/api` or `make dev`
+1. Put values in your shell, `server/.env`, or `server/setenv.sh`
+2. Source `setenv.sh` (or otherwise export env) before `go run ./cmd/api` or `make dev`
 
 The API server itself reads process env. It does not introduce a chat-only env file loader.
 
@@ -259,7 +258,7 @@ rm -rf _db-data
 mkdir -p _db-data
 ```
 
-After that, rerun `make dev` so Postgres initializes with the values from `setenv.sh` or `.setenv.sh`.
+After that, rerun `make dev` so Postgres initializes with the values from `setenv.sh`.
 
 **Missing air:**
 

--- a/server/cmd/gemini-smoke/main.go
+++ b/server/cmd/gemini-smoke/main.go
@@ -29,7 +29,7 @@ func main() {
 	}
 
 	if configuredAPIKeyEnvVar() == "" {
-		fmt.Fprintf(os.Stderr, "%s or %s must be set. Put one in your shell or in server/.env, server/.setenv.sh, or server/setenv.sh.\n", geminiAPIKeyEnvVar, googleAPIKeyEnvVar)
+		fmt.Fprintf(os.Stderr, "%s or %s must be set. Put one in your shell or in server/.env or server/setenv.sh.\n", geminiAPIKeyEnvVar, googleAPIKeyEnvVar)
 		os.Exit(1)
 	}
 
@@ -74,7 +74,7 @@ func loadLocalEnv() error {
 }
 
 func localEnvFiles() []string {
-	return []string{".env", ".setenv.sh", "setenv.sh"}
+	return []string{".env", "setenv.sh"}
 }
 
 func existingEnvFiles(paths ...string) []string {

--- a/server/cmd/gemini-smoke/main_test.go
+++ b/server/cmd/gemini-smoke/main_test.go
@@ -94,19 +94,7 @@ func TestLoadLocalEnvRespectsPriorityAndSetenv(t *testing.T) {
 	writeTestFile(t, filepath.Join(dir, ".env"), "GOOGLE_API_KEY=from-dotenv\nGEMINI_MODEL=env-model\n")
 	writeTestFile(t, filepath.Join(dir, "setenv.sh"), "export GEMINI_API_KEY=from-setenv\nexport GEMINI_MODEL=setenv-model\n")
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("os.Getwd() error = %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("os.Chdir() error = %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(cwd); err != nil {
-			t.Fatalf("restore cwd error = %v", err)
-		}
-	})
-
+	chdirForTest(t, dir)
 	unsetEnvForTest(t, geminiAPIKeyEnvVar, googleAPIKeyEnvVar, "GEMINI_MODEL")
 
 	if err := loadLocalEnv(); err != nil {
@@ -121,6 +109,22 @@ func TestLoadLocalEnvRespectsPriorityAndSetenv(t *testing.T) {
 	}
 	if got := os.Getenv("GEMINI_MODEL"); got != "env-model" {
 		t.Fatalf("expected GEMINI_MODEL from .env, got %q", got)
+	}
+}
+
+func TestLoadLocalEnvIgnoresHiddenSetenv(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, ".setenv.sh"), "export GEMINI_API_KEY=from-hidden-setenv\n")
+
+	chdirForTest(t, dir)
+	unsetEnvForTest(t, geminiAPIKeyEnvVar)
+
+	if err := loadLocalEnv(); err != nil {
+		t.Fatalf("loadLocalEnv() error = %v", err)
+	}
+
+	if got := os.Getenv(geminiAPIKeyEnvVar); got != "" {
+		t.Fatalf("expected %s to ignore .setenv.sh, got %q", geminiAPIKeyEnvVar, got)
 	}
 }
 
@@ -182,6 +186,23 @@ func unsetEnvForTest(t *testing.T, keys ...string) {
 			}
 		})
 	}
+}
+
+func chdirForTest(t *testing.T, dir string) {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() error = %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("os.Chdir() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("restore cwd error = %v", err)
+		}
+	})
 }
 
 func writeTestFile(t *testing.T, path string, contents string) {

--- a/server/migrations/README.md
+++ b/server/migrations/README.md
@@ -18,7 +18,7 @@ make migrate-up
 make migrate-down
 ```
 
-`make migrate-up` and `make migrate-down` load `DATABASE_URL` from the configured server env file, typically `server/.setenv.sh` or `server/setenv.sh`.
+`make migrate-up` and `make migrate-down` load `DATABASE_URL` from `server/setenv.sh`.
 
 ## Current Migration Set
 


### PR DESCRIPTION
## Summary
- standardize server env loading on setenv.sh
- remove .setenv.sh from active Makefile and Gemini smoke-test behavior
- update docs to point at setenv.sh only
- keep .setenv.sh ignored as a legacy secret-file safety net

## Verification
- go test ./cmd/gemini-smoke
- go test -short ./... excluding internal/database, matching make test-fast coverage
- git commit pre-commit hook passed server fast tests
- make test-short was attempted by pre-push but blocked by existing local _db-data credentials: Postgres reported role "user" does not exist
