### PR TITLE
feat: improve structured workout chat handoff

### DIFF
--- a/client/src/routes/_layout/-chat-workout-draft.tsx
+++ b/client/src/routes/_layout/-chat-workout-draft.tsx
@@ -7,8 +7,10 @@ type ChatWorkoutDraftCardProps = {
   draft: AIWorkoutDraft;
   isSaving?: boolean;
   isSaved?: boolean;
+  savedWorkoutId?: number;
   onSave: () => void;
   onEdit: () => void;
+  onOpenSavedWorkout?: () => void;
   className?: string;
 };
 
@@ -16,8 +18,10 @@ export function ChatWorkoutDraftCard({
   draft,
   isSaving = false,
   isSaved = false,
+  savedWorkoutId,
   onSave,
   onEdit,
+  onOpenSavedWorkout,
   className,
 }: ChatWorkoutDraftCardProps) {
   const totalSets = draft.exercises.reduce(
@@ -74,6 +78,15 @@ export function ChatWorkoutDraftCard({
           >
             Edit in workout form
           </Button>
+          {isSaved && savedWorkoutId && onOpenSavedWorkout ? (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onOpenSavedWorkout}
+            >
+              Open saved workout
+            </Button>
+          ) : null}
         </div>
       </div>
 

--- a/client/src/routes/_layout/-chat.test.tsx
+++ b/client/src/routes/_layout/-chat.test.tsx
@@ -1099,9 +1099,19 @@ describe("ChatRouteComponent", () => {
     expect(mockToastSuccess).toHaveBeenCalledWith("Workout saved successfully");
     expect(mockNavigate).not.toHaveBeenCalledWith({ to: "/workouts/new" });
     expect(await screen.findByRole("button", { name: "Saved" })).toBeDisabled();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Open saved workout" }),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/workouts/$workoutId",
+      params: { workoutId: 88 },
+    });
   });
 
-  it("shows a disabled Saved button when reopening a conversation with an already-saved draft", async () => {
+  it("shows a disabled Saved button and saved workout link when reopening an already-saved draft", async () => {
+    const user = userEvent.setup();
     const latestWorkoutDraft: AIWorkoutDraft = {
       date: "2026-04-21T12:00:00Z",
       notes: "Keep rest short",
@@ -1130,6 +1140,15 @@ describe("ChatRouteComponent", () => {
       screen.queryByRole("button", { name: "Save now" }),
     ).not.toBeInTheDocument();
     expect(mockSaveLatestWorkoutDraft).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole("button", { name: "Open saved workout" }),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/workouts/$workoutId",
+      params: { workoutId: 88 },
+    });
   });
 
   it("overwrites the latest workout draft CTA after a regenerated structured workout", async () => {

--- a/client/src/routes/_layout/chat.tsx
+++ b/client/src/routes/_layout/chat.tsx
@@ -837,8 +837,17 @@ export function ChatRouteComponent() {
     }
   }
 
+  function handleOpenSavedWorkout(workoutId: number) {
+    void navigate({
+      to: "/workouts/$workoutId",
+      params: { workoutId },
+    });
+  }
+
   const isLatestWorkoutDraftSaved =
     conversation?.latest_workout_draft_status?.is_saved ?? false;
+  const savedWorkoutId =
+    conversation?.latest_workout_draft_status?.saved_workout_id;
 
   return (
     <div className="mx-auto flex max-w-5xl flex-col gap-6 p-6">
@@ -898,8 +907,14 @@ export function ChatRouteComponent() {
                       void handleSaveWorkoutDraft();
                     }
                   }}
+                  onOpenSavedWorkout={
+                    savedWorkoutId
+                      ? () => handleOpenSavedWorkout(savedWorkoutId)
+                      : undefined
+                  }
                   isSavingWorkoutDraft={isSavingWorkoutDraft}
                   isSavedWorkoutDraft={isLatestWorkoutDraftSaved}
+                  savedWorkoutId={savedWorkoutId}
                 />
               ))}
             </div>
@@ -912,9 +927,15 @@ export function ChatRouteComponent() {
               draft={conversation.latest_workout_draft}
               isSaving={isSavingWorkoutDraft}
               isSaved={isLatestWorkoutDraftSaved}
+              savedWorkoutId={savedWorkoutId}
               onSave={() => void handleSaveWorkoutDraft()}
               onEdit={() =>
                 handleEditInWorkoutForm(conversation.latest_workout_draft!)
+              }
+              onOpenSavedWorkout={
+                savedWorkoutId
+                  ? () => handleOpenSavedWorkout(savedWorkoutId)
+                  : undefined
               }
             />
           ) : null}
