### PR TITLE
feat: add AI chat scenario evals

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -81,6 +81,30 @@ Optional env var: `GEMINI_MODEL` (defaults to `googleai/gemini-2.5-flash`)
 
 The command respects existing shell env first, then loads `server/.env` and `server/setenv.sh` if present. It sends one real Genkit request to Gemini, times out after 20 seconds, and prints a short model response to stdout.
 
+### AI Chat Scenario Sweep
+
+From `server/`, run real-provider AI chat scenario evals with:
+
+```bash
+go run ./cmd/ai-chat-scenario-sweep -mode single_turn
+go run ./cmd/ai-chat-scenario-sweep -mode two_turn
+```
+
+Expected env var: `GEMINI_API_KEY` or `GOOGLE_API_KEY`
+
+Optional env vars:
+
+- `GEMINI_MODEL` to override the default model
+- `FITTRACK_AI_CHAT_SWEEP_OUT` to override the JSON report path
+
+Optional flags:
+
+- `-mode single_turn` runs one assistant turn for each default scenario
+- `-mode two_turn` answers configured follow-up questions after the assistant asks one
+- `-timeout 15m` limits the full sweep wall-clock runtime; lower it for quick checks or raise it for slower provider runs
+
+The command writes a JSON report to `FITTRACK_AI_CHAT_SWEEP_OUT` when set, otherwise to `~/.codex/diagrams/fittrack-ai-chat-scenario-sweep.json`. The summary includes structured draft count, follow-up count, text-only count, error count, and conversion rates so model or prompt changes can be compared across runs.
+
 ### AI Chat Runtime
 
 The live API chat runtime uses the same model default as the smoke test:

