### PR TITLE
feat: add deterministic workout draft quality checks

### DIFF
--- a/client/src/routes/_layout/-chat-workout-draft.tsx
+++ b/client/src/routes/_layout/-chat-workout-draft.tsx
@@ -7,8 +7,10 @@ type ChatWorkoutDraftCardProps = {
   draft: AIWorkoutDraft;
   isSaving?: boolean;
   isSaved?: boolean;
+  savedWorkoutId?: number;
   onSave: () => void;
   onEdit: () => void;
+  onOpenSavedWorkout?: () => void;
   className?: string;
 };
 
@@ -16,8 +18,10 @@ export function ChatWorkoutDraftCard({
   draft,
   isSaving = false,
   isSaved = false,
+  savedWorkoutId,
   onSave,
   onEdit,
+  onOpenSavedWorkout,
   className,
 }: ChatWorkoutDraftCardProps) {
   const totalSets = draft.exercises.reduce(
@@ -74,6 +78,15 @@ export function ChatWorkoutDraftCard({
           >
             Edit in workout form
           </Button>
+          {isSaved && savedWorkoutId && onOpenSavedWorkout ? (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onOpenSavedWorkout}
+            >
+              Open saved workout
+            </Button>
+          ) : null}
         </div>
       </div>
 

--- a/client/src/routes/_layout/-chat.test.tsx
+++ b/client/src/routes/_layout/-chat.test.tsx
@@ -1099,9 +1099,19 @@ describe("ChatRouteComponent", () => {
     expect(mockToastSuccess).toHaveBeenCalledWith("Workout saved successfully");
     expect(mockNavigate).not.toHaveBeenCalledWith({ to: "/workouts/new" });
     expect(await screen.findByRole("button", { name: "Saved" })).toBeDisabled();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Open saved workout" }),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/workouts/$workoutId",
+      params: { workoutId: 88 },
+    });
   });
 
-  it("shows a disabled Saved button when reopening a conversation with an already-saved draft", async () => {
+  it("shows a disabled Saved button and saved workout link when reopening an already-saved draft", async () => {
+    const user = userEvent.setup();
     const latestWorkoutDraft: AIWorkoutDraft = {
       date: "2026-04-21T12:00:00Z",
       notes: "Keep rest short",
@@ -1130,6 +1140,15 @@ describe("ChatRouteComponent", () => {
       screen.queryByRole("button", { name: "Save now" }),
     ).not.toBeInTheDocument();
     expect(mockSaveLatestWorkoutDraft).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole("button", { name: "Open saved workout" }),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/workouts/$workoutId",
+      params: { workoutId: 88 },
+    });
   });
 
   it("overwrites the latest workout draft CTA after a regenerated structured workout", async () => {

--- a/client/src/routes/_layout/chat.tsx
+++ b/client/src/routes/_layout/chat.tsx
@@ -837,8 +837,17 @@ export function ChatRouteComponent() {
     }
   }
 
+  function handleOpenSavedWorkout(workoutId: number) {
+    void navigate({
+      to: "/workouts/$workoutId",
+      params: { workoutId },
+    });
+  }
+
   const isLatestWorkoutDraftSaved =
     conversation?.latest_workout_draft_status?.is_saved ?? false;
+  const savedWorkoutId =
+    conversation?.latest_workout_draft_status?.saved_workout_id;
 
   return (
     <div className="mx-auto flex max-w-5xl flex-col gap-6 p-6">
@@ -898,8 +907,14 @@ export function ChatRouteComponent() {
                       void handleSaveWorkoutDraft();
                     }
                   }}
+                  onOpenSavedWorkout={
+                    savedWorkoutId
+                      ? () => handleOpenSavedWorkout(savedWorkoutId)
+                      : undefined
+                  }
                   isSavingWorkoutDraft={isSavingWorkoutDraft}
                   isSavedWorkoutDraft={isLatestWorkoutDraftSaved}
+                  savedWorkoutId={savedWorkoutId}
                 />
               ))}
             </div>
@@ -912,9 +927,15 @@ export function ChatRouteComponent() {
               draft={conversation.latest_workout_draft}
               isSaving={isSavingWorkoutDraft}
               isSaved={isLatestWorkoutDraftSaved}
+              savedWorkoutId={savedWorkoutId}
               onSave={() => void handleSaveWorkoutDraft()}
               onEdit={() =>
                 handleEditInWorkoutForm(conversation.latest_workout_draft!)
+              }
+              onOpenSavedWorkout={
+                savedWorkoutId
+                  ? () => handleOpenSavedWorkout(savedWorkoutId)
+                  : undefined
               }
             />
           ) : null}
