### PR TITLE
Retry low-quality workout draft generation

### DIFF
--- a/server/internal/aichat/workout_generation.go
+++ b/server/internal/aichat/workout_generation.go
@@ -22,6 +22,14 @@ const (
 
 var workoutDraftValidator = validator.New()
 
+type workoutDraftGenerator func(
+	ctx context.Context,
+	g *genkit.Genkit,
+	modelName string,
+	systemPrompt string,
+	userPrompt string,
+) (*workout.CreateWorkoutRequest, error)
+
 type WorkoutGenerationToolInput struct {
 	FitnessLevel     string `json:"fitnessLevel,omitempty" jsonschema:"description=Optional training experience level. Use beginner, intermediate, or advanced when known."`
 	FitnessGoal      string `json:"fitnessGoal,omitempty" jsonschema:"description=Optional primary training goal such as strength, hypertrophy, endurance, power, or general fitness when known."`
@@ -83,24 +91,62 @@ func generateWorkoutDraft(
 	input WorkoutGenerationToolInput,
 	now time.Time,
 ) (*workout.CreateWorkoutRequest, error) {
+	return generateWorkoutDraftWith(ctx, g, modelName, input, now, generateWorkoutDraftData)
+}
+
+func generateWorkoutDraftData(
+	ctx context.Context,
+	g *genkit.Genkit,
+	modelName string,
+	systemPrompt string,
+	userPrompt string,
+) (*workout.CreateWorkoutRequest, error) {
 	output, _, err := genkit.GenerateData[workout.CreateWorkoutRequest](ctx, g,
 		ai.WithModelName(modelName),
-		ai.WithSystem(buildWorkoutGenerationPrompt(input, now)),
-		ai.WithPrompt(buildWorkoutGenerationUserPrompt(input)),
+		ai.WithSystem(systemPrompt),
+		ai.WithPrompt(userPrompt),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("generate workout draft: %w", err)
-	}
-
-	normalizeWorkoutDraft(output)
-	if err := validateWorkoutDraft(output); err != nil {
-		return nil, fmt.Errorf("validate workout draft: %w", err)
-	}
-	if err := validateWorkoutDraftQuality(input, output); err != nil {
-		return nil, fmt.Errorf("validate workout draft quality: %w", err)
+		return nil, err
 	}
 
 	return output, nil
+}
+
+func generateWorkoutDraftWith(
+	ctx context.Context,
+	g *genkit.Genkit,
+	modelName string,
+	input WorkoutGenerationToolInput,
+	now time.Time,
+	generator workoutDraftGenerator,
+) (*workout.CreateWorkoutRequest, error) {
+	systemPrompt := buildWorkoutGenerationPrompt(input, now)
+	userPrompt := buildWorkoutGenerationUserPrompt(input)
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		output, err := generator(ctx, g, modelName, systemPrompt, userPrompt)
+		if err != nil {
+			return nil, fmt.Errorf("generate workout draft: %w", err)
+		}
+
+		normalizeWorkoutDraft(output)
+		if err := validateWorkoutDraft(output); err != nil {
+			return nil, fmt.Errorf("validate workout draft: %w", err)
+		}
+
+		qualityErr := validateWorkoutDraftQuality(input, output)
+		if qualityErr == nil {
+			return output, nil
+		}
+		if attempt == 2 {
+			return nil, fmt.Errorf("validate workout draft quality after repair retry: %w", qualityErr)
+		}
+
+		userPrompt = buildWorkoutGenerationRepairPrompt(input, qualityErr)
+	}
+
+	return nil, fmt.Errorf("generate workout draft: exhausted quality repair attempts")
 }
 
 func buildWorkoutGenerationPrompt(input WorkoutGenerationToolInput, now time.Time) string {
@@ -164,6 +210,24 @@ func buildWorkoutGenerationUserPrompt(input WorkoutGenerationToolInput) string {
 	if requestedDate := strings.TrimSpace(input.WorkoutDate); requestedDate != "" {
 		builder.WriteString(fmt.Sprintf("- Requested workout date: %s\n", requestedDate))
 	}
+
+	return builder.String()
+}
+
+func buildWorkoutGenerationRepairPrompt(input WorkoutGenerationToolInput, qualityErr error) string {
+	var builder strings.Builder
+
+	builder.WriteString("Regenerate the FitTrack workout draft for the same user.\n")
+	builder.WriteString("The previous draft failed deterministic quality validation. Fix these issues:\n")
+	for _, issue := range strings.Split(qualityErr.Error(), "; ") {
+		issue = strings.TrimSpace(issue)
+		if issue == "" {
+			continue
+		}
+		builder.WriteString(fmt.Sprintf("- %s\n", issue))
+	}
+	builder.WriteString("\nReturn a complete replacement draft that still follows the original request:\n")
+	builder.WriteString(buildWorkoutGenerationUserPrompt(input))
 
 	return builder.String()
 }

--- a/server/internal/aichat/workout_generation_test.go
+++ b/server/internal/aichat/workout_generation_test.go
@@ -1,6 +1,8 @@
 package aichat
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -8,6 +10,7 @@ import (
 
 	"github.com/Andrewy-gh/fittrack/server/internal/workout"
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
 )
 
 func TestBuildChatSystemPromptIncludesWorkoutGuardrails(t *testing.T) {
@@ -195,6 +198,214 @@ func TestBuildWorkoutGenerationPromptUsesUserLocalLanguageForRelativeDates(t *te
 	}
 	if strings.Contains(prompt, `relative to`) {
 		t.Fatalf("buildWorkoutGenerationPrompt() = %q, should not anchor relative dates to a server timestamp", prompt)
+	}
+}
+
+func TestGenerateWorkoutDraftWithRepairsQualityFailureOnce(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "hypertrophy",
+		Equipment:       "full gym",
+		SessionDuration: 45,
+		WorkoutFocus:    "pull",
+		Injuries:        "none",
+	}
+	firstDraft := validDraftWithExercises(
+		draftExercise("Lat Pulldown", workingSet(10), workingSet(10)),
+	)
+	repairedDraft := validDraftWithExercises(
+		draftExercise("Pull-Up", warmupSet(6), warmupSet(6), workingSet(8), workingSet(8), workingSet(8)),
+		draftExercise("Chest Supported Row", workingSet(10), workingSet(10), workingSet(10)),
+		draftExercise("Seated Cable Row", workingSet(12), workingSet(12)),
+		draftExercise("Incline Dumbbell Curl", workingSet(12), workingSet(12)),
+	)
+	prompts := make([]string, 0, 2)
+	drafts := []*workout.CreateWorkoutRequest{firstDraft, repairedDraft}
+	generator := func(_ context.Context, _ *genkit.Genkit, _ string, _ string, userPrompt string) (*workout.CreateWorkoutRequest, error) {
+		prompts = append(prompts, userPrompt)
+		return drafts[len(prompts)-1], nil
+	}
+
+	draft, err := generateWorkoutDraftWith(
+		context.Background(),
+		nil,
+		"test-model",
+		input,
+		time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+		generator,
+	)
+	if err != nil {
+		t.Fatalf("generateWorkoutDraftWith() error = %v, want nil", err)
+	}
+	if draft != repairedDraft {
+		t.Fatalf("generateWorkoutDraftWith() draft = %#v, want repaired draft", draft)
+	}
+	if len(prompts) != 2 {
+		t.Fatalf("generator called %d times, want 2", len(prompts))
+	}
+	if !strings.Contains(prompts[1], "failed deterministic quality validation") {
+		t.Fatalf("repair prompt = %q, want quality validation context", prompts[1])
+	}
+	if !strings.Contains(prompts[1], "expected at least") {
+		t.Fatalf("repair prompt = %q, want deterministic validator feedback", prompts[1])
+	}
+	if !strings.Contains(prompts[1], "- Session duration: 45 minutes") || !strings.Contains(prompts[1], "- Workout focus: pull") {
+		t.Fatalf("repair prompt = %q, want original request context", prompts[1])
+	}
+}
+
+func TestGenerateWorkoutDraftWithDoesNotRetryGenerationErrors(t *testing.T) {
+	expectedErr := errors.New("model unavailable")
+	calls := 0
+	generator := func(_ context.Context, _ *genkit.Genkit, _ string, _ string, _ string) (*workout.CreateWorkoutRequest, error) {
+		calls++
+		return nil, expectedErr
+	}
+
+	draft, err := generateWorkoutDraftWith(
+		context.Background(),
+		nil,
+		"test-model",
+		WorkoutGenerationToolInput{Equipment: "full gym", SessionDuration: 45, WorkoutFocus: "pull", Injuries: "none"},
+		time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+		generator,
+	)
+	if err == nil {
+		t.Fatalf("generateWorkoutDraftWith() draft = %#v, error = nil, want generation error", draft)
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("generateWorkoutDraftWith() error = %v, want %v", err, expectedErr)
+	}
+	if calls != 1 {
+		t.Fatalf("generator called %d times, want 1", calls)
+	}
+}
+
+func TestGenerateWorkoutDraftWithDoesNotRetrySchemaValidationErrors(t *testing.T) {
+	calls := 0
+	generator := func(_ context.Context, _ *genkit.Genkit, _ string, _ string, _ string) (*workout.CreateWorkoutRequest, error) {
+		calls++
+		return &workout.CreateWorkoutRequest{
+			Date: "2026-04-20T12:00:00Z",
+		}, nil
+	}
+
+	draft, err := generateWorkoutDraftWith(
+		context.Background(),
+		nil,
+		"test-model",
+		WorkoutGenerationToolInput{Equipment: "full gym", SessionDuration: 45, WorkoutFocus: "pull", Injuries: "none"},
+		time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+		generator,
+	)
+	if err == nil {
+		t.Fatalf("generateWorkoutDraftWith() draft = %#v, error = nil, want validation error", draft)
+	}
+	if !strings.Contains(err.Error(), "validate workout draft") {
+		t.Fatalf("generateWorkoutDraftWith() error = %v, want schema validation context", err)
+	}
+	if calls != 1 {
+		t.Fatalf("generator called %d times, want 1", calls)
+	}
+}
+
+func TestGenerateWorkoutDraftWithStopsAfterOneQualityRepairRetry(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "hypertrophy",
+		Equipment:       "full gym",
+		SessionDuration: 45,
+		WorkoutFocus:    "pull",
+		Injuries:        "none",
+	}
+	calls := 0
+	generator := func(_ context.Context, _ *genkit.Genkit, _ string, _ string, _ string) (*workout.CreateWorkoutRequest, error) {
+		calls++
+		return validDraftWithExercises(
+			draftExercise("Lat Pulldown", workingSet(10), workingSet(10)),
+		), nil
+	}
+
+	draft, err := generateWorkoutDraftWith(
+		context.Background(),
+		nil,
+		"test-model",
+		input,
+		time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+		generator,
+	)
+	if err == nil {
+		t.Fatalf("generateWorkoutDraftWith() draft = %#v, error = nil, want quality retry error", draft)
+	}
+	if !strings.Contains(err.Error(), "after repair retry") {
+		t.Fatalf("generateWorkoutDraftWith() error = %v, want repair retry context", err)
+	}
+	if calls != 2 {
+		t.Fatalf("generator called %d times, want 2", calls)
+	}
+}
+
+func TestGenerateWorkoutDraftWithValidDraftPassesDirectly(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "hypertrophy",
+		Equipment:       "full gym",
+		SessionDuration: 45,
+		WorkoutFocus:    "pull",
+		Injuries:        "none",
+	}
+	expectedDraft := validDraftWithExercises(
+		draftExercise("Pull-Up", warmupSet(6), warmupSet(6), workingSet(8), workingSet(8), workingSet(8)),
+		draftExercise("Chest Supported Row", workingSet(10), workingSet(10), workingSet(10)),
+		draftExercise("Seated Cable Row", workingSet(12), workingSet(12)),
+		draftExercise("Incline Dumbbell Curl", workingSet(12), workingSet(12)),
+	)
+	calls := 0
+	generator := func(_ context.Context, _ *genkit.Genkit, _ string, _ string, _ string) (*workout.CreateWorkoutRequest, error) {
+		calls++
+		return expectedDraft, nil
+	}
+
+	draft, err := generateWorkoutDraftWith(
+		context.Background(),
+		nil,
+		"test-model",
+		input,
+		time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+		generator,
+	)
+	if err != nil {
+		t.Fatalf("generateWorkoutDraftWith() error = %v, want nil", err)
+	}
+	if draft != expectedDraft {
+		t.Fatalf("generateWorkoutDraftWith() draft = %#v, want expected draft", draft)
+	}
+	if calls != 1 {
+		t.Fatalf("generator called %d times, want 1", calls)
+	}
+}
+
+func TestBuildWorkoutGenerationRepairPromptUsesDeterministicFeedback(t *testing.T) {
+	input := WorkoutGenerationToolInput{
+		FitnessGoal:     "hypertrophy",
+		Equipment:       "bodyweight only",
+		SessionDuration: 45,
+		WorkoutFocus:    "upper body",
+		Injuries:        "shoulder pain",
+	}
+	draft := validDraftWithExercises(
+		draftExercise("Barbell Overhead Press", workingSet(10), workingSet(10)),
+	)
+	qualityErr := validateWorkoutDraftQuality(input, draft)
+	if qualityErr == nil {
+		t.Fatal("validateWorkoutDraftQuality() error = nil, want quality issue")
+	}
+
+	prompt := buildWorkoutGenerationRepairPrompt(input, qualityErr)
+	for _, issue := range strings.Split(qualityErr.Error(), "; ") {
+		if !strings.Contains(prompt, issue) {
+			t.Fatalf("repair prompt = %q, want deterministic issue %q", prompt, issue)
+		}
+	}
+	if !strings.Contains(prompt, "- Equipment: bodyweight only") || !strings.Contains(prompt, "- Injuries or limitations: shoulder pain") {
+		t.Fatalf("repair prompt = %q, want original constraints", prompt)
 	}
 }
 


### PR DESCRIPTION
## Summary
- retry workout draft generation once when deterministic quality validation fails
- feed the repair attempt concise validator feedback and original request context
- keep generation/runtime and schema validation errors as single-attempt failures

## Verification
- cd server && go test ./internal/aichat/...