--- a/server/cmd/ai-chat-scenario-sweep/main.go
+++ b/server/cmd/ai-chat-scenario-sweep/main.go
@@ -20,7 +20,7 @@ import (
 const (
 	defaultOutputDirName = ".codex/diagrams"
 	defaultOutputName    = "fittrack-ai-chat-scenario-sweep.json"
-	runTimeout           = 90 * time.Second
+	defaultRunTimeout    = 15 * time.Minute
 )
 
 type stubFeatureAccessReader struct{}
@@ -31,9 +31,13 @@ func (stubFeatureAccessReader) ListCurrentUserAccess(context.Context) ([]feature
 
 func main() {
 	mode := flag.String("mode", aichateval.ModeSingleTurn, "eval mode: single_turn or two_turn")
+	timeout := flag.Duration("timeout", defaultRunTimeout, "maximum wall-clock runtime for the full scenario sweep")
 	flag.Parse()
 	if err := aichateval.ValidateMode(*mode); err != nil {
 		fail("%v", err)
+	}
+	if *timeout <= 0 {
+		fail("timeout must be greater than zero")
 	}
 	if err := loadLocalEnv(); err != nil {
 		fail("failed to load local env files: %v", err)
@@ -44,7 +48,7 @@ func main() {
 		fail("failed to create output directory: %v", err)
 	}
 
-	runtimeCtx, cancel := context.WithTimeout(context.Background(), runTimeout)
+	runtimeCtx, cancel := context.WithTimeout(context.Background(), *timeout)
 	defer cancel()
 
 	runtime := aichat.NewGenkitRuntime(runtimeCtx, stubFeatureAccessReader{})
@@ -52,7 +56,7 @@ func main() {
 		fail("ai chat runtime unavailable. Set GEMINI_API_KEY or GOOGLE_API_KEY in your shell, server/.env, or server/setenv.sh")
 	}
 
-	report := aichateval.Run(context.Background(), runtime, aichateval.DefaultScenarios(), aichateval.RunOptions{
+	report := aichateval.Run(runtimeCtx, runtime, aichateval.DefaultScenarios(), aichateval.RunOptions{
 		Mode: *mode,
 		OnScenario: func(item aichateval.Scenario) {
 			fmt.Fprintf(os.Stderr, "Running %s: %s\n", item.ID, item.Title)

--- a/server/cmd/ai-chat-scenario-sweep/main.go
+++ b/server/cmd/ai-chat-scenario-sweep/main.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/joho/godotenv"
+
+	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
+	"github.com/Andrewy-gh/fittrack/server/internal/featureaccess"
+	"github.com/Andrewy-gh/fittrack/server/internal/workout"
+)
+
+const (
+	defaultOutputDirName = ".codex/diagrams"
+	defaultOutputName    = "fittrack-ai-chat-scenario-sweep.json"
+	runTimeout           = 90 * time.Second
+	maxAttempts          = 3
+)
+
+type scenario struct {
+	ID          string                      `json:"id"`
+	Title       string                      `json:"title"`
+	Prompt      string                      `json:"prompt"`
+	Expectation string                      `json:"expectation"`
+	History     []aichat.RuntimeChatMessage `json:"history,omitempty"`
+}
+
+type scenarioResult struct {
+	ID           string                        `json:"id"`
+	Title        string                        `json:"title"`
+	Prompt       string                        `json:"prompt"`
+	Expectation  string                        `json:"expectation"`
+	History      []historyMessage              `json:"history,omitempty"`
+	Status       string                        `json:"status"`
+	Text         string                        `json:"text,omitempty"`
+	Error        string                        `json:"error,omitempty"`
+	Model        string                        `json:"model,omitempty"`
+	DurationMS   int64                         `json:"duration_ms"`
+	Draft        *workout.CreateWorkoutRequest `json:"draft,omitempty"`
+	DraftSummary *draftSummary                 `json:"draft_summary,omitempty"`
+	Attempts     int                           `json:"attempts"`
+}
+
+type historyMessage struct {
+	Role string `json:"role"`
+	Text string `json:"text"`
+}
+
+type draftSummary struct {
+	ExerciseCount int      `json:"exercise_count"`
+	TotalSets     int      `json:"total_sets"`
+	WorkingSets   int      `json:"working_sets"`
+	ExerciseNames []string `json:"exercise_names"`
+}
+
+type report struct {
+	GeneratedAt   string           `json:"generated_at"`
+	Model         string           `json:"model"`
+	ScenarioCount int              `json:"scenario_count"`
+	Results       []scenarioResult `json:"results"`
+}
+
+type stubFeatureAccessReader struct{}
+
+var retryDelayPattern = regexp.MustCompile(`Please retry in ([0-9.]+)s`)
+
+func (stubFeatureAccessReader) ListCurrentUserAccess(context.Context) ([]featureaccess.FeatureAccessGrant, error) {
+	return nil, nil
+}
+
+func main() {
+	if err := loadLocalEnv(); err != nil {
+		fail("failed to load local env files: %v", err)
+	}
+
+	outPath := resolveOutputPath()
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		fail("failed to create output directory: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), runTimeout)
+	defer cancel()
+
+	runtime := aichat.NewGenkitRuntime(ctx, stubFeatureAccessReader{})
+	if !runtime.Available() {
+		fail("ai chat runtime unavailable. Set GEMINI_API_KEY or GOOGLE_API_KEY in your shell, server/.env, or server/setenv.sh")
+	}
+
+	scenarios := scenarioSet()
+	results := make([]scenarioResult, 0, len(scenarios))
+	for _, item := range scenarios {
+		fmt.Fprintf(os.Stderr, "Running %s: %s\n", item.ID, item.Title)
+		results = append(results, runScenario(runtime, item))
+	}
+
+	payload := report{
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Model:         runtime.ModelName(),
+		ScenarioCount: len(results),
+		Results:       results,
+	}
+
+	body, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		fail("failed to marshal report: %v", err)
+	}
+	if err := os.WriteFile(outPath, body, 0o644); err != nil {
+		fail("failed to write report: %v", err)
+	}
+
+	fmt.Printf("Wrote scenario report to %s\n", outPath)
+}
+
+func runScenario(runtime *aichat.GenkitRuntime, item scenario) scenarioResult {
+	started := time.Now()
+	result := scenarioResult{
+		ID:          item.ID,
+		Title:       item.Title,
+		Prompt:      item.Prompt,
+		Expectation: item.Expectation,
+		History:     convertHistory(item.History),
+	}
+
+	var (
+		done *aichat.StreamDone
+		err  error
+	)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		result.Attempts = attempt
+		done, err = runtime.StreamChat(context.Background(), item.Prompt, item.History, func(string) error {
+			return nil
+		})
+		if err == nil {
+			break
+		}
+
+		retryDelay, ok := parseRetryDelay(err)
+		if !ok || attempt == maxAttempts {
+			break
+		}
+
+		waitFor := time.Duration(math.Ceil(retryDelay.Seconds()+1)) * time.Second
+		fmt.Fprintf(os.Stderr, "Rate limited on %s, waiting %s before retry %d/%d\n", item.ID, waitFor, attempt+1, maxAttempts)
+		time.Sleep(waitFor)
+	}
+
+	result.DurationMS = time.Since(started).Milliseconds()
+	if err != nil {
+		result.Status = "error"
+		result.Error = err.Error()
+		return result
+	}
+
+	result.Text = strings.TrimSpace(done.Text)
+	result.Model = done.Model
+	result.Draft = done.WorkoutDraft
+	result.DraftSummary = summarizeDraft(done.WorkoutDraft)
+	switch {
+	case done.WorkoutDraft != nil:
+		result.Status = "structured_draft"
+	case strings.Contains(result.Text, "?"):
+		result.Status = "follow_up_question"
+	default:
+		result.Status = "text_only"
+	}
+
+	return result
+}
+
+func parseRetryDelay(err error) (time.Duration, bool) {
+	matches := retryDelayPattern.FindStringSubmatch(err.Error())
+	if len(matches) != 2 {
+		return 0, false
+	}
+
+	delay, parseErr := time.ParseDuration(matches[1] + "s")
+	if parseErr != nil {
+		return 0, false
+	}
+	return delay, true
+}
+
+func summarizeDraft(draft *workout.CreateWorkoutRequest) *draftSummary {
+	if draft == nil {
+		return nil
+	}
+
+	summary := &draftSummary{
+		ExerciseCount: len(draft.Exercises),
+		ExerciseNames: make([]string, 0, len(draft.Exercises)),
+	}
+	for _, exercise := range draft.Exercises {
+		summary.ExerciseNames = append(summary.ExerciseNames, exercise.Name)
+		for _, set := range exercise.Sets {
+			summary.TotalSets++
+			if set.SetType == "working" {
+				summary.WorkingSets++
+			}
+		}
+	}
+	return summary
+}
+
+func convertHistory(history []aichat.RuntimeChatMessage) []historyMessage {
+	if len(history) == 0 {
+		return nil
+	}
+
+	items := make([]historyMessage, 0, len(history))
+	for _, message := range history {
+		items = append(items, historyMessage{
+			Role: message.Role,
+			Text: message.Text,
+		})
+	}
+	return items
+}
+
+func scenarioSet() []scenario {
+	return []scenario{
+		{
+			ID:          "prompt-01",
+			Title:       "Home Dumbbell Pull",
+			Prompt:      "I've got 45 minutes at home with just adjustable dumbbells and a bench. Give me a pull workout.",
+			Expectation: "Should ideally generate a structured draft with realistic dumbbell-and-bench pull volume.",
+		},
+		{
+			ID:          "prompt-02",
+			Title:       "Commercial Gym Hypertrophy Legs",
+			Prompt:      "I want a 60-minute hypertrophy leg workout at a commercial gym.",
+			Expectation: "Should ask about injuries first or generate only if it can proceed after asking once; when it generates the draft should feel full enough for 60 minutes.",
+		},
+		{
+			ID:          "prompt-03",
+			Title:       "Lower Body With Knee Pain",
+			Prompt:      "I have knee pain. Build me a lower-body workout.",
+			Expectation: "Should gather missing readiness info first and avoid obvious knee-aggravating exercise choices if it generates.",
+		},
+		{
+			ID:          "prompt-04",
+			Title:       "Hotel Room No Equipment",
+			Prompt:      "Hotel room, 25 minutes, no equipment, full body.",
+			Expectation: "Should ask about injuries first or generate a concise feasible hotel-room bodyweight draft.",
+		},
+		{
+			ID:          "prompt-05",
+			Title:       "Beginner Upper Body Full Gym",
+			Prompt:      "Beginner, 40 minutes, upper body, full gym, no injuries.",
+			Expectation: "Should generate a structured beginner-appropriate draft without needing more info.",
+		},
+		{
+			ID:          "prompt-06",
+			Title:       "Shoulder Issue Push Workout",
+			Prompt:      "I tore up my shoulder recently, but I still want a push workout with dumbbells.",
+			Expectation: "Should gather missing readiness info first and avoid obvious shoulder-conflict push exercises if it generates.",
+		},
+		{
+			ID:          "prompt-07",
+			Title:       "Bodyweight Strength Full Body",
+			Prompt:      "Bodyweight only, 30 minutes, strength-focused full body.",
+			Expectation: "Should ask about injuries first or generate a realistic bodyweight strength-leaning draft.",
+		},
+		{
+			ID:          "prompt-08",
+			Title:       "Barbell-Only Pull Day",
+			Prompt:      "No machines, no cables, just barbells and plates, 50 minutes, pull day.",
+			Expectation: "Should avoid cable and machine work if it generates.",
+		},
+		{
+			ID:          "prompt-09",
+			Title:       "Mobility Rehab Back",
+			Prompt:      "I only want 15 minutes of mobility and rehab work for my back.",
+			Expectation: "Should allow intentionally low-volume work instead of forcing a normal lifting session.",
+		},
+		{
+			ID:    "prompt-10",
+			Title: "Elbow-Sensitive Revision Follow-Up",
+			History: []aichat.RuntimeChatMessage{
+				{Role: "user", Text: "Build me a 45 minute push workout with dumbbells and a bench. No injuries."},
+				{Role: "assistant", Text: "I put together a structured workout draft for you."},
+			},
+			Prompt:      "Swap out anything that bothers my elbow.",
+			Expectation: "Should ask a focused revision follow-up or adapt the next draft around the new elbow constraint.",
+		},
+	}
+}
+
+func loadLocalEnv() error {
+	files := existingEnvFiles(".env", "setenv.sh")
+	if len(files) == 0 {
+		return nil
+	}
+	if err := godotenv.Load(files...); err != nil {
+		return fmt.Errorf("load %v: %w", files, err)
+	}
+	return nil
+}
+
+func existingEnvFiles(paths ...string) []string {
+	files := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			files = append(files, path)
+		}
+	}
+	return files
+}
+
+func resolveOutputPath() string {
+	if explicit := strings.TrimSpace(os.Getenv("FITTRACK_AI_CHAT_SWEEP_OUT")); explicit != "" {
+		return explicit
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return defaultOutputName
+	}
+	return filepath.Join(home, defaultOutputDirName, defaultOutputName)
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/server/cmd/ai-chat-scenario-sweep/main.go
+++ b/server/cmd/ai-chat-scenario-sweep/main.go
@@ -3,80 +3,38 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/joho/godotenv"
 
 	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
+	"github.com/Andrewy-gh/fittrack/server/internal/aichateval"
 	"github.com/Andrewy-gh/fittrack/server/internal/featureaccess"
-	"github.com/Andrewy-gh/fittrack/server/internal/workout"
 )
 
 const (
 	defaultOutputDirName = ".codex/diagrams"
 	defaultOutputName    = "fittrack-ai-chat-scenario-sweep.json"
 	runTimeout           = 90 * time.Second
-	maxAttempts          = 3
 )
 
-type scenario struct {
-	ID          string                      `json:"id"`
-	Title       string                      `json:"title"`
-	Prompt      string                      `json:"prompt"`
-	Expectation string                      `json:"expectation"`
-	History     []aichat.RuntimeChatMessage `json:"history,omitempty"`
-}
-
-type scenarioResult struct {
-	ID           string                        `json:"id"`
-	Title        string                        `json:"title"`
-	Prompt       string                        `json:"prompt"`
-	Expectation  string                        `json:"expectation"`
-	History      []historyMessage              `json:"history,omitempty"`
-	Status       string                        `json:"status"`
-	Text         string                        `json:"text,omitempty"`
-	Error        string                        `json:"error,omitempty"`
-	Model        string                        `json:"model,omitempty"`
-	DurationMS   int64                         `json:"duration_ms"`
-	Draft        *workout.CreateWorkoutRequest `json:"draft,omitempty"`
-	DraftSummary *draftSummary                 `json:"draft_summary,omitempty"`
-	Attempts     int                           `json:"attempts"`
-}
-
-type historyMessage struct {
-	Role string `json:"role"`
-	Text string `json:"text"`
-}
-
-type draftSummary struct {
-	ExerciseCount int      `json:"exercise_count"`
-	TotalSets     int      `json:"total_sets"`
-	WorkingSets   int      `json:"working_sets"`
-	ExerciseNames []string `json:"exercise_names"`
-}
-
-type report struct {
-	GeneratedAt   string           `json:"generated_at"`
-	Model         string           `json:"model"`
-	ScenarioCount int              `json:"scenario_count"`
-	Results       []scenarioResult `json:"results"`
-}
-
 type stubFeatureAccessReader struct{}
-
-var retryDelayPattern = regexp.MustCompile(`Please retry in ([0-9.]+)s`)
 
 func (stubFeatureAccessReader) ListCurrentUserAccess(context.Context) ([]featureaccess.FeatureAccessGrant, error) {
 	return nil, nil
 }
 
 func main() {
+	mode := flag.String("mode", aichateval.ModeSingleTurn, "eval mode: single_turn or two_turn")
+	flag.Parse()
+	if err := aichateval.ValidateMode(*mode); err != nil {
+		fail("%v", err)
+	}
 	if err := loadLocalEnv(); err != nil {
 		fail("failed to load local env files: %v", err)
 	}
@@ -86,29 +44,25 @@ func main() {
 		fail("failed to create output directory: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), runTimeout)
+	runtimeCtx, cancel := context.WithTimeout(context.Background(), runTimeout)
 	defer cancel()
 
-	runtime := aichat.NewGenkitRuntime(ctx, stubFeatureAccessReader{})
+	runtime := aichat.NewGenkitRuntime(runtimeCtx, stubFeatureAccessReader{})
 	if !runtime.Available() {
 		fail("ai chat runtime unavailable. Set GEMINI_API_KEY or GOOGLE_API_KEY in your shell, server/.env, or server/setenv.sh")
 	}
 
-	scenarios := scenarioSet()
-	results := make([]scenarioResult, 0, len(scenarios))
-	for _, item := range scenarios {
-		fmt.Fprintf(os.Stderr, "Running %s: %s\n", item.ID, item.Title)
-		results = append(results, runScenario(runtime, item))
-	}
+	report := aichateval.Run(context.Background(), runtime, aichateval.DefaultScenarios(), aichateval.RunOptions{
+		Mode: *mode,
+		OnScenario: func(item aichateval.Scenario) {
+			fmt.Fprintf(os.Stderr, "Running %s: %s\n", item.ID, item.Title)
+		},
+		OnRetry: func(item aichateval.Scenario, waitFor time.Duration, nextAttempt int, maxAttempts int) {
+			fmt.Fprintf(os.Stderr, "Rate limited on %s, waiting %s before retry %d/%d\n", item.ID, waitFor, nextAttempt, maxAttempts)
+		},
+	})
 
-	payload := report{
-		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
-		Model:         runtime.ModelName(),
-		ScenarioCount: len(results),
-		Results:       results,
-	}
-
-	body, err := json.MarshalIndent(payload, "", "  ")
+	body, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		fail("failed to marshal report: %v", err)
 	}
@@ -117,180 +71,6 @@ func main() {
 	}
 
 	fmt.Printf("Wrote scenario report to %s\n", outPath)
-}
-
-func runScenario(runtime *aichat.GenkitRuntime, item scenario) scenarioResult {
-	started := time.Now()
-	result := scenarioResult{
-		ID:          item.ID,
-		Title:       item.Title,
-		Prompt:      item.Prompt,
-		Expectation: item.Expectation,
-		History:     convertHistory(item.History),
-	}
-
-	var (
-		done *aichat.StreamDone
-		err  error
-	)
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		result.Attempts = attempt
-		done, err = runtime.StreamChat(context.Background(), item.Prompt, item.History, func(string) error {
-			return nil
-		})
-		if err == nil {
-			break
-		}
-
-		retryDelay, ok := parseRetryDelay(err)
-		if !ok || attempt == maxAttempts {
-			break
-		}
-
-		waitFor := time.Duration(math.Ceil(retryDelay.Seconds()+1)) * time.Second
-		fmt.Fprintf(os.Stderr, "Rate limited on %s, waiting %s before retry %d/%d\n", item.ID, waitFor, attempt+1, maxAttempts)
-		time.Sleep(waitFor)
-	}
-
-	result.DurationMS = time.Since(started).Milliseconds()
-	if err != nil {
-		result.Status = "error"
-		result.Error = err.Error()
-		return result
-	}
-
-	result.Text = strings.TrimSpace(done.Text)
-	result.Model = done.Model
-	result.Draft = done.WorkoutDraft
-	result.DraftSummary = summarizeDraft(done.WorkoutDraft)
-	switch {
-	case done.WorkoutDraft != nil:
-		result.Status = "structured_draft"
-	case strings.Contains(result.Text, "?"):
-		result.Status = "follow_up_question"
-	default:
-		result.Status = "text_only"
-	}
-
-	return result
-}
-
-func parseRetryDelay(err error) (time.Duration, bool) {
-	matches := retryDelayPattern.FindStringSubmatch(err.Error())
-	if len(matches) != 2 {
-		return 0, false
-	}
-
-	delay, parseErr := time.ParseDuration(matches[1] + "s")
-	if parseErr != nil {
-		return 0, false
-	}
-	return delay, true
-}
-
-func summarizeDraft(draft *workout.CreateWorkoutRequest) *draftSummary {
-	if draft == nil {
-		return nil
-	}
-
-	summary := &draftSummary{
-		ExerciseCount: len(draft.Exercises),
-		ExerciseNames: make([]string, 0, len(draft.Exercises)),
-	}
-	for _, exercise := range draft.Exercises {
-		summary.ExerciseNames = append(summary.ExerciseNames, exercise.Name)
-		for _, set := range exercise.Sets {
-			summary.TotalSets++
-			if set.SetType == "working" {
-				summary.WorkingSets++
-			}
-		}
-	}
-	return summary
-}
-
-func convertHistory(history []aichat.RuntimeChatMessage) []historyMessage {
-	if len(history) == 0 {
-		return nil
-	}
-
-	items := make([]historyMessage, 0, len(history))
-	for _, message := range history {
-		items = append(items, historyMessage{
-			Role: message.Role,
-			Text: message.Text,
-		})
-	}
-	return items
-}
-
-func scenarioSet() []scenario {
-	return []scenario{
-		{
-			ID:          "prompt-01",
-			Title:       "Home Dumbbell Pull",
-			Prompt:      "I've got 45 minutes at home with just adjustable dumbbells and a bench. Give me a pull workout.",
-			Expectation: "Should ideally generate a structured draft with realistic dumbbell-and-bench pull volume.",
-		},
-		{
-			ID:          "prompt-02",
-			Title:       "Commercial Gym Hypertrophy Legs",
-			Prompt:      "I want a 60-minute hypertrophy leg workout at a commercial gym.",
-			Expectation: "Should ask about injuries first or generate only if it can proceed after asking once; when it generates the draft should feel full enough for 60 minutes.",
-		},
-		{
-			ID:          "prompt-03",
-			Title:       "Lower Body With Knee Pain",
-			Prompt:      "I have knee pain. Build me a lower-body workout.",
-			Expectation: "Should gather missing readiness info first and avoid obvious knee-aggravating exercise choices if it generates.",
-		},
-		{
-			ID:          "prompt-04",
-			Title:       "Hotel Room No Equipment",
-			Prompt:      "Hotel room, 25 minutes, no equipment, full body.",
-			Expectation: "Should ask about injuries first or generate a concise feasible hotel-room bodyweight draft.",
-		},
-		{
-			ID:          "prompt-05",
-			Title:       "Beginner Upper Body Full Gym",
-			Prompt:      "Beginner, 40 minutes, upper body, full gym, no injuries.",
-			Expectation: "Should generate a structured beginner-appropriate draft without needing more info.",
-		},
-		{
-			ID:          "prompt-06",
-			Title:       "Shoulder Issue Push Workout",
-			Prompt:      "I tore up my shoulder recently, but I still want a push workout with dumbbells.",
-			Expectation: "Should gather missing readiness info first and avoid obvious shoulder-conflict push exercises if it generates.",
-		},
-		{
-			ID:          "prompt-07",
-			Title:       "Bodyweight Strength Full Body",
-			Prompt:      "Bodyweight only, 30 minutes, strength-focused full body.",
-			Expectation: "Should ask about injuries first or generate a realistic bodyweight strength-leaning draft.",
-		},
-		{
-			ID:          "prompt-08",
-			Title:       "Barbell-Only Pull Day",
-			Prompt:      "No machines, no cables, just barbells and plates, 50 minutes, pull day.",
-			Expectation: "Should avoid cable and machine work if it generates.",
-		},
-		{
-			ID:          "prompt-09",
-			Title:       "Mobility Rehab Back",
-			Prompt:      "I only want 15 minutes of mobility and rehab work for my back.",
-			Expectation: "Should allow intentionally low-volume work instead of forcing a normal lifting session.",
-		},
-		{
-			ID:    "prompt-10",
-			Title: "Elbow-Sensitive Revision Follow-Up",
-			History: []aichat.RuntimeChatMessage{
-				{Role: "user", Text: "Build me a 45 minute push workout with dumbbells and a bench. No injuries."},
-				{Role: "assistant", Text: "I put together a structured workout draft for you."},
-			},
-			Prompt:      "Swap out anything that bothers my elbow.",
-			Expectation: "Should ask a focused revision follow-up or adapt the next draft around the new elbow constraint.",
-		},
-	}
 }
 
 func loadLocalEnv() error {

--- a/server/internal/aichat/repository.go
+++ b/server/internal/aichat/repository.go
@@ -766,10 +766,10 @@ func (r *repository) CompleteRun(ctx context.Context, prepared *PreparedMessageS
 	}
 
 	runRow, err := qtx.UpdateAIChatRunCompleted(ctx, db.UpdateAIChatRunCompletedParams{
-		ID:           prepared.Run.ID,
-		UserID:       prepared.Run.UserID,
-		CompletedAt:  completedTS,
-		WorkoutDraft: workoutDraftJSON,
+		ID:          prepared.Run.ID,
+		UserID:      prepared.Run.UserID,
+		CompletedAt: completedTS,
+		Column4:     string(workoutDraftJSON),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("complete ai chat run: %w", err)
@@ -777,9 +777,9 @@ func (r *repository) CompleteRun(ctx context.Context, prepared *PreparedMessageS
 
 	if len(workoutDraftJSON) > 0 {
 		if err := qtx.SetAIChatConversationLatestWorkoutDraft(ctx, db.SetAIChatConversationLatestWorkoutDraftParams{
-			ID:                 prepared.Conversation.ID,
-			UserID:             prepared.Conversation.UserID,
-			LatestWorkoutDraft: workoutDraftJSON,
+			ID:      prepared.Conversation.ID,
+			UserID:  prepared.Conversation.UserID,
+			Column3: string(workoutDraftJSON),
 			LatestWorkoutDraftSourceRunID: pgtype.Int4{
 				Int32: prepared.Run.ID,
 				Valid: true,
@@ -1062,6 +1062,7 @@ func marshalWorkoutDraft(draft *workout.CreateWorkoutRequest) ([]byte, error) {
 	if draft == nil {
 		return nil, nil
 	}
+	normalizeWorkoutDraft(draft)
 	return json.Marshal(draft)
 }
 

--- a/server/internal/aichat/repository_integration_test.go
+++ b/server/internal/aichat/repository_integration_test.go
@@ -88,6 +88,99 @@ func TestRepositoryCompleteRun_PersistsWorkoutDraftJSONB(t *testing.T) {
 	assert.JSONEq(t, string(expectedJSON), string(storedLatestDraft))
 }
 
+func TestRepositoryCompleteRun_AllowsNilWorkoutDraft(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database-backed AI chat repository test in short mode")
+	}
+
+	pool, cleanup := setupAIChatRepositoryTestDatabase(t)
+	if pool == nil {
+		return
+	}
+	defer cleanup()
+
+	const userID = "aichat-complete-run-nil-draft-user"
+
+	ctx := context.Background()
+	seedAIChatRepositoryTestUser(t, pool, userID)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	queries := db.New(pool)
+	exerciseRepo := exercise.NewRepository(logger, queries, pool)
+	repo := NewRepository(logger, queries, pool, workout.NewTxSaver(logger, exerciseRepo))
+
+	conversation, err := repo.CreateConversation(ctx, userID)
+	require.NoError(t, err)
+
+	prepared, err := repo.PrepareMessageStream(ctx, conversation.ID, userID, "How should I warm up today?", defaultModelName, "req-complete-run-nil-draft")
+	require.NoError(t, err)
+
+	message, run, err := repo.CompleteRun(ctx, prepared, "Start with five easy minutes and a few ramp-up sets.", nil, time.Date(2026, 4, 22, 16, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.NotNil(t, message)
+	require.NotNil(t, run)
+	assert.Nil(t, run.WorkoutDraft)
+	assert.Equal(t, statusCompleted, run.Status)
+
+	storedConversation, err := repo.GetConversation(ctx, conversation.ID, userID)
+	require.NoError(t, err)
+	assert.Nil(t, storedConversation.LatestWorkoutDraft)
+
+	var storedRunDraft []byte
+	err = pool.QueryRow(ctx, "SELECT workout_draft FROM ai_chat_run WHERE id = $1 AND user_id = $2", run.ID, userID).Scan(&storedRunDraft)
+	require.NoError(t, err)
+	assert.Nil(t, storedRunDraft)
+}
+
+func TestRepositoryCompleteRun_PersistsWorkoutDraftWithNullByteText(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database-backed AI chat repository test in short mode")
+	}
+
+	pool, cleanup := setupAIChatRepositoryTestDatabase(t)
+	if pool == nil {
+		return
+	}
+	defer cleanup()
+
+	const userID = "aichat-complete-run-null-byte-draft-user"
+
+	ctx := context.Background()
+	seedAIChatRepositoryTestUser(t, pool, userID)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	queries := db.New(pool)
+	exerciseRepo := exercise.NewRepository(logger, queries, pool)
+	repo := NewRepository(logger, queries, pool, workout.NewTxSaver(logger, exerciseRepo))
+
+	conversation, err := repo.CreateConversation(ctx, userID)
+	require.NoError(t, err)
+
+	prepared, err := repo.PrepareMessageStream(ctx, conversation.ID, userID, "Build me a structured workout draft for today.", defaultModelName, "req-complete-run-null-byte-draft")
+	require.NoError(t, err)
+
+	notes := "Move well\x00and stop with two reps in reserve."
+	draft := &workout.CreateWorkoutRequest{
+		Date:  "2026-04-22T12:00:00Z",
+		Notes: &notes,
+		Exercises: []workout.ExerciseInput{
+			{
+				Name: "Goblet Squat",
+				Sets: []workout.SetInput{
+					{Reps: 10, SetType: "working"},
+				},
+			},
+		},
+	}
+
+	_, run, err := repo.CompleteRun(ctx, prepared, workoutDraftSummaryMessage, draft, time.Date(2026, 4, 22, 16, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.NotNil(t, run.WorkoutDraft)
+	require.NotNil(t, run.WorkoutDraft.Notes)
+	assert.NotContains(t, *run.WorkoutDraft.Notes, "\x00")
+}
+
 func TestRepositorySaveLatestWorkoutDraft_ConcurrentCallsCreateOneWorkout(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping database-backed AI chat repository test in short mode")
@@ -205,6 +298,10 @@ func setupAIChatRepositoryTestDatabase(t *testing.T) (*pgxpool.Pool, func()) {
 	cleanup := func() {
 		ctx := context.Background()
 		_, err := pool.Exec(ctx, "DELETE FROM users WHERE user_id = $1", "aichat-complete-run-user")
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx, "DELETE FROM users WHERE user_id = $1", "aichat-complete-run-nil-draft-user")
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx, "DELETE FROM users WHERE user_id = $1", "aichat-complete-run-null-byte-draft-user")
 		require.NoError(t, err)
 		_, err = pool.Exec(ctx, "DELETE FROM users WHERE user_id = $1", "aichat-save-draft-race-user")
 		require.NoError(t, err)

--- a/server/internal/aichat/workout_generation.go
+++ b/server/internal/aichat/workout_generation.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	workoutDraftToolName               = "fittrack.generate_workout_draft"
+	workoutDraftToolName               = "generate_workout_draft"
 	workoutDraftToolDescription        = "Creates a FitTrack workout draft. Call this immediately once you know the user's workout focus, session duration, enough equipment or workout context to choose feasible exercises, and injury status. Fitness level improves weight assumptions but is not required."
 	workoutDraftSummaryMessage         = "I put together a structured workout draft for you."
 	workoutChatFollowUpQuestionCeiling = 3
@@ -254,14 +254,15 @@ func normalizeWorkoutDraft(draft *workout.CreateWorkoutRequest) {
 		return
 	}
 
-	draft.Date = strings.TrimSpace(draft.Date)
-	draft.Notes = trimOptionalString(draft.Notes)
-	draft.WorkoutFocus = trimOptionalString(draft.WorkoutFocus)
+	draft.Date = cleanWorkoutDraftText(draft.Date)
+	draft.Notes = cleanOptionalWorkoutDraftText(draft.Notes)
+	draft.WorkoutFocus = cleanOptionalWorkoutDraftText(draft.WorkoutFocus)
 
 	for exerciseIndex := range draft.Exercises {
-		draft.Exercises[exerciseIndex].Name = strings.TrimSpace(draft.Exercises[exerciseIndex].Name)
+		draft.Exercises[exerciseIndex].Name = cleanWorkoutDraftText(draft.Exercises[exerciseIndex].Name)
 		for setIndex := range draft.Exercises[exerciseIndex].Sets {
-			draft.Exercises[exerciseIndex].Sets[setIndex].SetType = strings.ToLower(strings.TrimSpace(draft.Exercises[exerciseIndex].Sets[setIndex].SetType))
+			setType := cleanWorkoutDraftText(draft.Exercises[exerciseIndex].Sets[setIndex].SetType)
+			draft.Exercises[exerciseIndex].Sets[setIndex].SetType = strings.ToLower(setType)
 		}
 	}
 }
@@ -337,15 +338,19 @@ func looksLikeExerciseDump(text string, draft *workout.CreateWorkoutRequest) boo
 	return false
 }
 
-func trimOptionalString(value *string) *string {
+func cleanOptionalWorkoutDraftText(value *string) *string {
 	if value == nil {
 		return nil
 	}
 
-	trimmed := strings.TrimSpace(*value)
+	trimmed := cleanWorkoutDraftText(*value)
 	if trimmed == "" {
 		return nil
 	}
 
 	return &trimmed
+}
+
+func cleanWorkoutDraftText(value string) string {
+	return strings.TrimSpace(strings.ReplaceAll(value, "\x00", ""))
 }

--- a/server/internal/aichateval/runner.go
+++ b/server/internal/aichateval/runner.go
@@ -50,7 +50,21 @@ type Report struct {
 	Mode          string   `json:"mode"`
 	Model         string   `json:"model"`
 	ScenarioCount int      `json:"scenario_count"`
+	Summary       Summary  `json:"summary"`
 	Results       []Result `json:"results"`
+}
+
+type Summary struct {
+	TotalScenarios                 int      `json:"total_scenarios"`
+	StructuredDraftCount           int      `json:"structured_draft_count"`
+	FollowUpQuestionCount          int      `json:"follow_up_question_count"`
+	TextOnlyCount                  int      `json:"text_only_count"`
+	ErrorCount                     int      `json:"error_count"`
+	StructuredOutputConversionRate float64  `json:"structured_output_conversion_rate"`
+	TwoTurnFollowUpCount           int      `json:"two_turn_follow_up_count"`
+	TwoTurnAttemptCount            int      `json:"two_turn_attempt_count"`
+	TwoTurnStructuredDraftCount    int      `json:"two_turn_structured_draft_count"`
+	TwoTurnConversionRate          *float64 `json:"two_turn_conversion_rate"`
 }
 
 type Result struct {
@@ -113,8 +127,59 @@ func Run(ctx context.Context, runtime Runtime, scenarios []Scenario, options Run
 		Mode:          mode,
 		Model:         runtime.ModelName(),
 		ScenarioCount: len(results),
+		Summary:       BuildSummary(mode, results),
 		Results:       results,
 	}
+}
+
+func BuildSummary(mode string, results []Result) Summary {
+	summary := Summary{
+		TotalScenarios: len(results),
+	}
+	for _, result := range results {
+		switch result.Status {
+		case StatusStructuredDraft:
+			summary.StructuredDraftCount++
+		case StatusFollowUpQuestion:
+			summary.FollowUpQuestionCount++
+		case StatusTextOnly:
+			summary.TextOnlyCount++
+		case StatusError:
+			summary.ErrorCount++
+		}
+
+		if mode == ModeTwoTurn && firstTurnStatus(result) == StatusFollowUpQuestion {
+			summary.TwoTurnFollowUpCount++
+			if len(result.Turns) > 1 {
+				summary.TwoTurnAttemptCount++
+				if result.Status == StatusStructuredDraft {
+					summary.TwoTurnStructuredDraftCount++
+				}
+			}
+		}
+	}
+
+	summary.StructuredOutputConversionRate = rate(summary.StructuredDraftCount, summary.TotalScenarios)
+	if mode == ModeTwoTurn {
+		twoTurnRate := rate(summary.TwoTurnStructuredDraftCount, summary.TwoTurnAttemptCount)
+		summary.TwoTurnConversionRate = &twoTurnRate
+	}
+
+	return summary
+}
+
+func firstTurnStatus(result Result) string {
+	if len(result.Turns) == 0 {
+		return ""
+	}
+	return result.Turns[0].Status
+}
+
+func rate(count int, total int) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(count) / float64(total)
 }
 
 func normalizeMode(mode string) string {

--- a/server/internal/aichateval/runner.go
+++ b/server/internal/aichateval/runner.go
@@ -255,6 +255,10 @@ func runTurn(ctx context.Context, runtime Runtime, scenario Scenario, prompt str
 		maxAttempts = defaultMaxAttempts
 	}
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
+			break
+		}
 		result.Attempts = attempt
 		done, err = runtime.StreamChat(ctx, prompt, history, func(string) error {
 			return nil
@@ -272,7 +276,10 @@ func runTurn(ctx context.Context, runtime Runtime, scenario Scenario, prompt str
 		if options.OnRetry != nil {
 			options.OnRetry(scenario, waitFor, attempt+1, maxAttempts)
 		}
-		time.Sleep(waitFor)
+		if waitErr := waitForRetry(ctx, waitFor); waitErr != nil {
+			err = waitErr
+			break
+		}
 	}
 
 	result.DurationMS = time.Since(started).Milliseconds()
@@ -288,6 +295,18 @@ func runTurn(ctx context.Context, runtime Runtime, scenario Scenario, prompt str
 	result.DraftSummary = SummarizeDraft(done.WorkoutDraft)
 	result.Status = Classify(done)
 	return result
+}
+
+func waitForRetry(ctx context.Context, waitFor time.Duration) error {
+	timer := time.NewTimer(waitFor)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func Classify(done *aichat.StreamDone) string {

--- a/server/internal/aichateval/runner.go
+++ b/server/internal/aichateval/runner.go
@@ -1,0 +1,300 @@
+package aichateval
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
+	"github.com/Andrewy-gh/fittrack/server/internal/workout"
+)
+
+const (
+	ModeSingleTurn = "single_turn"
+	ModeTwoTurn    = "two_turn"
+
+	StatusFollowUpQuestion = "follow_up_question"
+	StatusStructuredDraft  = "structured_draft"
+	StatusTextOnly         = "text_only"
+	StatusError            = "error"
+)
+
+const defaultMaxAttempts = 3
+
+type Runtime interface {
+	StreamChat(ctx context.Context, prompt string, history []aichat.RuntimeChatMessage, onChunk func(string) error) (*aichat.StreamDone, error)
+	ModelName() string
+}
+
+type Scenario struct {
+	ID             string                      `json:"id"`
+	Title          string                      `json:"title"`
+	Prompt         string                      `json:"prompt"`
+	Expectation    string                      `json:"expectation"`
+	History        []aichat.RuntimeChatMessage `json:"history,omitempty"`
+	FollowUpAnswer string                      `json:"follow_up_answer,omitempty"`
+}
+
+type RunOptions struct {
+	Mode        string
+	MaxAttempts int
+	OnScenario  func(Scenario)
+	OnRetry     func(Scenario, time.Duration, int, int)
+}
+
+type Report struct {
+	GeneratedAt   string   `json:"generated_at"`
+	Mode          string   `json:"mode"`
+	Model         string   `json:"model"`
+	ScenarioCount int      `json:"scenario_count"`
+	Results       []Result `json:"results"`
+}
+
+type Result struct {
+	ID             string                        `json:"id"`
+	Title          string                        `json:"title"`
+	Prompt         string                        `json:"prompt"`
+	Expectation    string                        `json:"expectation"`
+	History        []HistoryMessage              `json:"history,omitempty"`
+	FollowUpAnswer string                        `json:"follow_up_answer,omitempty"`
+	Status         string                        `json:"status"`
+	Text           string                        `json:"text,omitempty"`
+	Error          string                        `json:"error,omitempty"`
+	Model          string                        `json:"model,omitempty"`
+	DurationMS     int64                         `json:"duration_ms"`
+	Draft          *workout.CreateWorkoutRequest `json:"draft,omitempty"`
+	DraftSummary   *DraftSummary                 `json:"draft_summary,omitempty"`
+	Attempts       int                           `json:"attempts"`
+	Turns          []TurnResult                  `json:"turns,omitempty"`
+}
+
+type TurnResult struct {
+	Turn         int                           `json:"turn"`
+	Prompt       string                        `json:"prompt"`
+	Status       string                        `json:"status"`
+	Text         string                        `json:"text,omitempty"`
+	Error        string                        `json:"error,omitempty"`
+	Model        string                        `json:"model,omitempty"`
+	DurationMS   int64                         `json:"duration_ms"`
+	Draft        *workout.CreateWorkoutRequest `json:"draft,omitempty"`
+	DraftSummary *DraftSummary                 `json:"draft_summary,omitempty"`
+	Attempts     int                           `json:"attempts"`
+}
+
+type HistoryMessage struct {
+	Role string `json:"role"`
+	Text string `json:"text"`
+}
+
+type DraftSummary struct {
+	ExerciseCount int      `json:"exercise_count"`
+	TotalSets     int      `json:"total_sets"`
+	WorkingSets   int      `json:"working_sets"`
+	ExerciseNames []string `json:"exercise_names"`
+}
+
+var retryDelayPattern = regexp.MustCompile(`Please retry in ([0-9.]+)s`)
+
+func Run(ctx context.Context, runtime Runtime, scenarios []Scenario, options RunOptions) Report {
+	mode := normalizeMode(options.Mode)
+	results := make([]Result, 0, len(scenarios))
+	for _, scenario := range scenarios {
+		if options.OnScenario != nil {
+			options.OnScenario(scenario)
+		}
+		results = append(results, runScenario(ctx, runtime, scenario, mode, options))
+	}
+
+	return Report{
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Mode:          mode,
+		Model:         runtime.ModelName(),
+		ScenarioCount: len(results),
+		Results:       results,
+	}
+}
+
+func normalizeMode(mode string) string {
+	switch strings.TrimSpace(mode) {
+	case "", ModeSingleTurn:
+		return ModeSingleTurn
+	case ModeTwoTurn:
+		return ModeTwoTurn
+	default:
+		return ModeSingleTurn
+	}
+}
+
+func runScenario(ctx context.Context, runtime Runtime, scenario Scenario, mode string, options RunOptions) Result {
+	result := Result{
+		ID:             scenario.ID,
+		Title:          scenario.Title,
+		Prompt:         scenario.Prompt,
+		Expectation:    scenario.Expectation,
+		History:        ConvertHistory(scenario.History),
+		FollowUpAnswer: scenario.FollowUpAnswer,
+	}
+
+	first := runTurn(ctx, runtime, scenario, scenario.Prompt, scenario.History, options)
+	applyTurnToResult(&result, first)
+	if mode != ModeTwoTurn || first.Status != StatusFollowUpQuestion || strings.TrimSpace(scenario.FollowUpAnswer) == "" {
+		return result
+	}
+
+	history := append([]aichat.RuntimeChatMessage{}, scenario.History...)
+	history = append(history,
+		aichat.RuntimeChatMessage{Role: "user", Text: scenario.Prompt},
+		aichat.RuntimeChatMessage{Role: "assistant", Text: first.Text},
+	)
+	second := runTurn(ctx, runtime, scenario, scenario.FollowUpAnswer, history, options)
+	second.Turn = 2
+	result.Turns = append(result.Turns, second)
+	applyTurnToResult(&result, second)
+
+	return result
+}
+
+func applyTurnToResult(result *Result, turn TurnResult) {
+	result.Status = turn.Status
+	result.Text = turn.Text
+	result.Error = turn.Error
+	result.Model = turn.Model
+	result.DurationMS += turn.DurationMS
+	result.Draft = turn.Draft
+	result.DraftSummary = turn.DraftSummary
+	result.Attempts += turn.Attempts
+	if len(result.Turns) == 0 {
+		turn.Turn = 1
+		result.Turns = append(result.Turns, turn)
+		return
+	}
+	result.Turns[len(result.Turns)-1] = turn
+}
+
+func runTurn(ctx context.Context, runtime Runtime, scenario Scenario, prompt string, history []aichat.RuntimeChatMessage, options RunOptions) TurnResult {
+	started := time.Now()
+	result := TurnResult{
+		Turn:   1,
+		Prompt: prompt,
+	}
+
+	var (
+		done *aichat.StreamDone
+		err  error
+	)
+	maxAttempts := options.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = defaultMaxAttempts
+	}
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		result.Attempts = attempt
+		done, err = runtime.StreamChat(ctx, prompt, history, func(string) error {
+			return nil
+		})
+		if err == nil {
+			break
+		}
+
+		retryDelay, ok := ParseRetryDelay(err)
+		if !ok || attempt == maxAttempts {
+			break
+		}
+
+		waitFor := time.Duration(math.Ceil(retryDelay.Seconds()+1)) * time.Second
+		if options.OnRetry != nil {
+			options.OnRetry(scenario, waitFor, attempt+1, maxAttempts)
+		}
+		time.Sleep(waitFor)
+	}
+
+	result.DurationMS = time.Since(started).Milliseconds()
+	if err != nil {
+		result.Status = StatusError
+		result.Error = err.Error()
+		return result
+	}
+
+	result.Text = strings.TrimSpace(done.Text)
+	result.Model = done.Model
+	result.Draft = done.WorkoutDraft
+	result.DraftSummary = SummarizeDraft(done.WorkoutDraft)
+	result.Status = Classify(done)
+	return result
+}
+
+func Classify(done *aichat.StreamDone) string {
+	if done == nil {
+		return StatusError
+	}
+	if done.WorkoutDraft != nil {
+		return StatusStructuredDraft
+	}
+	if strings.Contains(strings.TrimSpace(done.Text), "?") {
+		return StatusFollowUpQuestion
+	}
+	return StatusTextOnly
+}
+
+func ParseRetryDelay(err error) (time.Duration, bool) {
+	if err == nil {
+		return 0, false
+	}
+	matches := retryDelayPattern.FindStringSubmatch(err.Error())
+	if len(matches) != 2 {
+		return 0, false
+	}
+
+	delay, parseErr := time.ParseDuration(matches[1] + "s")
+	if parseErr != nil {
+		return 0, false
+	}
+	return delay, true
+}
+
+func SummarizeDraft(draft *workout.CreateWorkoutRequest) *DraftSummary {
+	if draft == nil {
+		return nil
+	}
+
+	summary := &DraftSummary{
+		ExerciseCount: len(draft.Exercises),
+		ExerciseNames: make([]string, 0, len(draft.Exercises)),
+	}
+	for _, exercise := range draft.Exercises {
+		summary.ExerciseNames = append(summary.ExerciseNames, exercise.Name)
+		for _, set := range exercise.Sets {
+			summary.TotalSets++
+			if set.SetType == "working" {
+				summary.WorkingSets++
+			}
+		}
+	}
+	return summary
+}
+
+func ConvertHistory(history []aichat.RuntimeChatMessage) []HistoryMessage {
+	if len(history) == 0 {
+		return nil
+	}
+
+	items := make([]HistoryMessage, 0, len(history))
+	for _, message := range history {
+		items = append(items, HistoryMessage{
+			Role: message.Role,
+			Text: message.Text,
+		})
+	}
+	return items
+}
+
+func ValidateMode(mode string) error {
+	switch mode {
+	case ModeSingleTurn, ModeTwoTurn:
+		return nil
+	default:
+		return fmt.Errorf("unsupported mode %q; use %q or %q", mode, ModeSingleTurn, ModeTwoTurn)
+	}
+}

--- a/server/internal/aichateval/runner_test.go
+++ b/server/internal/aichateval/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
 	"github.com/Andrewy-gh/fittrack/server/internal/workout"
@@ -230,6 +231,39 @@ func TestClassifyErrorAndRetryDelay(t *testing.T) {
 	}
 	if delay.String() != "2.4s" {
 		t.Fatalf("ParseRetryDelay() = %s, want 2.4s", delay)
+	}
+}
+
+func TestRunRetryWaitStopsWhenContextCanceled(t *testing.T) {
+	runtime := &fakeRuntime{
+		next: []runtimeResponse{{
+			err: errors.New("provider rate limited: Please retry in 300s"),
+		}},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := time.Now()
+	result := runTurn(ctx, runtime, Scenario{ID: "case-retry"}, "Build legs.", nil, RunOptions{
+		OnRetry: func(Scenario, time.Duration, int, int) {
+			cancel()
+		},
+	})
+
+	if result.Status != StatusError {
+		t.Fatalf("result.Status = %q, want %q", result.Status, StatusError)
+	}
+	if result.Error != context.Canceled.Error() {
+		t.Fatalf("result.Error = %q, want %q", result.Error, context.Canceled.Error())
+	}
+	if result.Attempts != 1 {
+		t.Fatalf("result.Attempts = %d, want 1", result.Attempts)
+	}
+	if len(runtime.calls) != 1 {
+		t.Fatalf("runtime calls = %d, want 1", len(runtime.calls))
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("runTurn waited %s, want context cancellation before retry sleep completes", elapsed)
 	}
 }
 

--- a/server/internal/aichateval/runner_test.go
+++ b/server/internal/aichateval/runner_test.go
@@ -1,0 +1,193 @@
+package aichateval
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
+	"github.com/Andrewy-gh/fittrack/server/internal/workout"
+)
+
+type fakeRuntime struct {
+	model string
+	calls []runtimeCall
+	next  []runtimeResponse
+}
+
+type runtimeCall struct {
+	prompt  string
+	history []aichat.RuntimeChatMessage
+}
+
+type runtimeResponse struct {
+	done *aichat.StreamDone
+	err  error
+}
+
+func (f *fakeRuntime) StreamChat(ctx context.Context, prompt string, history []aichat.RuntimeChatMessage, onChunk func(string) error) (*aichat.StreamDone, error) {
+	f.calls = append(f.calls, runtimeCall{
+		prompt:  prompt,
+		history: append([]aichat.RuntimeChatMessage{}, history...),
+	})
+	if len(f.next) == 0 {
+		return nil, errors.New("unexpected call")
+	}
+	response := f.next[0]
+	f.next = f.next[1:]
+	return response.done, response.err
+}
+
+func (f *fakeRuntime) ModelName() string {
+	if f.model == "" {
+		return "fake-model"
+	}
+	return f.model
+}
+
+func TestRunSingleTurnClassifiesStructuredDraft(t *testing.T) {
+	runtime := &fakeRuntime{
+		next: []runtimeResponse{{
+			done: &aichat.StreamDone{
+				Model:        "test-model",
+				Text:         "I made a draft.",
+				WorkoutDraft: testDraft(),
+			},
+		}},
+	}
+
+	report := Run(context.Background(), runtime, []Scenario{{
+		ID:          "case-1",
+		Title:       "Ready Prompt",
+		Prompt:      "Beginner upper body, full gym, no injuries.",
+		Expectation: "Should generate.",
+	}}, RunOptions{Mode: ModeSingleTurn})
+
+	if report.Mode != ModeSingleTurn {
+		t.Fatalf("Run() mode = %q, want %q", report.Mode, ModeSingleTurn)
+	}
+	if len(report.Results) != 1 {
+		t.Fatalf("Run() returned %d results, want 1", len(report.Results))
+	}
+	result := report.Results[0]
+	if result.Status != StatusStructuredDraft {
+		t.Fatalf("Result status = %q, want %q", result.Status, StatusStructuredDraft)
+	}
+	if result.DraftSummary == nil || result.DraftSummary.WorkingSets != 2 {
+		t.Fatalf("DraftSummary = %#v, want 2 working sets", result.DraftSummary)
+	}
+	if len(result.Turns) != 1 {
+		t.Fatalf("Turns = %d, want 1", len(result.Turns))
+	}
+}
+
+func TestRunTwoTurnAnswersFollowUpAndUsesFinalStatus(t *testing.T) {
+	runtime := &fakeRuntime{
+		next: []runtimeResponse{
+			{
+				done: &aichat.StreamDone{
+					Model: "test-model",
+					Text:  "Any injuries or equipment limits?",
+				},
+			},
+			{
+				done: &aichat.StreamDone{
+					Model:        "test-model",
+					Text:         "I made a draft.",
+					WorkoutDraft: testDraft(),
+				},
+			},
+		},
+	}
+	scenario := Scenario{
+		ID:             "case-2",
+		Title:          "Follow Up",
+		Prompt:         "Give me a pull workout.",
+		Expectation:    "Should ask, then generate.",
+		FollowUpAnswer: "No injuries, dumbbells and bench, 45 minutes.",
+	}
+
+	report := Run(context.Background(), runtime, []Scenario{scenario}, RunOptions{Mode: ModeTwoTurn})
+
+	result := report.Results[0]
+	if result.Status != StatusStructuredDraft {
+		t.Fatalf("Result status = %q, want %q", result.Status, StatusStructuredDraft)
+	}
+	if result.Text != "I made a draft." {
+		t.Fatalf("Result text = %q, want final turn text", result.Text)
+	}
+	if len(result.Turns) != 2 {
+		t.Fatalf("Turns = %d, want 2", len(result.Turns))
+	}
+	if len(runtime.calls) != 2 {
+		t.Fatalf("runtime calls = %d, want 2", len(runtime.calls))
+	}
+	second := runtime.calls[1]
+	if second.prompt != scenario.FollowUpAnswer {
+		t.Fatalf("second prompt = %q, want follow-up answer", second.prompt)
+	}
+	if len(second.history) != 2 {
+		t.Fatalf("second history length = %d, want 2", len(second.history))
+	}
+	if second.history[0].Role != "user" || second.history[0].Text != scenario.Prompt {
+		t.Fatalf("second history[0] = %#v, want original user prompt", second.history[0])
+	}
+	if second.history[1].Role != "assistant" || second.history[1].Text != "Any injuries or equipment limits?" {
+		t.Fatalf("second history[1] = %#v, want first assistant follow-up", second.history[1])
+	}
+}
+
+func TestRunTwoTurnDoesNotAnswerWhenFirstTurnIsTextOnly(t *testing.T) {
+	runtime := &fakeRuntime{
+		next: []runtimeResponse{{
+			done: &aichat.StreamDone{
+				Model: "test-model",
+				Text:  "Here are some general ideas.",
+			},
+		}},
+	}
+
+	report := Run(context.Background(), runtime, []Scenario{{
+		ID:             "case-3",
+		Title:          "Text Only",
+		Prompt:         "Give me ideas.",
+		Expectation:    "Should be tracked as text only.",
+		FollowUpAnswer: "No injuries.",
+	}}, RunOptions{Mode: ModeTwoTurn})
+
+	if report.Results[0].Status != StatusTextOnly {
+		t.Fatalf("Result status = %q, want %q", report.Results[0].Status, StatusTextOnly)
+	}
+	if len(runtime.calls) != 1 {
+		t.Fatalf("runtime calls = %d, want 1", len(runtime.calls))
+	}
+}
+
+func TestClassifyErrorAndRetryDelay(t *testing.T) {
+	if got := Classify(nil); got != StatusError {
+		t.Fatalf("Classify(nil) = %q, want %q", got, StatusError)
+	}
+
+	delay, ok := ParseRetryDelay(errors.New("Please retry in 2.4s"))
+	if !ok {
+		t.Fatal("ParseRetryDelay() ok = false, want true")
+	}
+	if delay.String() != "2.4s" {
+		t.Fatalf("ParseRetryDelay() = %s, want 2.4s", delay)
+	}
+}
+
+func testDraft() *workout.CreateWorkoutRequest {
+	return &workout.CreateWorkoutRequest{
+		Date: "2026-04-25T12:00:00Z",
+		Exercises: []workout.ExerciseInput{
+			{
+				Name: "Dumbbell Row",
+				Sets: []workout.SetInput{
+					{Reps: 10, SetType: "working"},
+					{Reps: 10, SetType: "working"},
+				},
+			},
+		},
+	}
+}

--- a/server/internal/aichateval/runner_test.go
+++ b/server/internal/aichateval/runner_test.go
@@ -69,6 +69,15 @@ func TestRunSingleTurnClassifiesStructuredDraft(t *testing.T) {
 	if len(report.Results) != 1 {
 		t.Fatalf("Run() returned %d results, want 1", len(report.Results))
 	}
+	if report.Summary.StructuredDraftCount != 1 {
+		t.Fatalf("StructuredDraftCount = %d, want 1", report.Summary.StructuredDraftCount)
+	}
+	if report.Summary.StructuredOutputConversionRate != 1 {
+		t.Fatalf("StructuredOutputConversionRate = %f, want 1", report.Summary.StructuredOutputConversionRate)
+	}
+	if report.Summary.TwoTurnConversionRate != nil {
+		t.Fatalf("TwoTurnConversionRate = %v, want nil for single-turn mode", *report.Summary.TwoTurnConversionRate)
+	}
 	result := report.Results[0]
 	if result.Status != StatusStructuredDraft {
 		t.Fatalf("Result status = %q, want %q", result.Status, StatusStructuredDraft)
@@ -116,6 +125,21 @@ func TestRunTwoTurnAnswersFollowUpAndUsesFinalStatus(t *testing.T) {
 	if result.Text != "I made a draft." {
 		t.Fatalf("Result text = %q, want final turn text", result.Text)
 	}
+	if report.Summary.FollowUpQuestionCount != 0 {
+		t.Fatalf("FollowUpQuestionCount = %d, want final status counts only", report.Summary.FollowUpQuestionCount)
+	}
+	if report.Summary.TwoTurnFollowUpCount != 1 {
+		t.Fatalf("TwoTurnFollowUpCount = %d, want 1", report.Summary.TwoTurnFollowUpCount)
+	}
+	if report.Summary.TwoTurnAttemptCount != 1 {
+		t.Fatalf("TwoTurnAttemptCount = %d, want 1", report.Summary.TwoTurnAttemptCount)
+	}
+	if report.Summary.TwoTurnStructuredDraftCount != 1 {
+		t.Fatalf("TwoTurnStructuredDraftCount = %d, want 1", report.Summary.TwoTurnStructuredDraftCount)
+	}
+	if report.Summary.TwoTurnConversionRate == nil || *report.Summary.TwoTurnConversionRate != 1 {
+		t.Fatalf("TwoTurnConversionRate = %v, want 1", report.Summary.TwoTurnConversionRate)
+	}
 	if len(result.Turns) != 2 {
 		t.Fatalf("Turns = %d, want 2", len(result.Turns))
 	}
@@ -134,6 +158,38 @@ func TestRunTwoTurnAnswersFollowUpAndUsesFinalStatus(t *testing.T) {
 	}
 	if second.history[1].Role != "assistant" || second.history[1].Text != "Any injuries or equipment limits?" {
 		t.Fatalf("second history[1] = %#v, want first assistant follow-up", second.history[1])
+	}
+}
+
+func TestRunSummaryCountsFinalStatuses(t *testing.T) {
+	runtime := &fakeRuntime{
+		next: []runtimeResponse{
+			{done: &aichat.StreamDone{Text: "Any injuries?"}},
+			{done: &aichat.StreamDone{Text: "General guidance only."}},
+			{err: errors.New("provider failed")},
+		},
+	}
+
+	report := Run(context.Background(), runtime, []Scenario{
+		{ID: "case-1", Title: "Follow Up", Prompt: "Build legs."},
+		{ID: "case-2", Title: "Text", Prompt: "Ideas."},
+		{ID: "case-3", Title: "Error", Prompt: "Build push."},
+	}, RunOptions{Mode: ModeSingleTurn})
+
+	if report.Summary.TotalScenarios != 3 {
+		t.Fatalf("TotalScenarios = %d, want 3", report.Summary.TotalScenarios)
+	}
+	if report.Summary.FollowUpQuestionCount != 1 {
+		t.Fatalf("FollowUpQuestionCount = %d, want 1", report.Summary.FollowUpQuestionCount)
+	}
+	if report.Summary.TextOnlyCount != 1 {
+		t.Fatalf("TextOnlyCount = %d, want 1", report.Summary.TextOnlyCount)
+	}
+	if report.Summary.ErrorCount != 1 {
+		t.Fatalf("ErrorCount = %d, want 1", report.Summary.ErrorCount)
+	}
+	if report.Summary.StructuredOutputConversionRate != 0 {
+		t.Fatalf("StructuredOutputConversionRate = %f, want 0", report.Summary.StructuredOutputConversionRate)
 	}
 }
 

--- a/server/internal/aichateval/scenarios.go
+++ b/server/internal/aichateval/scenarios.go
@@ -1,0 +1,83 @@
+package aichateval
+
+import "github.com/Andrewy-gh/fittrack/server/internal/aichat"
+
+// DefaultScenarios returns realistic prompts that exercise workout draft readiness.
+func DefaultScenarios() []Scenario {
+	return []Scenario{
+		{
+			ID:             "prompt-01",
+			Title:          "Home Dumbbell Pull",
+			Prompt:         "I've got 45 minutes at home with just adjustable dumbbells and a bench. Give me a pull workout.",
+			Expectation:    "Should ideally generate a structured draft with realistic dumbbell-and-bench pull volume.",
+			FollowUpAnswer: "No injuries. I'm intermediate and want muscle growth.",
+		},
+		{
+			ID:             "prompt-02",
+			Title:          "Commercial Gym Hypertrophy Legs",
+			Prompt:         "I want a 60-minute hypertrophy leg workout at a commercial gym.",
+			Expectation:    "Should ask about injuries first or generate only if it can proceed after asking once; when it generates the draft should feel full enough for 60 minutes.",
+			FollowUpAnswer: "No injuries. I'm intermediate, and hypertrophy is the goal.",
+		},
+		{
+			ID:             "prompt-03",
+			Title:          "Lower Body With Knee Pain",
+			Prompt:         "I have knee pain. Build me a lower-body workout.",
+			Expectation:    "Should gather missing readiness info first and avoid obvious knee-aggravating exercise choices if it generates.",
+			FollowUpAnswer: "It's mild front-of-knee discomfort, no sharp pain. Keep it joint-friendly, 35 minutes, dumbbells and machines are available.",
+		},
+		{
+			ID:             "prompt-04",
+			Title:          "Hotel Room No Equipment",
+			Prompt:         "Hotel room, 25 minutes, no equipment, full body.",
+			Expectation:    "Should ask about injuries first or generate a concise feasible hotel-room bodyweight draft.",
+			FollowUpAnswer: "No injuries. I'm beginner to intermediate and want a balanced full-body session.",
+		},
+		{
+			ID:             "prompt-05",
+			Title:          "Beginner Upper Body Full Gym",
+			Prompt:         "Beginner, 40 minutes, upper body, full gym, no injuries.",
+			Expectation:    "Should generate a structured beginner-appropriate draft without needing more info.",
+			FollowUpAnswer: "Main goal is general strength and confidence with machines and dumbbells.",
+		},
+		{
+			ID:             "prompt-06",
+			Title:          "Shoulder Issue Push Workout",
+			Prompt:         "I tore up my shoulder recently, but I still want a push workout with dumbbells.",
+			Expectation:    "Should gather missing readiness info first and avoid obvious shoulder-conflict push exercises if it generates.",
+			FollowUpAnswer: "It is a recent mild strain and overhead pressing bothers it. Keep the workout shoulder-friendly, 30 minutes, no sharp pain.",
+		},
+		{
+			ID:             "prompt-07",
+			Title:          "Bodyweight Strength Full Body",
+			Prompt:         "Bodyweight only, 30 minutes, strength-focused full body.",
+			Expectation:    "Should ask about injuries first or generate a realistic bodyweight strength-leaning draft.",
+			FollowUpAnswer: "No injuries. I'm intermediate and can do push-ups, lunges, and planks.",
+		},
+		{
+			ID:             "prompt-08",
+			Title:          "Barbell-Only Pull Day",
+			Prompt:         "No machines, no cables, just barbells and plates, 50 minutes, pull day.",
+			Expectation:    "Should avoid cable and machine work if it generates.",
+			FollowUpAnswer: "No injuries. I'm intermediate and want strength with some hypertrophy.",
+		},
+		{
+			ID:             "prompt-09",
+			Title:          "Mobility Rehab Back",
+			Prompt:         "I only want 15 minutes of mobility and rehab work for my back.",
+			Expectation:    "Should allow intentionally low-volume work instead of forcing a normal lifting session.",
+			FollowUpAnswer: "No acute injury or numbness. This is gentle low-back stiffness, and I want easy mobility only.",
+		},
+		{
+			ID:    "prompt-10",
+			Title: "Elbow-Sensitive Revision Follow-Up",
+			History: []aichat.RuntimeChatMessage{
+				{Role: "user", Text: "Build me a 45 minute push workout with dumbbells and a bench. No injuries."},
+				{Role: "assistant", Text: "I put together a structured workout draft for you."},
+			},
+			Prompt:         "Swap out anything that bothers my elbow.",
+			Expectation:    "Should ask a focused revision follow-up or adapt the next draft around the new elbow constraint.",
+			FollowUpAnswer: "It's mild elbow irritation during deep pressing and skull crushers. Keep dumbbells and bench, avoid elbow-aggravating moves.",
+		},
+	}
+}

--- a/server/internal/database/query.sql.go
+++ b/server/internal/database/query.sql.go
@@ -2127,7 +2127,7 @@ func (q *Queries) MarkAIChatRunAwaitingRecovery(ctx context.Context, arg MarkAIC
 
 const setAIChatConversationLatestWorkoutDraft = `-- name: SetAIChatConversationLatestWorkoutDraft :exec
 UPDATE ai_chat_conversation
-SET latest_workout_draft = $3,
+SET latest_workout_draft = NULLIF($3::text, '')::jsonb,
     latest_workout_draft_source_run_id = $4,
     latest_workout_draft_saved_workout_id = NULL,
     latest_workout_draft_saved_at = NULL,
@@ -2138,7 +2138,7 @@ WHERE id = $1 AND user_id = $2
 type SetAIChatConversationLatestWorkoutDraftParams struct {
 	ID                            int32       `json:"id"`
 	UserID                        string      `json:"user_id"`
-	LatestWorkoutDraft            []byte      `json:"latest_workout_draft"`
+	Column3                       string      `json:"column_3"`
 	LatestWorkoutDraftSourceRunID pgtype.Int4 `json:"latest_workout_draft_source_run_id"`
 }
 
@@ -2146,7 +2146,7 @@ func (q *Queries) SetAIChatConversationLatestWorkoutDraft(ctx context.Context, a
 	_, err := q.db.Exec(ctx, setAIChatConversationLatestWorkoutDraft,
 		arg.ID,
 		arg.UserID,
-		arg.LatestWorkoutDraft,
+		arg.Column3,
 		arg.LatestWorkoutDraftSourceRunID,
 	)
 	return err
@@ -2393,7 +2393,7 @@ UPDATE ai_chat_run
 SET status = 'completed',
     error_message = NULL,
     completed_at = $3,
-    workout_draft = $4,
+    workout_draft = NULLIF($4::text, '')::jsonb,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1 AND user_id = $2
 RETURNING
@@ -2414,10 +2414,10 @@ RETURNING
 `
 
 type UpdateAIChatRunCompletedParams struct {
-	ID           int32              `json:"id"`
-	UserID       string             `json:"user_id"`
-	CompletedAt  pgtype.Timestamptz `json:"completed_at"`
-	WorkoutDraft []byte             `json:"workout_draft"`
+	ID          int32              `json:"id"`
+	UserID      string             `json:"user_id"`
+	CompletedAt pgtype.Timestamptz `json:"completed_at"`
+	Column4     string             `json:"column_4"`
 }
 
 func (q *Queries) UpdateAIChatRunCompleted(ctx context.Context, arg UpdateAIChatRunCompletedParams) (AiChatRun, error) {
@@ -2425,7 +2425,7 @@ func (q *Queries) UpdateAIChatRunCompleted(ctx context.Context, arg UpdateAIChat
 		arg.ID,
 		arg.UserID,
 		arg.CompletedAt,
-		arg.WorkoutDraft,
+		arg.Column4,
 	)
 	var i AiChatRun
 	err := row.Scan(

--- a/server/internal/e2eauth/service.go
+++ b/server/internal/e2eauth/service.go
@@ -171,9 +171,9 @@ func (s *Service) SeedConversation(
 	}
 
 	if err := qtx.SetAIChatConversationLatestWorkoutDraft(ctx, db.SetAIChatConversationLatestWorkoutDraftParams{
-		ID:                 conversationRow.ID,
-		UserID:             s.userID,
-		LatestWorkoutDraft: draftJSON,
+		ID:      conversationRow.ID,
+		UserID:  s.userID,
+		Column3: string(draftJSON),
 	}); err != nil {
 		return nil, fmt.Errorf("set seeded latest workout draft: %w", err)
 	}

--- a/server/query.sql
+++ b/server/query.sql
@@ -762,7 +762,7 @@ WHERE id = $1 AND user_id = $2;
 
 -- name: SetAIChatConversationLatestWorkoutDraft :exec
 UPDATE ai_chat_conversation
-SET latest_workout_draft = $3,
+SET latest_workout_draft = NULLIF($3::text, '')::jsonb,
     latest_workout_draft_source_run_id = $4,
     latest_workout_draft_saved_workout_id = NULL,
     latest_workout_draft_saved_at = NULL,
@@ -867,7 +867,7 @@ UPDATE ai_chat_run
 SET status = 'completed',
     error_message = NULL,
     completed_at = $3,
-    workout_draft = $4,
+    workout_draft = NULLIF($4::text, '')::jsonb,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1 AND user_id = $2
 RETURNING


### PR DESCRIPTION
## Summary
- add AI chat scenario eval runner coverage and summary metrics
- fix workout draft tool registration so generated workout requests can call the registered tool
- harden AI workout draft completion by normalizing draft text and storing JSON through text-to-jsonb parsing

## Verification
- go test -count=1 ./internal/aichat ./internal/e2eauth ./cmd/api
- go vet ./...
- make test-short via pre-push hook