@@ -954,15 +975,19 @@ function MessageBubble({
   workoutDraft,
   isSavingWorkoutDraft,
   isSavedWorkoutDraft,
+  savedWorkoutId,
   onSaveWorkoutDraft,
   onEditWorkoutDraft,
+  onOpenSavedWorkout,
 }: {
   message: AIChatMessage;
   workoutDraft?: AIWorkoutDraft;
   isSavingWorkoutDraft?: boolean;
   isSavedWorkoutDraft?: boolean;
+  savedWorkoutId?: number;
   onSaveWorkoutDraft?: () => void;
   onEditWorkoutDraft?: () => void;
+  onOpenSavedWorkout?: () => void;
 }) {
   const isUser = message.role === "user";
   const statusLabel =
@@ -1006,8 +1031,10 @@ function MessageBubble({
           draft={workoutDraft}
           isSaving={isSavingWorkoutDraft}
           isSaved={isSavedWorkoutDraft}
+          savedWorkoutId={savedWorkoutId}
           onSave={onSaveWorkoutDraft}
           onEdit={onEditWorkoutDraft}
+          onOpenSavedWorkout={onOpenSavedWorkout}
         />
       ) : null}
     </div>

--- a/server/internal/aichat/workout_generation.go
+++ b/server/internal/aichat/workout_generation.go
@@ -136,6 +136,9 @@ Rules:
 - The exercise list must contain at least one real exercise, and every exercise must contain at least one set.
 - Use only "warmup" or "working" for setType.
 - Match the workout focus, available equipment, session length, training location, and injury constraints.
+- Scale the draft to the requested session duration by estimating setup and transitions, set execution time, rest between sets, and warm-up or ramp-up needs when appropriate.
+- Use a reasonable share of the requested time. Do not satisfy a normal 40+ minute strength or hypertrophy request with a very small workout unless the user asked for minimal, beginner, rehab, warm-up, or low-volume work.
+- Adjust density by goal: strength can use fewer exercises with longer rests and enough sets; hypertrophy should use moderate rests and enough total working sets; endurance or circuit work should use shorter rests and higher density; rehab, mobility, and beginner sessions can use lower volume when appropriate.
 - Do not invent equipment the user does not have.
 - Use real, established exercise names only.
 - Add weights only when they are reasonably known from the user's context. If fitness level is unknown, prefer omitting weights instead of guessing aggressively.

--- a/server/internal/aichat/workout_generation.go
+++ b/server/internal/aichat/workout_generation.go
@@ -96,6 +96,9 @@ func generateWorkoutDraft(
 	if err := validateWorkoutDraft(output); err != nil {
 		return nil, fmt.Errorf("validate workout draft: %w", err)
 	}
+	if err := validateWorkoutDraftQuality(input, output); err != nil {
+		return nil, fmt.Errorf("validate workout draft quality: %w", err)
+	}
 
 	return output, nil
 }

--- a/server/internal/aichat/workout_generation_test.go
+++ b/server/internal/aichat/workout_generation_test.go
@@ -154,6 +154,10 @@ func TestBuildWorkoutGenerationPromptIncludesFitTrackContract(t *testing.T) {
 		`"setType": "warmup" | "working"`,
 		`"date" is always required and must be RFC3339.`,
 		`If fitness level is unknown, prefer omitting weights instead of guessing aggressively.`,
+		`Scale the draft to the requested session duration by estimating setup and transitions, set execution time, rest between sets, and warm-up or ramp-up needs when appropriate.`,
+		`Do not satisfy a normal 40+ minute strength or hypertrophy request with a very small workout unless the user asked for minimal, beginner, rehab, warm-up, or low-volume work.`,
+		`strength can use fewer exercises with longer rests and enough sets`,
+		`endurance or circuit work should use shorter rests and higher density`,
 	}
 
 	for _, snippet := range requiredSnippets {

--- a/server/internal/aichat/workout_quality.go
+++ b/server/internal/aichat/workout_quality.go
@@ -212,7 +212,7 @@ func parseEquipmentInventory(context string) equipmentInventory {
 func disallowedEquipmentTerms(context string) []string {
 	inventory := parseEquipmentInventory(context)
 	if inventory.hasFullGym {
-		return nil
+		return explicitlyUnavailableGymEquipmentTerms(context)
 	}
 
 	terms := make([]string, 0, 12)
@@ -235,6 +235,29 @@ func disallowedEquipmentTerms(context string) []string {
 		terms = append(terms, "bench", "bench-supported")
 	}
 
+	return terms
+}
+
+func explicitlyUnavailableGymEquipmentTerms(context string) []string {
+	terms := make([]string, 0, 12)
+	if hasUnavailableEquipmentTerm(context, "barbell", "power rack", "squat rack") {
+		terms = append(terms, "barbell", "smith")
+	}
+	if hasUnavailableEquipmentTerm(context, "dumbbell", "dumbbells") {
+		terms = append(terms, "dumbbell")
+	}
+	if hasUnavailableEquipmentTerm(context, "kettlebell", "kettlebells") {
+		terms = append(terms, "kettlebell")
+	}
+	if hasUnavailableEquipmentTerm(context, "cable", "cables") {
+		terms = append(terms, "cable", "lat pulldown")
+	}
+	if hasUnavailableEquipmentTerm(context, "machine", "machines", "leg press", "lat pulldown") {
+		terms = append(terms, "machine", "leg press")
+	}
+	if hasUnavailableEquipmentTerm(context, "bench", "box", "chair", "step") {
+		terms = append(terms, "bench", "bench-supported")
+	}
 	return terms
 }
 
@@ -368,6 +391,20 @@ func hasAvailableEquipmentTerm(text string, terms ...string) bool {
 			continue
 		}
 		return true
+	}
+	return false
+}
+
+func hasUnavailableEquipmentTerm(text string, terms ...string) bool {
+	for _, term := range terms {
+		normalizedTerm := normalizeQualityText(term)
+		if hasAnyQualityTerm(text,
+			"no "+normalizedTerm,
+			"without "+normalizedTerm,
+			"no access to "+normalizedTerm,
+		) {
+			return true
+		}
 	}
 	return false
 }

--- a/server/internal/aichat/workout_quality.go
+++ b/server/internal/aichat/workout_quality.go
@@ -87,8 +87,8 @@ func validateDraftEquipmentQuality(input WorkoutGenerationToolInput, draft *work
 }
 
 func validateDraftInjuryQuality(input WorkoutGenerationToolInput, draft *workout.CreateWorkoutRequest) []workoutDraftQualityIssue {
-	injuries := normalizeQualityText(input.Injuries)
-	if hasNoActiveInjury(injuries) {
+	injuries := activeInjuryText(input.Injuries)
+	if injuries == "" {
 		return nil
 	}
 
@@ -199,7 +199,7 @@ type equipmentInventory struct {
 
 func parseEquipmentInventory(context string) equipmentInventory {
 	return equipmentInventory{
-		hasFullGym:    hasAnyQualityTerm(context, "full gym", "commercial gym"),
+		hasFullGym:    hasAvailableGymContext(context),
 		hasBench:      hasAvailableEquipmentTerm(context, "bench", "box", "chair", "step"),
 		hasBarbell:    hasAvailableEquipmentTerm(context, "barbell", "power rack", "squat rack"),
 		hasDumbbell:   hasAvailableEquipmentTerm(context, "dumbbell", "dumbbells"),
@@ -258,9 +258,13 @@ func disallowedInjuryTerms(injuries string) []string {
 func hasNoActiveInjury(injuries string) bool {
 	return injuries == "" ||
 		injuries == "none" ||
-		hasExactQualityTerm(injuries, "no injuries", "no injury", "no pain", "no issues", "no limitations") ||
-		hasAnyQualityTerm(
+		hasExactQualityTerm(
 			injuries,
+			"no injuries",
+			"no injury",
+			"no pain",
+			"no issues",
+			"no limitations",
 			"no knee pain",
 			"no knee issues",
 			"no shoulder pain",
@@ -272,6 +276,31 @@ func hasNoActiveInjury(injuries string) bool {
 			"no elbow pain",
 			"no elbow issues",
 		)
+}
+
+func activeInjuryText(value string) string {
+	injuries := normalizeQualityText(value)
+	if hasNoActiveInjury(injuries) {
+		return ""
+	}
+
+	negatedBodyPartPhrases := []string{
+		"no knee pain",
+		"no knee issues",
+		"no shoulder pain",
+		"no shoulder issues",
+		"no back pain",
+		"no back issues",
+		"no wrist pain",
+		"no wrist issues",
+		"no elbow pain",
+		"no elbow issues",
+	}
+	for _, phrase := range negatedBodyPartPhrases {
+		injuries = strings.ReplaceAll(injuries, phrase, " ")
+	}
+
+	return normalizeQualityText(injuries)
 }
 
 func allowsLowerVolume(input WorkoutGenerationToolInput) bool {
@@ -339,6 +368,35 @@ func hasAvailableEquipmentTerm(text string, terms ...string) bool {
 			continue
 		}
 		return true
+	}
+	return false
+}
+
+func hasAvailableGymContext(text string) bool {
+	if hasAnyQualityTerm(
+		text,
+		"no gym",
+		"without gym",
+		"no access to gym",
+		"no full gym",
+		"without full gym",
+		"no access to full gym",
+		"no commercial gym",
+		"without commercial gym",
+		"no access to commercial gym",
+	) {
+		return false
+	}
+
+	return hasAnyQualityTerm(text, "full gym", "commercial gym") || hasQualityWord(text, "gym")
+}
+
+func hasQualityWord(text string, word string) bool {
+	normalizedWord := normalizeQualityText(word)
+	for _, field := range strings.Fields(text) {
+		if strings.Trim(field, ".,;:!?()[]{}") == normalizedWord {
+			return true
+		}
 	}
 	return false
 }

--- a/server/internal/aichat/workout_quality.go
+++ b/server/internal/aichat/workout_quality.go
@@ -88,7 +88,7 @@ func validateDraftEquipmentQuality(input WorkoutGenerationToolInput, draft *work
 
 func validateDraftInjuryQuality(input WorkoutGenerationToolInput, draft *workout.CreateWorkoutRequest) []workoutDraftQualityIssue {
 	injuries := normalizeQualityText(input.Injuries)
-	if injuries == "" || injuries == "none" || strings.Contains(injuries, "no injur") {
+	if hasNoActiveInjury(injuries) {
 		return nil
 	}
 
@@ -187,30 +187,52 @@ func workingRestSeconds(input WorkoutGenerationToolInput) int {
 	}
 }
 
+type equipmentInventory struct {
+	hasFullGym    bool
+	hasBench      bool
+	hasBarbell    bool
+	hasDumbbell   bool
+	hasKettlebell bool
+	hasCable      bool
+	hasMachine    bool
+}
+
+func parseEquipmentInventory(context string) equipmentInventory {
+	return equipmentInventory{
+		hasFullGym:    hasAnyQualityTerm(context, "full gym", "commercial gym"),
+		hasBench:      hasAvailableEquipmentTerm(context, "bench", "box", "chair", "step"),
+		hasBarbell:    hasAvailableEquipmentTerm(context, "barbell", "power rack", "squat rack"),
+		hasDumbbell:   hasAvailableEquipmentTerm(context, "dumbbell", "dumbbells"),
+		hasKettlebell: hasAvailableEquipmentTerm(context, "kettlebell", "kettlebells"),
+		hasCable:      hasAvailableEquipmentTerm(context, "cable", "cables"),
+		hasMachine:    hasAvailableEquipmentTerm(context, "machine", "machines", "leg press", "lat pulldown"),
+	}
+}
+
 func disallowedEquipmentTerms(context string) []string {
-	terms := make([]string, 0, 8)
-	bodyweightOnly := hasAnyQualityTerm(context, "bodyweight only", "no equipment", "without equipment")
-	if bodyweightOnly {
-		return []string{"barbell", "dumbbell", "kettlebell", "cable", "machine", "smith", "bench", "leg press", "lat pulldown"}
+	inventory := parseEquipmentInventory(context)
+	if inventory.hasFullGym {
+		return nil
 	}
 
-	if !hasAnyQualityTerm(context, "barbell", "full gym", "commercial gym", "power rack", "squat rack") {
+	terms := make([]string, 0, 12)
+	if !inventory.hasBarbell {
 		terms = append(terms, "barbell", "smith")
 	}
-	if !hasAnyQualityTerm(context, "dumbbell", "full gym", "commercial gym") {
+	if !inventory.hasDumbbell {
 		terms = append(terms, "dumbbell")
 	}
-	if !hasAnyQualityTerm(context, "kettlebell", "full gym", "commercial gym") {
+	if !inventory.hasKettlebell {
 		terms = append(terms, "kettlebell")
 	}
-	if !hasAnyQualityTerm(context, "cable", "full gym", "commercial gym") {
+	if !inventory.hasCable {
 		terms = append(terms, "cable", "lat pulldown")
 	}
-	if !hasAnyQualityTerm(context, "machine", "full gym", "commercial gym") {
+	if !inventory.hasMachine {
 		terms = append(terms, "machine", "leg press")
 	}
-	if !hasAnyQualityTerm(context, "bench", "full gym", "commercial gym") && hasAnyQualityTerm(context, "home", "hotel", "small space") {
-		terms = append(terms, "bench press", "incline bench")
+	if !inventory.hasBench {
+		terms = append(terms, "bench", "bench-supported")
 	}
 
 	return terms
@@ -231,6 +253,25 @@ func disallowedInjuryTerms(injuries string) []string {
 		terms = append(terms, "dip", "skull crusher", "barbell curl")
 	}
 	return terms
+}
+
+func hasNoActiveInjury(injuries string) bool {
+	return injuries == "" ||
+		injuries == "none" ||
+		hasExactQualityTerm(injuries, "no injuries", "no injury", "no pain", "no issues", "no limitations") ||
+		hasAnyQualityTerm(
+			injuries,
+			"no knee pain",
+			"no knee issues",
+			"no shoulder pain",
+			"no shoulder issues",
+			"no back pain",
+			"no back issues",
+			"no wrist pain",
+			"no wrist issues",
+			"no elbow pain",
+			"no elbow issues",
+		)
 }
 
 func allowsLowerVolume(input WorkoutGenerationToolInput) bool {
@@ -271,6 +312,33 @@ func hasAnyQualityTerm(text string, terms ...string) bool {
 		if strings.Contains(text, normalizeQualityText(term)) {
 			return true
 		}
+	}
+	return false
+}
+
+func hasExactQualityTerm(text string, terms ...string) bool {
+	for _, term := range terms {
+		if text == normalizeQualityText(term) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAvailableEquipmentTerm(text string, terms ...string) bool {
+	for _, term := range terms {
+		normalizedTerm := normalizeQualityText(term)
+		if !strings.Contains(text, normalizedTerm) {
+			continue
+		}
+		if hasAnyQualityTerm(text,
+			"no "+normalizedTerm,
+			"without "+normalizedTerm,
+			"no access to "+normalizedTerm,
+		) {
+			continue
+		}
+		return true
 	}
 	return false
 }

--- a/server/internal/aichat/workout_quality.go
+++ b/server/internal/aichat/workout_quality.go
@@ -1,0 +1,280 @@
+package aichat
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/Andrewy-gh/fittrack/server/internal/workout"
+)
+
+const (
+	minNormalDurationShare = 0.5
+)
+
+type workoutDraftQualityIssue struct {
+	message string
+}
+
+func validateWorkoutDraftQuality(input WorkoutGenerationToolInput, draft *workout.CreateWorkoutRequest) error {
+	if draft == nil {
+		return fmt.Errorf("workout draft is required")
+	}
+
+	issues := make([]workoutDraftQualityIssue, 0, 4)
+	issues = append(issues, validateDraftDurationQuality(input, draft)...)
+	issues = append(issues, validateDraftEquipmentQuality(input, draft)...)
+	issues = append(issues, validateDraftInjuryQuality(input, draft)...)
+
+	if len(issues) == 0 {
+		return nil
+	}
+
+	messages := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		messages = append(messages, issue.message)
+	}
+	return errors.New(strings.Join(messages, "; "))
+}
+
+func validateDraftDurationQuality(input WorkoutGenerationToolInput, draft *workout.CreateWorkoutRequest) []workoutDraftQualityIssue {
+	if input.SessionDuration <= 0 || allowsLowerVolume(input) {
+		return nil
+	}
+	if !isStrengthOrHypertrophy(input) {
+		return nil
+	}
+
+	workingSets := countWorkingSets(draft)
+	estimatedMinutes := estimateWorkoutDurationMinutes(input, draft)
+	minEstimatedMinutes := float64(input.SessionDuration) * minNormalDurationShare
+	minWorkingSets := minimumWorkingSets(input)
+
+	issues := make([]workoutDraftQualityIssue, 0, 2)
+	if workingSets < minWorkingSets {
+		issues = append(issues, workoutDraftQualityIssue{message: fmt.Sprintf("draft has %d working sets; expected at least %d for a normal %d-minute %s request", workingSets, minWorkingSets, input.SessionDuration, strengthHypertrophyLabel(input))})
+	}
+	if estimatedMinutes < minEstimatedMinutes {
+		issues = append(issues, workoutDraftQualityIssue{message: fmt.Sprintf("draft estimates to %.0f minutes; expected at least %.0f minutes for the requested %d-minute session", estimatedMinutes, minEstimatedMinutes, input.SessionDuration)})
+	}
+
+	return issues
+}
+
+func validateDraftEquipmentQuality(input WorkoutGenerationToolInput, draft *workout.CreateWorkoutRequest) []workoutDraftQualityIssue {
+	context := normalizedWorkoutContext(input)
+	if context == "" {
+		return nil
+	}
+
+	disallowed := disallowedEquipmentTerms(context)
+	if len(disallowed) == 0 {
+		return nil
+	}
+
+	issues := make([]workoutDraftQualityIssue, 0)
+	for _, exercise := range draft.Exercises {
+		name := normalizeQualityText(exercise.Name)
+		for _, term := range disallowed {
+			if strings.Contains(name, term) {
+				issues = append(issues, workoutDraftQualityIssue{message: fmt.Sprintf("%q appears to require %s, which is not available in the request", exercise.Name, term)})
+				break
+			}
+		}
+	}
+	return issues
+}
+
+func validateDraftInjuryQuality(input WorkoutGenerationToolInput, draft *workout.CreateWorkoutRequest) []workoutDraftQualityIssue {
+	injuries := normalizeQualityText(input.Injuries)
+	if injuries == "" || injuries == "none" || strings.Contains(injuries, "no injur") {
+		return nil
+	}
+
+	disallowed := disallowedInjuryTerms(injuries)
+	if len(disallowed) == 0 {
+		return nil
+	}
+
+	issues := make([]workoutDraftQualityIssue, 0)
+	for _, exercise := range draft.Exercises {
+		name := normalizeQualityText(exercise.Name)
+		for _, term := range disallowed {
+			if strings.Contains(name, term) {
+				issues = append(issues, workoutDraftQualityIssue{message: fmt.Sprintf("%q conflicts with the reported injury context", exercise.Name)})
+				break
+			}
+		}
+	}
+	return issues
+}
+
+func countWorkingSets(draft *workout.CreateWorkoutRequest) int {
+	count := 0
+	for _, exercise := range draft.Exercises {
+		for _, set := range exercise.Sets {
+			if set.SetType == "working" {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func estimateWorkoutDurationMinutes(input WorkoutGenerationToolInput, draft *workout.CreateWorkoutRequest) float64 {
+	if draft == nil || len(draft.Exercises) == 0 {
+		return 0
+	}
+
+	seconds := 0
+	if input.SessionDuration >= 30 && isStrengthOrHypertrophy(input) {
+		seconds += 5 * 60
+	}
+	seconds += len(draft.Exercises) * 90
+
+	totalSets := 0
+	for _, exercise := range draft.Exercises {
+		for _, set := range exercise.Sets {
+			totalSets++
+			seconds += 45
+			if set.SetType == "warmup" {
+				seconds += warmupRestSeconds(input)
+			} else {
+				seconds += workingRestSeconds(input)
+			}
+		}
+	}
+	if totalSets > 0 {
+		seconds -= workingRestSeconds(input)
+	}
+
+	return float64(seconds) / 60
+}
+
+func minimumWorkingSets(input WorkoutGenerationToolInput) int {
+	estimatedMinutesPerWorkingSet := 6.0
+	if isHypertrophy(input) {
+		estimatedMinutesPerWorkingSet = 5.0
+	}
+	sets := int(math.Ceil(float64(input.SessionDuration) / estimatedMinutesPerWorkingSet))
+	if sets < 2 {
+		return 2
+	}
+	return sets
+}
+
+func warmupRestSeconds(input WorkoutGenerationToolInput) int {
+	if isStrength(input) {
+		return 75
+	}
+	if isHypertrophy(input) {
+		return 45
+	}
+	return 45
+}
+
+func workingRestSeconds(input WorkoutGenerationToolInput) int {
+	switch {
+	case isStrength(input):
+		return 150
+	case isHypertrophy(input):
+		return 75
+	case strings.Contains(normalizedGoalFocus(input), "endurance"):
+		return 45
+	default:
+		return 60
+	}
+}
+
+func disallowedEquipmentTerms(context string) []string {
+	terms := make([]string, 0, 8)
+	bodyweightOnly := hasAnyQualityTerm(context, "bodyweight only", "no equipment", "without equipment")
+	if bodyweightOnly {
+		return []string{"barbell", "dumbbell", "kettlebell", "cable", "machine", "smith", "bench", "leg press", "lat pulldown"}
+	}
+
+	if !hasAnyQualityTerm(context, "barbell", "full gym", "commercial gym", "power rack", "squat rack") {
+		terms = append(terms, "barbell", "smith")
+	}
+	if !hasAnyQualityTerm(context, "dumbbell", "full gym", "commercial gym") {
+		terms = append(terms, "dumbbell")
+	}
+	if !hasAnyQualityTerm(context, "kettlebell", "full gym", "commercial gym") {
+		terms = append(terms, "kettlebell")
+	}
+	if !hasAnyQualityTerm(context, "cable", "full gym", "commercial gym") {
+		terms = append(terms, "cable", "lat pulldown")
+	}
+	if !hasAnyQualityTerm(context, "machine", "full gym", "commercial gym") {
+		terms = append(terms, "machine", "leg press")
+	}
+	if !hasAnyQualityTerm(context, "bench", "full gym", "commercial gym") && hasAnyQualityTerm(context, "home", "hotel", "small space") {
+		terms = append(terms, "bench press", "incline bench")
+	}
+
+	return terms
+}
+
+func disallowedInjuryTerms(injuries string) []string {
+	terms := make([]string, 0, 8)
+	if hasAnyQualityTerm(injuries, "knee", "acl", "meniscus") {
+		terms = append(terms, "squat", "lunge", "leg press", "jump", "step-up", "step up", "running")
+	}
+	if hasAnyQualityTerm(injuries, "shoulder", "rotator cuff") {
+		terms = append(terms, "overhead press", "shoulder press", "upright row", "dip", "snatch")
+	}
+	if hasAnyQualityTerm(injuries, "back", "low back", "lower back", "spine") {
+		terms = append(terms, "deadlift", "good morning", "back squat", "barbell row")
+	}
+	if hasAnyQualityTerm(injuries, "wrist", "elbow") {
+		terms = append(terms, "dip", "skull crusher", "barbell curl")
+	}
+	return terms
+}
+
+func allowsLowerVolume(input WorkoutGenerationToolInput) bool {
+	text := normalizeQualityText(input.FitnessLevel) + " " + normalizedGoalFocus(input) + " " + normalizedWorkoutContext(input)
+	return hasAnyQualityTerm(text, "minimal", "quick", "short", "beginner", "rehab", "prehab", "mobility", "warm-up", "warmup", "low volume", "easy")
+}
+
+func isStrengthOrHypertrophy(input WorkoutGenerationToolInput) bool {
+	return isStrength(input) || isHypertrophy(input)
+}
+
+func isStrength(input WorkoutGenerationToolInput) bool {
+	return strings.Contains(normalizedGoalFocus(input), "strength")
+}
+
+func isHypertrophy(input WorkoutGenerationToolInput) bool {
+	text := normalizedGoalFocus(input)
+	return strings.Contains(text, "hypertrophy") || strings.Contains(text, "muscle") || strings.Contains(text, "size")
+}
+
+func strengthHypertrophyLabel(input WorkoutGenerationToolInput) string {
+	if isHypertrophy(input) {
+		return "hypertrophy"
+	}
+	return "strength"
+}
+
+func normalizedGoalFocus(input WorkoutGenerationToolInput) string {
+	return normalizeQualityText(input.FitnessGoal + " " + input.WorkoutFocus)
+}
+
+func normalizedWorkoutContext(input WorkoutGenerationToolInput) string {
+	return normalizeQualityText(input.Equipment + " " + input.SpaceConstraints)
+}
+
+func hasAnyQualityTerm(text string, terms ...string) bool {
+	for _, term := range terms {
+		if strings.Contains(text, normalizeQualityText(term)) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeQualityText(value string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(value))), " ")
+}

--- a/server/internal/aichat/workout_quality_test.go
+++ b/server/internal/aichat/workout_quality_test.go
@@ -90,6 +90,25 @@ func TestValidateWorkoutDraftQualityRejectsUnavailableEquipment(t *testing.T) {
 	}
 }
 
+func TestValidateWorkoutDraftQualityAllowsGymLocationAsEquipmentContext(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:      "general fitness",
+		SessionDuration:  30,
+		WorkoutFocus:     "full body",
+		SpaceConstraints: "gym",
+		Injuries:         "none",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Barbell Back Squat", workingSet(8), workingSet(8), workingSet(8)),
+		draftExercise("Seated Cable Row", workingSet(10), workingSet(10), workingSet(10)),
+		draftExercise("Leg Press", workingSet(10), workingSet(10), workingSet(10)),
+	)
+
+	if err := validateWorkoutDraftQuality(input, draft); err != nil {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want nil for gym context", err)
+	}
+}
+
 func TestValidateWorkoutDraftQualityRejectsExerciseConflictingWithInjury(t *testing.T) {
 	input := WorkoutGenerationToolInput{
 		FitnessGoal:     "strength",
@@ -107,6 +126,27 @@ func TestValidateWorkoutDraftQualityRejectsExerciseConflictingWithInjury(t *test
 	err := validateWorkoutDraftQuality(input, draft)
 	if err == nil {
 		t.Fatal("validateWorkoutDraftQuality() error = nil, want injury conflict error")
+	}
+	if !strings.Contains(err.Error(), "injury") {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want injury issue", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityRejectsActiveInjuryWhenAnotherBodyPartIsNegated(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "strength",
+		Equipment:       "full gym",
+		SessionDuration: 45,
+		WorkoutFocus:    "upper body",
+		Injuries:        "no knee pain but shoulder pain",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Overhead Press", workingSet(5), workingSet(5), workingSet(5), workingSet(5), workingSet(5), workingSet(5), workingSet(5), workingSet(5)),
+	)
+
+	err := validateWorkoutDraftQuality(input, draft)
+	if err == nil {
+		t.Fatal("validateWorkoutDraftQuality() error = nil, want active shoulder injury conflict")
 	}
 	if !strings.Contains(err.Error(), "injury") {
 		t.Fatalf("validateWorkoutDraftQuality() error = %v, want injury issue", err)

--- a/server/internal/aichat/workout_quality_test.go
+++ b/server/internal/aichat/workout_quality_test.go
@@ -109,6 +109,72 @@ func TestValidateWorkoutDraftQualityAllowsGymLocationAsEquipmentContext(t *testi
 	}
 }
 
+func TestValidateWorkoutDraftQualityRejectsCableExerciseWhenGymContextExcludesCables(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:      "general fitness",
+		Equipment:        "no cables",
+		SessionDuration:  30,
+		WorkoutFocus:     "upper body",
+		SpaceConstraints: "gym",
+		Injuries:         "none",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Seated Cable Row", workingSet(10), workingSet(10), workingSet(10)),
+	)
+
+	err := validateWorkoutDraftQuality(input, draft)
+	if err == nil {
+		t.Fatal("validateWorkoutDraftQuality() error = nil, want unavailable cable error")
+	}
+	if !strings.Contains(err.Error(), "cable") {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want cable issue", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityRejectsMachineExerciseWhenGymContextExcludesMachines(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:      "general fitness",
+		Equipment:        "no machines",
+		SessionDuration:  30,
+		WorkoutFocus:     "legs",
+		SpaceConstraints: "gym",
+		Injuries:         "none",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Leg Press", workingSet(10), workingSet(10), workingSet(10)),
+	)
+
+	err := validateWorkoutDraftQuality(input, draft)
+	if err == nil {
+		t.Fatal("validateWorkoutDraftQuality() error = nil, want unavailable machine error")
+	}
+	if !strings.Contains(err.Error(), "leg press") {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want leg press issue", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityRejectsBenchExerciseWhenGymContextExcludesBench(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:      "general fitness",
+		Equipment:        "dumbbells, no bench",
+		SessionDuration:  30,
+		WorkoutFocus:     "upper body",
+		SpaceConstraints: "gym",
+		Injuries:         "none",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Dumbbell Bench Press", workingSet(10), workingSet(10), workingSet(10)),
+	)
+
+	err := validateWorkoutDraftQuality(input, draft)
+	if err == nil {
+		t.Fatal("validateWorkoutDraftQuality() error = nil, want unavailable bench error")
+	}
+	if !strings.Contains(err.Error(), "bench") {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want bench issue", err)
+	}
+}
+
 func TestValidateWorkoutDraftQualityRejectsExerciseConflictingWithInjury(t *testing.T) {
 	input := WorkoutGenerationToolInput{
 		FitnessGoal:     "strength",

--- a/server/internal/aichat/workout_quality_test.go
+++ b/server/internal/aichat/workout_quality_test.go
@@ -1,0 +1,154 @@
+package aichat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Andrewy-gh/fittrack/server/internal/workout"
+)
+
+func TestValidateWorkoutDraftQualityRejectsUnderScopedHypertrophyDraft(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "hypertrophy",
+		Equipment:       "full gym",
+		SessionDuration: 45,
+		WorkoutFocus:    "pull",
+		Injuries:        "none",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Lat Pulldown", workingSet(10), workingSet(10)),
+		draftExercise("Cable Row", workingSet(12), workingSet(12)),
+	)
+
+	err := validateWorkoutDraftQuality(input, draft)
+	if err == nil {
+		t.Fatal("validateWorkoutDraftQuality() error = nil, want under-scoped draft error")
+	}
+	if !strings.Contains(err.Error(), "working sets") {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want working set issue", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityScalesMinimumWorkToRequestedDuration(t *testing.T) {
+	shortInput := WorkoutGenerationToolInput{
+		FitnessGoal:     "hypertrophy",
+		Equipment:       "dumbbells",
+		SessionDuration: 25,
+		WorkoutFocus:    "upper body",
+		Injuries:        "none",
+	}
+	longInput := shortInput
+	longInput.SessionDuration = 60
+
+	if got := minimumWorkingSets(shortInput); got != 5 {
+		t.Fatalf("minimumWorkingSets(shortInput) = %d, want 5", got)
+	}
+	if got := minimumWorkingSets(longInput); got != 12 {
+		t.Fatalf("minimumWorkingSets(longInput) = %d, want 12", got)
+	}
+}
+
+func TestValidateWorkoutDraftQualityAcceptsReasonableHypertrophyDraft(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "hypertrophy",
+		Equipment:       "full gym",
+		SessionDuration: 45,
+		WorkoutFocus:    "pull",
+		Injuries:        "none",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Pull-Up", warmupSet(6), warmupSet(6), workingSet(8), workingSet(8), workingSet(8)),
+		draftExercise("Chest Supported Row", workingSet(10), workingSet(10), workingSet(10)),
+		draftExercise("Seated Cable Row", workingSet(12), workingSet(12)),
+		draftExercise("Incline Dumbbell Curl", workingSet(12), workingSet(12)),
+	)
+
+	if err := validateWorkoutDraftQuality(input, draft); err != nil {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want nil", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityRejectsUnavailableEquipment(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:      "general fitness",
+		Equipment:        "bodyweight only",
+		SessionDuration:  30,
+		WorkoutFocus:     "full body",
+		SpaceConstraints: "home",
+		Injuries:         "none",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Barbell Back Squat", workingSet(8), workingSet(8), workingSet(8)),
+	)
+
+	err := validateWorkoutDraftQuality(input, draft)
+	if err == nil {
+		t.Fatal("validateWorkoutDraftQuality() error = nil, want unavailable equipment error")
+	}
+	if !strings.Contains(err.Error(), "barbell") {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want barbell issue", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityRejectsExerciseConflictingWithInjury(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "strength",
+		Equipment:       "full gym",
+		SessionDuration: 45,
+		WorkoutFocus:    "legs",
+		Injuries:        "knee pain",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Back Squat", warmupSet(5), workingSet(5), workingSet(5), workingSet(5)),
+		draftExercise("Leg Press", workingSet(8), workingSet(8), workingSet(8)),
+		draftExercise("Hamstring Curl", workingSet(10), workingSet(10)),
+	)
+
+	err := validateWorkoutDraftQuality(input, draft)
+	if err == nil {
+		t.Fatal("validateWorkoutDraftQuality() error = nil, want injury conflict error")
+	}
+	if !strings.Contains(err.Error(), "injury") {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want injury issue", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityAllowsExplicitBeginnerLowerVolume(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessLevel:    "beginner",
+		FitnessGoal:     "strength",
+		Equipment:       "dumbbells",
+		SessionDuration: 45,
+		WorkoutFocus:    "beginner upper body",
+		Injuries:        "none",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Dumbbell Bench Press", workingSet(8), workingSet(8)),
+		draftExercise("One-Arm Dumbbell Row", workingSet(10), workingSet(10)),
+	)
+
+	if err := validateWorkoutDraftQuality(input, draft); err != nil {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want nil for explicit beginner request", err)
+	}
+}
+
+func validDraftWithExercises(exercises ...workout.ExerciseInput) *workout.CreateWorkoutRequest {
+	focus := "test"
+	return &workout.CreateWorkoutRequest{
+		Date:         "2026-04-20T12:00:00Z",
+		WorkoutFocus: &focus,
+		Exercises:    exercises,
+	}
+}
+
+func draftExercise(name string, sets ...workout.SetInput) workout.ExerciseInput {
+	return workout.ExerciseInput{Name: name, Sets: sets}
+}
+
+func warmupSet(reps int) workout.SetInput {
+	return workout.SetInput{Reps: reps, SetType: "warmup"}
+}
+
+func workingSet(reps int) workout.SetInput {
+	return workout.SetInput{Reps: reps, SetType: "working"}
+}

--- a/server/internal/aichat/workout_quality_test.go
+++ b/server/internal/aichat/workout_quality_test.go
@@ -117,7 +117,7 @@ func TestValidateWorkoutDraftQualityAllowsExplicitBeginnerLowerVolume(t *testing
 	input := WorkoutGenerationToolInput{
 		FitnessLevel:    "beginner",
 		FitnessGoal:     "strength",
-		Equipment:       "dumbbells",
+		Equipment:       "dumbbells, bench",
 		SessionDuration: 45,
 		WorkoutFocus:    "beginner upper body",
 		Injuries:        "none",
@@ -129,6 +129,120 @@ func TestValidateWorkoutDraftQualityAllowsExplicitBeginnerLowerVolume(t *testing
 
 	if err := validateWorkoutDraftQuality(input, draft); err != nil {
 		t.Fatalf("validateWorkoutDraftQuality() error = %v, want nil for explicit beginner request", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityRejectsBenchExerciseForBodyweightRequest(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "general fitness",
+		Equipment:       "bodyweight",
+		SessionDuration: 30,
+		WorkoutFocus:    "upper body",
+		Injuries:        "none",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Bench Dip", workingSet(10), workingSet(10), workingSet(10)),
+	)
+
+	err := validateWorkoutDraftQuality(input, draft)
+	if err == nil {
+		t.Fatal("validateWorkoutDraftQuality() error = nil, want unavailable bench error")
+	}
+	if !strings.Contains(err.Error(), "bench") {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want bench issue", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityAllowsBenchExerciseWhenBenchIsAvailable(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "general fitness",
+		Equipment:       "bodyweight, bench",
+		SessionDuration: 30,
+		WorkoutFocus:    "upper body",
+		Injuries:        "none",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Bench Dip", workingSet(10), workingSet(10), workingSet(10)),
+	)
+
+	if err := validateWorkoutDraftQuality(input, draft); err != nil {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want nil when bench is available", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityRejectsDumbbellBenchPressWithoutBench(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "general fitness",
+		Equipment:       "dumbbells, no bench",
+		SessionDuration: 30,
+		WorkoutFocus:    "upper body",
+		Injuries:        "none",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Dumbbell Bench Press", workingSet(10), workingSet(10), workingSet(10)),
+	)
+
+	err := validateWorkoutDraftQuality(input, draft)
+	if err == nil {
+		t.Fatal("validateWorkoutDraftQuality() error = nil, want unavailable bench error")
+	}
+	if !strings.Contains(err.Error(), "bench") {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want bench issue", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityAllowsDumbbellBenchPressWithDumbbellsAndBench(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "general fitness",
+		Equipment:       "bodyweight, bench, dumbbells",
+		SessionDuration: 30,
+		WorkoutFocus:    "upper body",
+		Injuries:        "none",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Dumbbell Bench Press", workingSet(10), workingSet(10), workingSet(10)),
+	)
+
+	if err := validateWorkoutDraftQuality(input, draft); err != nil {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want nil when dumbbells and bench are available", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityTreatsNoKneePainAsNoActiveInjury(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "strength",
+		Equipment:       "full gym",
+		SessionDuration: 45,
+		WorkoutFocus:    "legs",
+		Injuries:        "no knee pain",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Back Squat", workingSet(5), workingSet(5), workingSet(5), workingSet(5), workingSet(5), workingSet(5), workingSet(5), workingSet(5)),
+	)
+
+	if err := validateWorkoutDraftQuality(input, draft); err != nil {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want nil for negated knee pain", err)
+	}
+}
+
+func TestValidateWorkoutDraftQualityTreatsHistoryOfKneePainAsActiveConstraint(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "strength",
+		Equipment:       "full gym",
+		SessionDuration: 45,
+		WorkoutFocus:    "legs",
+		Injuries:        "history of knee pain",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Back Squat", workingSet(5), workingSet(5), workingSet(5), workingSet(5), workingSet(5), workingSet(5), workingSet(5), workingSet(5)),
+	)
+
+	err := validateWorkoutDraftQuality(input, draft)
+	if err == nil {
+		t.Fatal("validateWorkoutDraftQuality() error = nil, want knee history constraint")
+	}
+	if !strings.Contains(err.Error(), "injury") {
+		t.Fatalf("validateWorkoutDraftQuality() error = %v, want injury issue", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- adds a deterministic post-generation workout draft quality gate
- checks duration realism, unavailable equipment, and obvious injury conflicts before a draft becomes durable
- adds regression coverage for under-scoped drafts, equipment mismatch, injury mismatch, and beginner low-volume allowance

## Verification
- cd server && go test ./internal/aichat/...
- pre-push hook: make test-short / go test -short ./...