@@ -954,15 +975,19 @@ function MessageBubble({
   workoutDraft,
   isSavingWorkoutDraft,
   isSavedWorkoutDraft,
+  savedWorkoutId,
   onSaveWorkoutDraft,
   onEditWorkoutDraft,
+  onOpenSavedWorkout,
 }: {
   message: AIChatMessage;
   workoutDraft?: AIWorkoutDraft;
   isSavingWorkoutDraft?: boolean;
   isSavedWorkoutDraft?: boolean;
+  savedWorkoutId?: number;
   onSaveWorkoutDraft?: () => void;
   onEditWorkoutDraft?: () => void;
+  onOpenSavedWorkout?: () => void;
 }) {
   const isUser = message.role === "user";
   const statusLabel =
@@ -1006,8 +1031,10 @@ function MessageBubble({
           draft={workoutDraft}
           isSaving={isSavingWorkoutDraft}
           isSaved={isSavedWorkoutDraft}
+          savedWorkoutId={savedWorkoutId}
           onSave={onSaveWorkoutDraft}
           onEdit={onEditWorkoutDraft}
+          onOpenSavedWorkout={onOpenSavedWorkout}
         />
       ) : null}
     </div>

--- a/server/internal/aichat/workout_generation.go
+++ b/server/internal/aichat/workout_generation.go
@@ -136,6 +136,9 @@ Rules:
 - The exercise list must contain at least one real exercise, and every exercise must contain at least one set.
 - Use only "warmup" or "working" for setType.
 - Match the workout focus, available equipment, session length, training location, and injury constraints.
+- Scale the draft to the requested session duration by estimating setup and transitions, set execution time, rest between sets, and warm-up or ramp-up needs when appropriate.
+- Use a reasonable share of the requested time. Do not satisfy a normal 40+ minute strength or hypertrophy request with a very small workout unless the user asked for minimal, beginner, rehab, warm-up, or low-volume work.
+- Adjust density by goal: strength can use fewer exercises with longer rests and enough sets; hypertrophy should use moderate rests and enough total working sets; endurance or circuit work should use shorter rests and higher density; rehab, mobility, and beginner sessions can use lower volume when appropriate.
 - Do not invent equipment the user does not have.
 - Use real, established exercise names only.
 - Add weights only when they are reasonably known from the user's context. If fitness level is unknown, prefer omitting weights instead of guessing aggressively.

--- a/server/internal/aichat/workout_generation_test.go
+++ b/server/internal/aichat/workout_generation_test.go
@@ -154,6 +154,10 @@ func TestBuildWorkoutGenerationPromptIncludesFitTrackContract(t *testing.T) {
 		`"setType": "warmup" | "working"`,
 		`"date" is always required and must be RFC3339.`,
 		`If fitness level is unknown, prefer omitting weights instead of guessing aggressively.`,
+		`Scale the draft to the requested session duration by estimating setup and transitions, set execution time, rest between sets, and warm-up or ramp-up needs when appropriate.`,
+		`Do not satisfy a normal 40+ minute strength or hypertrophy request with a very small workout unless the user asked for minimal, beginner, rehab, warm-up, or low-volume work.`,
+		`strength can use fewer exercises with longer rests and enough sets`,
+		`endurance or circuit work should use shorter rests and higher density`,
 	}
 
 	for _, snippet := range requiredSnippets {


### PR DESCRIPTION
## User impact
Users who save an AI-generated structured workout draft can now open the saved workout directly from chat, instead of having to find it elsewhere. Workout generation guidance also better respects requested session duration so normal 40+ minute strength or hypertrophy requests should not produce tiny drafts unless the user explicitly asks for low-volume work.

## Product behavior
- Shows an "Open saved workout" action when a chat draft is already saved and has a saved workout id.
- Routes that action to the saved workout detail page.
- Preserves the existing "Edit in workout form" draft import path.
- Updates the workout-generation prompt to budget setup, transitions, set time, rest, and warm-up/ramp-up needs dynamically.

## Risks and decision points
- Low API risk: no backend response shape changed.
- Prompt change is flexible rather than hard-coded to exercise counts.
- Future hardening could add a backend duration estimator to reject wildly short or long generated drafts.

## Verification
- cd client && bun run test -- src/routes/_layout/-chat.test.tsx
- cd server && go test ./internal/aichat
- cd server && make vet
- Push hook ran cd server && make test-short successfully