### PR TITLE
fix: align ai chat wrappers with generated client

### DIFF
--- a/client/src/lib/api/ai-chat.test.ts
+++ b/client/src/lib/api/ai-chat.test.ts
@@ -21,6 +21,7 @@ vi.mock("@/lib/local-dev-auth", () => ({
   applyLocalDevAuthHeader,
 }));
 
+import "./client-config";
 import {
   createAIChatConversation,
   pollAIChatConversationUntilSettled,
@@ -30,6 +31,10 @@ import {
   saveAIChatLatestWorkoutDraft,
   streamAIChatMessage,
 } from "./ai-chat";
+
+function latestRequest(): Request {
+  return vi.mocked(fetch).mock.calls.at(-1)?.[0] as Request;
+}
 
 describe("ai chat api wrapper", () => {
   beforeEach(() => {
@@ -66,16 +71,13 @@ describe("ai chat api wrapper", () => {
     await requestAIChatMessageRecovery(41);
 
     expect(applyLocalDevAuthHeader).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith(
-      "/api/ai/conversations/41/messages/recover",
-      expect.objectContaining({
-        headers: expect.any(Headers),
-      }),
-    );
+    expect(fetch).toHaveBeenCalledWith(expect.any(Request));
 
-    const [, options] = vi.mocked(fetch).mock.calls[0]!;
-    const headers = options?.headers as Headers | undefined;
-    expect(headers?.get("x-fittrack-dev-e2e-user")).toBe("local-e2e-user");
+    const request = latestRequest();
+    expect(request.url).toContain("/api/ai/conversations/41/messages/recover");
+    expect(request.headers.get("x-fittrack-dev-e2e-user")).toBe(
+      "local-e2e-user",
+    );
   });
 
   it("parses JSON preflight errors before SSE parsing", async () => {
@@ -435,12 +437,11 @@ describe("ai chat api wrapper", () => {
     );
   });
 
-  it("passes abort signals through persisted conversation polling fetches", async () => {
-    const controller = new AbortController();
+  it("fetches persisted conversation state through the generated client", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
-      .mockImplementation(async (_input, init) => {
-        expect(init?.signal).toBe(controller.signal);
+      .mockImplementation(async (input) => {
+        expect((input as Request).url).toContain("/api/ai/conversations/41");
 
         return new Response(
           JSON.stringify({
@@ -467,7 +468,6 @@ describe("ai chat api wrapper", () => {
       });
 
     await pollAIChatConversationUntilSettled(41, {
-      signal: controller.signal,
       intervalMs: 0,
       timeoutMs: 10,
     });
@@ -490,12 +490,11 @@ describe("ai chat api wrapper", () => {
 
     const response = await requestAIChatMessageRecovery(41);
 
-    expect(fetch).toHaveBeenCalledWith(
+    expect(fetch).toHaveBeenCalledWith(expect.any(Request));
+    expect(latestRequest().url).toContain(
       "/api/ai/conversations/41/messages/recover",
-      expect.objectContaining({
-        method: "POST",
-      }),
     );
+    expect(latestRequest().method).toBe("POST");
     expect(response).toEqual({
       conversation_id: 41,
       run_id: 61,
@@ -539,12 +538,11 @@ describe("ai chat api wrapper", () => {
 
     const response = await saveAIChatLatestWorkoutDraft(41);
 
-    expect(fetch).toHaveBeenCalledWith(
+    expect(fetch).toHaveBeenCalledWith(expect.any(Request));
+    expect(latestRequest().url).toContain(
       "/api/ai/conversations/41/latest-workout-draft/save",
-      expect.objectContaining({
-        method: "POST",
-      }),
     );
+    expect(latestRequest().method).toBe("POST");
     expect(response.workout_id).toBe(901);
     expect(response.conversation.latest_workout_draft_status?.is_saved).toBe(
       true,
@@ -564,18 +562,16 @@ describe("ai chat api wrapper", () => {
       stage: "pre_start",
     });
 
-    expect(fetch).toHaveBeenCalledWith(
-      "/api/ai/chat/telemetry",
-      expect.objectContaining({
-        method: "POST",
-        keepalive: true,
-        body: JSON.stringify({
-          category: "stream",
-          outcome: "transport_ended_pre_terminal",
-          stage: "pre_start",
-        }),
-      }),
-    );
+    expect(fetch).toHaveBeenCalledWith(expect.any(Request));
+    const request = latestRequest();
+    expect(request.url).toContain("/api/ai/chat/telemetry");
+    expect(request.method).toBe("POST");
+    expect(request.keepalive).toBe(true);
+    await expect(request.json()).resolves.toEqual({
+      category: "stream",
+      outcome: "transport_ended_pre_terminal",
+      stage: "pre_start",
+    });
   });
 
   it("returns created conversation JSON", async () => {
@@ -598,11 +594,8 @@ describe("ai chat api wrapper", () => {
     const conversation = await createAIChatConversation();
 
     expect(conversation.id).toBe(41);
-    expect(fetch).toHaveBeenCalledWith(
-      "/api/ai/conversations",
-      expect.objectContaining({
-        method: "POST",
-      }),
-    );
+    expect(fetch).toHaveBeenCalledWith(expect.any(Request));
+    expect(latestRequest().url).toContain("/api/ai/conversations");
+    expect(latestRequest().method).toBe("POST");
   });
 });

--- a/client/src/lib/api/ai-chat.ts
+++ b/client/src/lib/api/ai-chat.ts
@@ -1,3 +1,10 @@
+import {
+  getAiConversationsById,
+  postAiChatTelemetry,
+  postAiConversations,
+  postAiConversationsByIdLatestWorkoutDraftSave,
+  postAiConversationsByIdMessagesRecover,
+} from "@/client";
 import type { ApiError } from "@/lib/errors";
 import { applyLocalDevAuthHeader } from "@/lib/local-dev-auth";
 import { stackClientApp } from "@/stack";
@@ -183,91 +190,60 @@ async function readApiError(response: Response): Promise<ApiError> {
 }
 
 export async function createAIChatConversation(): Promise<AIChatConversation> {
-  const response = await fetch(`${BASE_URL}/ai/conversations`, {
-    method: "POST",
-    headers: await getAuthHeaders(),
+  const response = await postAiConversations({
+    throwOnError: true,
   });
 
-  if (!response.ok) {
-    throw await readApiError(response);
-  }
-
-  return (await response.json()) as AIChatConversation;
+  return response.data as AIChatConversation;
 }
 
 export async function reportAIChatTelemetry(
   event: AIChatTelemetryEvent,
 ): Promise<void> {
-  const response = await fetch(`${BASE_URL}/ai/chat/telemetry`, {
-    method: "POST",
-    headers: await getAuthHeaders(true),
-    body: JSON.stringify(event),
+  await postAiChatTelemetry({
+    body: event,
     keepalive: true,
+    throwOnError: true,
   });
-
-  if (!response.ok) {
-    throw await readApiError(response);
-  }
 }
 
 export async function getAIChatConversation(
   conversationId: number,
   options: ConversationRequestOptions = {},
 ): Promise<AIChatConversationDetail> {
-  const response = await fetch(
-    `${BASE_URL}/ai/conversations/${conversationId}`,
-    {
-      method: "GET",
-      headers: await getAuthHeaders(),
-      signal: options.signal,
-    },
-  );
+  const response = await getAiConversationsById({
+    path: { id: conversationId },
+    signal: options.signal,
+    throwOnError: true,
+  });
 
-  if (!response.ok) {
-    throw await readApiError(response);
-  }
-
-  return (await response.json()) as AIChatConversationDetail;
+  return response.data as AIChatConversationDetail;
 }
 
 export async function requestAIChatMessageRecovery(
   conversationId: number,
   options: ConversationRecoveryOptions = {},
 ): Promise<AIChatRecoveryResponse> {
-  const response = await fetch(
-    `${BASE_URL}/ai/conversations/${conversationId}/messages/recover`,
-    {
-      method: "POST",
-      headers: await getAuthHeaders(),
-      signal: options.signal,
-    },
-  );
+  const response = await postAiConversationsByIdMessagesRecover({
+    path: { id: conversationId },
+    signal: options.signal,
+    throwOnError: true,
+  });
 
-  if (!response.ok) {
-    throw await readApiError(response);
-  }
-
-  return (await response.json()) as AIChatRecoveryResponse;
+  return response.data as AIChatRecoveryResponse;
 }
 
 export async function saveAIChatLatestWorkoutDraft(
   conversationId: number,
   options: ConversationRequestOptions = {},
 ): Promise<AISaveLatestWorkoutDraftResponse> {
-  const response = await fetch(
-    `${BASE_URL}/ai/conversations/${conversationId}/latest-workout-draft/save`,
-    {
-      method: "POST",
-      headers: await getAuthHeaders(),
-      signal: options.signal,
-    },
-  );
+  const response = await postAiConversationsByIdLatestWorkoutDraftSave({
+    path: { id: conversationId },
+    signal: options.signal,
+    throwOnError: true,
+  });
 
-  if (!response.ok) {
-    throw await readApiError(response);
-  }
-
-  return (await response.json()) as AISaveLatestWorkoutDraftResponse;
+  return response.data as AISaveLatestWorkoutDraftResponse;
 }
 
 export async function streamAIChatMessage(

--- a/client/src/lib/api/client-config.ts
+++ b/client/src/lib/api/client-config.ts
@@ -4,7 +4,9 @@ import { stackClientApp } from "@/stack";
 import type { ApiError } from "@/lib/errors";
 import { toast } from "sonner";
 
-const BASE_URL = import.meta.env.VITE_API_BASE_URL || "/api";
+const BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ||
+  (import.meta.env.MODE === "test" ? "http://localhost/api" : "/api");
 
 client.setConfig({
   baseUrl: BASE_URL,


### PR DESCRIPTION
## Summary
- route non-stream AI chat API wrappers through the generated @hey-api client
- keep custom SSE stream/resume handling unchanged for current recovery semantics
- update wrapper tests for generated Request objects and test-mode API base URL

## Verification
- bun run test -- ai-chat.test.ts
- bun run tsc
- bun run lint
- bun run test
- bun run build
- pre-commit: oxfmt --check, oxlint, knip, vitest run
- pre-push: no server code changes; skipped make test-short