### PR TITLE
chore: gate AI chat trace logs

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -164,6 +164,7 @@ Common optional variables:
 - `METRICS_USERNAME`, `METRICS_PASSWORD`
 - `GEMINI_API_KEY` or `GOOGLE_API_KEY`
 - `GEMINI_MODEL`
+- `AI_CHAT_TRACE_LOGS=true` to temporarily enable verbose AI chat stream timing logs while debugging
 - `E2E_LOCAL_AUTH_ENABLED` to enable the local-only Playwright auth bootstrap in `development`
 - `E2E_LOCAL_AUTH_USER_ID`, `E2E_LOCAL_AUTH_EMAIL`, `E2E_LOCAL_AUTH_DISPLAY_NAME` to override the deterministic local test user
 - `SECRET_SERVER_KEY` for Playwright's server-side auth bootstrap

--- a/server/internal/aichat/handler.go
+++ b/server/internal/aichat/handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	apperrors "github.com/Andrewy-gh/fittrack/server/internal/errors"
 	"github.com/Andrewy-gh/fittrack/server/internal/request"
@@ -312,6 +313,7 @@ func (h *Handler) RecoverMessage(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} response.Error
 // @Router /ai/conversations/{id}/messages/stream [post]
 func (h *Handler) StreamMessage(w http.ResponseWriter, r *http.Request) {
+	traceStartedAt := time.Now()
 	conversationID, ok := h.decodeConversationID(w, r)
 	if !ok {
 		return
@@ -353,13 +355,35 @@ func (h *Handler) StreamMessage(w http.ResponseWriter, r *http.Request) {
 		h.logStreamWriteFailure("failed to start ai chat stream", r, err)
 		return
 	}
+	// Trace marker: confirms when the browser should have received the SSE start event.
+	logAIChatTrace(h.logger, "sse_start_written",
+		"elapsed_ms", time.Since(traceStartedAt).Milliseconds(),
+		"conversation_id", prepared.Conversation.ID,
+		"run_id", prepared.Run.ID,
+		"message_id", prepared.AssistantMessage.ID,
+		"request_id", request.GetRequestID(r.Context()),
+	)
 
+	firstDeltaWritten := false
 	done, err := h.service.StreamMessage(r.Context(), prepared, func(chunk StreamChunk) error {
-		return sse.write("delta", StreamEvent{
+		err := sse.write("delta", StreamEvent{
 			Type:     "delta",
 			Delta:    chunk.Delta,
 			Sequence: chunk.Sequence,
 		})
+		if err == nil && !firstDeltaWritten {
+			firstDeltaWritten = true
+			// Trace marker: separates "stream opened" from "assistant text became visible."
+			logAIChatTrace(h.logger, "first_delta_written",
+				"elapsed_ms", time.Since(traceStartedAt).Milliseconds(),
+				"conversation_id", prepared.Conversation.ID,
+				"run_id", prepared.Run.ID,
+				"message_id", prepared.AssistantMessage.ID,
+				"sequence", chunk.Sequence,
+				"request_id", request.GetRequestID(r.Context()),
+			)
+		}
+		return err
 	})
 	if err != nil {
 		if errors.Is(err, ErrStreamAwaitingRecovery) {
@@ -382,7 +406,18 @@ func (h *Handler) StreamMessage(w http.ResponseWriter, r *http.Request) {
 		WorkoutDraft:   done.WorkoutDraft,
 	}); err != nil {
 		h.logStreamWriteFailure("failed to finish ai chat stream", r, err)
+		return
 	}
+	// Trace marker: confirms when the terminal payload, including workout draft, reached SSE.
+	logAIChatTrace(h.logger, "sse_done_written",
+		"elapsed_ms", time.Since(traceStartedAt).Milliseconds(),
+		"conversation_id", done.ConversationID,
+		"run_id", done.RunID,
+		"message_id", done.MessageID,
+		"sequence", done.Sequence,
+		"has_workout_draft", done.WorkoutDraft != nil,
+		"request_id", request.GetRequestID(r.Context()),
+	)
 }
 
 // ResumeMessageStream godoc

--- a/server/internal/aichat/runtime.go
+++ b/server/internal/aichat/runtime.go
@@ -15,6 +15,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 
 	"github.com/Andrewy-gh/fittrack/server/internal/featureaccess"
+	"github.com/Andrewy-gh/fittrack/server/internal/request"
 )
 
 const (
@@ -164,11 +165,13 @@ func (r *GenkitRuntime) StreamChat(ctx context.Context, prompt string, history [
 		return nil, ErrRuntimeUnavailable
 	}
 
+	traceStartedAt := time.Now()
 	streamCtx, cancel := context.WithTimeout(ctx, chatStreamTimeout)
 	defer cancel()
 	streamCtx = withToolGuard(streamCtx)
 
 	var builder strings.Builder
+	firstModelDelta := false
 	opts := []ai.GenerateOption{
 		ai.WithModelName(r.modelName),
 		ai.WithTools(r.activeFeaturesTool, r.workoutDraftTool),
@@ -180,11 +183,27 @@ func (r *GenkitRuntime) StreamChat(ctx context.Context, prompt string, history [
 			if delta == "" {
 				return nil
 			}
+			if !firstModelDelta {
+				firstModelDelta = true
+				// Trace marker: confirms when Gemini produced the first text delta.
+				logAIChatTraceContext(ctx, "runtime_first_model_delta",
+					"elapsed_ms", time.Since(traceStartedAt).Milliseconds(),
+					"model", r.modelName,
+					"history_messages", len(history),
+					"request_id", request.GetRequestID(ctx),
+				)
+			}
 			builder.WriteString(delta)
 			return onChunk(delta)
 		}),
 	}
 
+	// Trace marker: starts the outer chat generation, including any tool planning.
+	logAIChatTraceContext(ctx, "runtime_generate_started",
+		"model", r.modelName,
+		"history_messages", len(history),
+		"request_id", request.GetRequestID(ctx),
+	)
 	resp, err := genkit.Generate(streamCtx, r.g, opts...)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(streamCtx.Err(), context.DeadlineExceeded) {
@@ -192,6 +211,12 @@ func (r *GenkitRuntime) StreamChat(ctx context.Context, prompt string, history [
 		}
 		return nil, fmt.Errorf("stream ai chat response: %w", err)
 	}
+	logAIChatTraceContext(ctx, "runtime_generate_finished",
+		"elapsed_ms", time.Since(traceStartedAt).Milliseconds(),
+		"model", r.modelName,
+		"history_messages", len(history),
+		"request_id", request.GetRequestID(ctx),
+	)
 
 	text := strings.TrimSpace(resp.Text())
 	if text == "" {

--- a/server/internal/aichat/service.go
+++ b/server/internal/aichat/service.go
@@ -377,16 +377,36 @@ func (s *Service) RecoverStreamingRun(ctx context.Context, request RunRecoveryRe
 }
 
 func (s *Service) executePreparedRun(ctx context.Context, prepared *PreparedMessageStream, onChunk func(StreamChunk) error, allowRecovery bool) (*StreamDone, error) {
+	traceStartedAt := time.Now()
 	history := toRuntimeHistory(prepared.History)
 	var partial strings.Builder
 	persistCtx := context.WithoutCancel(ctx)
 
+	// Trace marker: measures the whole service layer around model streaming and persistence.
+	logAIChatTrace(s.logger, "service_stream_started",
+		"conversation_id", prepared.Conversation.ID,
+		"run_id", prepared.Run.ID,
+		"message_id", prepared.AssistantMessage.ID,
+		"history_messages", len(history),
+	)
+	firstChunkPersisted := false
 	done, err := s.runtime.StreamChat(ctx, prepared.Prompt, history, func(delta string) error {
 		partial.WriteString(delta)
 		partialText := strings.TrimSpace(partial.String())
 		sequence, err := s.repo.AppendStreamChunk(persistCtx, prepared, delta, partialText, time.Now().UTC())
 		if err != nil {
 			return err
+		}
+		if !firstChunkPersisted {
+			firstChunkPersisted = true
+			// Trace marker: shows when the first model delta was persisted before SSE delivery.
+			logAIChatTrace(s.logger, "first_chunk_persisted",
+				"elapsed_ms", time.Since(traceStartedAt).Milliseconds(),
+				"conversation_id", prepared.Conversation.ID,
+				"run_id", prepared.Run.ID,
+				"message_id", prepared.AssistantMessage.ID,
+				"sequence", sequence,
+			)
 		}
 		if onChunk == nil {
 			return nil
@@ -408,12 +428,21 @@ func (s *Service) executePreparedRun(ctx context.Context, prepared *PreparedMess
 		}
 		return nil, err
 	}
+	// Trace marker: captures total runtime latency before final DB completion.
+	logAIChatTrace(s.logger, "runtime_stream_finished",
+		"elapsed_ms", time.Since(traceStartedAt).Milliseconds(),
+		"conversation_id", prepared.Conversation.ID,
+		"run_id", prepared.Run.ID,
+		"message_id", prepared.AssistantMessage.ID,
+		"has_workout_draft", done.WorkoutDraft != nil,
+	)
 
 	text := strings.TrimSpace(done.Text)
 	if text == "" {
 		text = strings.TrimSpace(partial.String())
 	}
 
+	completeStartedAt := time.Now()
 	message, run, err := s.repo.CompleteRun(persistCtx, prepared, text, done.WorkoutDraft, time.Now().UTC())
 	if err != nil {
 		persistErr := err
@@ -422,6 +451,15 @@ func (s *Service) executePreparedRun(ctx context.Context, prepared *PreparedMess
 		}
 		return nil, persistErr
 	}
+	// Trace marker: separates model latency from final persistence latency.
+	logAIChatTrace(s.logger, "complete_run_finished",
+		"elapsed_ms", time.Since(traceStartedAt).Milliseconds(),
+		"duration_ms", time.Since(completeStartedAt).Milliseconds(),
+		"conversation_id", prepared.Conversation.ID,
+		"run_id", run.ID,
+		"message_id", message.ID,
+		"has_workout_draft", done.WorkoutDraft != nil,
+	)
 	prepared.AssistantMessage = message
 	prepared.Run = run
 

--- a/server/internal/aichat/trace.go
+++ b/server/internal/aichat/trace.go
@@ -1,0 +1,40 @@
+package aichat
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+const aiChatTraceLogsEnvVar = "AI_CHAT_TRACE_LOGS"
+
+func aiChatTraceEnabled() bool {
+	value := strings.TrimSpace(strings.ToLower(os.Getenv(aiChatTraceLogsEnvVar)))
+	return value == "1" || value == "true" || value == "yes" || value == "on"
+}
+
+func logAIChatTrace(logger *slog.Logger, stage string, attrs ...any) {
+	if !aiChatTraceEnabled() {
+		return
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	logAttrs := make([]any, 0, len(attrs)+2)
+	logAttrs = append(logAttrs, "stage", stage)
+	logAttrs = append(logAttrs, attrs...)
+	logger.Info("ai chat stream trace", logAttrs...)
+}
+
+func logAIChatTraceContext(ctx context.Context, stage string, attrs ...any) {
+	if !aiChatTraceEnabled() {
+		return
+	}
+
+	logAttrs := make([]any, 0, len(attrs)+2)
+	logAttrs = append(logAttrs, "stage", stage)
+	logAttrs = append(logAttrs, attrs...)
+	slog.InfoContext(ctx, "ai chat stream trace", logAttrs...)
+}

--- a/server/internal/aichat/trace_test.go
+++ b/server/internal/aichat/trace_test.go
@@ -1,0 +1,37 @@
+package aichat
+
+import "testing"
+
+func TestAIChatTraceEnabled(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		t.Setenv(aiChatTraceLogsEnvVar, "")
+
+		if aiChatTraceEnabled() {
+			t.Fatal("expected AI chat trace logs to be disabled by default")
+		}
+	})
+
+	t.Run("accepts common truthy values", func(t *testing.T) {
+		for _, value := range []string{"1", "true", "TRUE", "yes", "on"} {
+			t.Run(value, func(t *testing.T) {
+				t.Setenv(aiChatTraceLogsEnvVar, value)
+
+				if !aiChatTraceEnabled() {
+					t.Fatalf("expected %s=%q to enable AI chat trace logs", aiChatTraceLogsEnvVar, value)
+				}
+			})
+		}
+	})
+
+	t.Run("rejects non-truthy values", func(t *testing.T) {
+		for _, value := range []string{"0", "false", "off", "no"} {
+			t.Run(value, func(t *testing.T) {
+				t.Setenv(aiChatTraceLogsEnvVar, value)
+
+				if aiChatTraceEnabled() {
+					t.Fatalf("expected %s=%q to disable AI chat trace logs", aiChatTraceLogsEnvVar, value)
+				}
+			})
+		}
+	})
+}

--- a/server/internal/aichat/workout_generation.go
+++ b/server/internal/aichat/workout_generation.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Andrewy-gh/fittrack/server/internal/request"
 	"github.com/Andrewy-gh/fittrack/server/internal/workout"
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
@@ -45,11 +46,29 @@ func defineWorkoutDraftTool(g *genkit.Genkit, modelName string) ai.Tool {
 	return genkit.DefineTool(g, workoutDraftToolName,
 		workoutDraftToolDescription,
 		func(ctx *ai.ToolContext, input WorkoutGenerationToolInput) (*workout.CreateWorkoutRequest, error) {
+			startedAt := time.Now()
+			// Trace marker: shows when the outer chat model entered the workout draft tool.
+			logAIChatTraceContext(ctx, "workout_draft_tool_started",
+				"model", modelName,
+				"session_duration", input.SessionDuration,
+				"workout_focus", strings.TrimSpace(input.WorkoutFocus),
+				"request_id", request.GetRequestID(ctx),
+			)
 			if err := validateWorkoutGenerationToolInput(input); err != nil {
 				return nil, err
 			}
 
-			return generateWorkoutDraft(ctx, g, modelName, input, time.Now())
+			draft, err := generateWorkoutDraft(ctx, g, modelName, input, time.Now())
+			logAIChatTraceContext(ctx, "workout_draft_tool_finished",
+				"elapsed_ms", time.Since(startedAt).Milliseconds(),
+				"model", modelName,
+				"session_duration", input.SessionDuration,
+				"workout_focus", strings.TrimSpace(input.WorkoutFocus),
+				"exercise_count", workoutDraftExerciseCount(draft),
+				"error", traceError(err),
+				"request_id", request.GetRequestID(ctx),
+			)
+			return draft, err
 		},
 	)
 }
@@ -125,10 +144,33 @@ func generateWorkoutDraftWith(
 	userPrompt := buildWorkoutGenerationUserPrompt(input)
 
 	for attempt := 1; attempt <= 2; attempt++ {
+		attemptStartedAt := time.Now()
+		// Trace marker: each attempt is a structured model call; a second attempt means quality repair ran.
+		logAIChatTraceContext(ctx, "workout_draft_generation_attempt_started",
+			"attempt", attempt,
+			"model", modelName,
+			"session_duration", input.SessionDuration,
+			"workout_focus", strings.TrimSpace(input.WorkoutFocus),
+			"request_id", request.GetRequestID(ctx),
+		)
 		output, err := generator(ctx, g, modelName, systemPrompt, userPrompt)
 		if err != nil {
+			logAIChatTraceContext(ctx, "workout_draft_generation_attempt_finished",
+				"attempt", attempt,
+				"elapsed_ms", time.Since(attemptStartedAt).Milliseconds(),
+				"model", modelName,
+				"error", traceError(err),
+				"request_id", request.GetRequestID(ctx),
+			)
 			return nil, fmt.Errorf("generate workout draft: %w", err)
 		}
+		logAIChatTraceContext(ctx, "workout_draft_generation_attempt_finished",
+			"attempt", attempt,
+			"elapsed_ms", time.Since(attemptStartedAt).Milliseconds(),
+			"model", modelName,
+			"exercise_count", workoutDraftExerciseCount(output),
+			"request_id", request.GetRequestID(ctx),
+		)
 
 		normalizeWorkoutDraft(output)
 		if err := validateWorkoutDraft(output); err != nil {
@@ -143,10 +185,31 @@ func generateWorkoutDraftWith(
 			return nil, fmt.Errorf("validate workout draft quality after repair retry: %w", qualityErr)
 		}
 
+		// Trace marker: explains why the tool is about to spend time on a second model call.
+		logAIChatTraceContext(ctx, "workout_draft_quality_retry",
+			"attempt", attempt,
+			"model", modelName,
+			"reason", qualityErr.Error(),
+			"request_id", request.GetRequestID(ctx),
+		)
 		userPrompt = buildWorkoutGenerationRepairPrompt(input, qualityErr)
 	}
 
 	return nil, fmt.Errorf("generate workout draft: exhausted quality repair attempts")
+}
+
+func workoutDraftExerciseCount(draft *workout.CreateWorkoutRequest) int {
+	if draft == nil {
+		return 0
+	}
+	return len(draft.Exercises)
+}
+
+func traceError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 func buildWorkoutGenerationPrompt(input WorkoutGenerationToolInput, now time.Time) string {

--- a/server/setenv.example.sh
+++ b/server/setenv.example.sh
@@ -33,6 +33,7 @@ export DB_HEALTHCHECK=30s
 export GEMINI_API_KEY="your-gemini-api-key"
 # export GOOGLE_API_KEY="your-google-api-key"
 # export GEMINI_MODEL="googleai/gemini-2.5-flash"
+# export AI_CHAT_TRACE_LOGS=true # enables verbose AI chat stream timing logs for local debugging
 
 # Optional Inngest-backed AI chat recovery
 # export INNGEST_DEV="1" # or a dev server URL such as http://127.0.0.1:8288


### PR DESCRIPTION
## Summary
- add `AI_CHAT_TRACE_LOGS` to enable verbose AI chat stream timing only when needed
- route AI chat stream trace markers through the new gated helper
- document the local debugging flag and cover truthy/falsey values with tests

## Verification
- `go test ./internal/aichat`
- commit hook ran server `go test ./...`
- pre-push hook ran `make test-short`