### PR TITLE
Add AI chat sweep scenario selection

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -86,8 +86,17 @@ The command respects existing shell env first, then loads `server/.env` and `ser
 From `server/`, run real-provider AI chat scenario evals with:
 
 ```bash
+# Full single-turn default pack
 go run ./cmd/ai-chat-scenario-sweep -mode single_turn
+
+# Full two-turn default pack
 go run ./cmd/ai-chat-scenario-sweep -mode two_turn
+
+# Selected two-turn single scenario
+go run ./cmd/ai-chat-scenario-sweep -mode two_turn -scenario prompt-03
+
+# Selected two-turn batch
+go run ./cmd/ai-chat-scenario-sweep -mode two_turn -scenarios prompt-03,prompt-04,prompt-12
 ```
 
 Expected env var: `GEMINI_API_KEY` or `GOOGLE_API_KEY`
@@ -101,9 +110,12 @@ Optional flags:
 
 - `-mode single_turn` runs one assistant turn for each default scenario
 - `-mode two_turn` answers configured follow-up questions after the assistant asks one
+- `-scenario prompt-03` runs one scenario id from the default pack
+- `-scenarios prompt-03,prompt-04,prompt-12` runs selected scenario ids while preserving default-pack order
+- `-from prompt-03 -to prompt-08` runs an inclusive contiguous id range in default-pack order
 - `-timeout 15m` limits the full sweep wall-clock runtime; lower it for quick checks or raise it for slower provider runs
 
-The command writes a JSON report to `FITTRACK_AI_CHAT_SWEEP_OUT` when set, otherwise to `~/.codex/diagrams/fittrack-ai-chat-scenario-sweep.json`. The summary includes structured draft count, follow-up count, text-only count, error count, and conversion rates so model or prompt changes can be compared across runs.
+The command writes a JSON report to `FITTRACK_AI_CHAT_SWEEP_OUT` when set, otherwise to `~/.codex/diagrams/fittrack-ai-chat-scenario-sweep.json`. The summary includes structured draft count, follow-up count, text-only count, error count, and conversion rates so model or prompt changes can be compared across runs. When scenario selection flags are used, `scenario_count`, summary totals, results, and stderr progress include only the selected scenarios.
 
 ### AI Chat Runtime
 

--- a/server/cmd/ai-chat-scenario-sweep/main.go
+++ b/server/cmd/ai-chat-scenario-sweep/main.go
@@ -32,12 +32,25 @@ func (stubFeatureAccessReader) ListCurrentUserAccess(context.Context) ([]feature
 func main() {
 	mode := flag.String("mode", aichateval.ModeSingleTurn, "eval mode: single_turn or two_turn")
 	timeout := flag.Duration("timeout", defaultRunTimeout, "maximum wall-clock runtime for the full scenario sweep")
+	scenarioID := flag.String("scenario", "", "run one scenario id from the default pack, for example prompt-03")
+	scenarioIDs := flag.String("scenarios", "", "run comma-separated scenario ids from the default pack, for example prompt-03,prompt-04")
+	fromID := flag.String("from", "", "run an inclusive scenario id range starting at this id")
+	toID := flag.String("to", "", "run an inclusive scenario id range ending at this id")
 	flag.Parse()
 	if err := aichateval.ValidateMode(*mode); err != nil {
 		fail("%v", err)
 	}
 	if *timeout <= 0 {
 		fail("timeout must be greater than zero")
+	}
+	scenarios, err := aichateval.FilterScenarios(aichateval.DefaultScenarios(), aichateval.ScenarioSelection{
+		ScenarioID:  *scenarioID,
+		ScenarioIDs: *scenarioIDs,
+		FromID:      *fromID,
+		ToID:        *toID,
+	})
+	if err != nil {
+		fail("invalid scenario selection: %v", err)
 	}
 	if err := loadLocalEnv(); err != nil {
 		fail("failed to load local env files: %v", err)
@@ -56,7 +69,7 @@ func main() {
 		fail("ai chat runtime unavailable. Set GEMINI_API_KEY or GOOGLE_API_KEY in your shell, server/.env, or server/setenv.sh")
 	}
 
-	report := aichateval.Run(runtimeCtx, runtime, aichateval.DefaultScenarios(), aichateval.RunOptions{
+	report := aichateval.Run(runtimeCtx, runtime, scenarios, aichateval.RunOptions{
 		Mode: *mode,
 		OnScenario: func(item aichateval.Scenario) {
 			fmt.Fprintf(os.Stderr, "Running %s: %s\n", item.ID, item.Title)

--- a/server/internal/aichateval/selection.go
+++ b/server/internal/aichateval/selection.go
@@ -1,0 +1,144 @@
+package aichateval
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ScenarioSelection describes a narrow subset of the default scenario pack.
+type ScenarioSelection struct {
+	ScenarioID  string
+	ScenarioIDs string
+	FromID      string
+	ToID        string
+}
+
+// FilterScenarios returns scenarios matching one selection mode while preserving pack order.
+func FilterScenarios(scenarios []Scenario, selection ScenarioSelection) ([]Scenario, error) {
+	singleID, err := normalizedID(selection.ScenarioID, "scenario")
+	if err != nil {
+		return nil, err
+	}
+	listIDs, err := normalizedIDs(selection.ScenarioIDs)
+	if err != nil {
+		return nil, err
+	}
+	fromID, err := normalizedID(selection.FromID, "from")
+	if err != nil {
+		return nil, err
+	}
+	toID, err := normalizedID(selection.ToID, "to")
+	if err != nil {
+		return nil, err
+	}
+
+	hasSingle := singleID != ""
+	hasList := len(listIDs) > 0
+	hasRange := fromID != "" || toID != ""
+	if hasSingle && hasList {
+		return nil, fmt.Errorf("use only one of scenario or scenarios")
+	}
+	if hasRange && (hasSingle || hasList) {
+		return nil, fmt.Errorf("range selection cannot be combined with scenario or scenarios")
+	}
+	if hasRange {
+		return filterScenarioRange(scenarios, fromID, toID)
+	}
+	if hasSingle {
+		listIDs = []string{singleID}
+	}
+	if len(listIDs) == 0 {
+		return append([]Scenario(nil), scenarios...), nil
+	}
+	return filterScenarioIDs(scenarios, listIDs)
+}
+
+func filterScenarioIDs(scenarios []Scenario, ids []string) ([]Scenario, error) {
+	wanted := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		wanted[id] = true
+	}
+
+	filtered := make([]Scenario, 0, len(ids))
+	for _, scenario := range scenarios {
+		if wanted[scenario.ID] {
+			filtered = append(filtered, scenario)
+			delete(wanted, scenario.ID)
+		}
+	}
+	if len(wanted) > 0 {
+		return nil, fmt.Errorf("unknown scenario id(s): %s", joinUnknownIDs(ids, wanted))
+	}
+	return filtered, nil
+}
+
+func filterScenarioRange(scenarios []Scenario, fromID string, toID string) ([]Scenario, error) {
+	if fromID == "" || toID == "" {
+		return nil, fmt.Errorf("from and to must both be provided for range selection")
+	}
+
+	start := -1
+	end := -1
+	for index, scenario := range scenarios {
+		if scenario.ID == fromID {
+			start = index
+		}
+		if scenario.ID == toID {
+			end = index
+		}
+	}
+
+	var unknown []string
+	if start == -1 {
+		unknown = append(unknown, fromID)
+	}
+	if end == -1 {
+		unknown = append(unknown, toID)
+	}
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf("unknown scenario id(s): %s", strings.Join(unknown, ", "))
+	}
+	if start > end {
+		return nil, fmt.Errorf("from scenario %q must not come after to scenario %q", fromID, toID)
+	}
+	return append([]Scenario(nil), scenarios[start:end+1]...), nil
+}
+
+func normalizedID(id string, flagName string) (string, error) {
+	trimmed := strings.TrimSpace(id)
+	if id != "" && trimmed == "" {
+		return "", fmt.Errorf("%s must include a scenario id", flagName)
+	}
+	return trimmed, nil
+}
+
+func normalizedIDs(raw string) ([]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("scenarios must include at least one scenario id")
+	}
+
+	parts := strings.Split(raw, ",")
+	ids := make([]string, 0, len(parts))
+	for _, part := range parts {
+		id := strings.TrimSpace(part)
+		if id == "" {
+			return nil, fmt.Errorf("scenarios must not include empty scenario ids")
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func joinUnknownIDs(ids []string, unknown map[string]bool) string {
+	ordered := make([]string, 0, len(unknown))
+	for _, id := range ids {
+		if unknown[id] {
+			ordered = append(ordered, id)
+			delete(unknown, id)
+		}
+	}
+	return strings.Join(ordered, ", ")
+}

--- a/server/internal/aichateval/selection_test.go
+++ b/server/internal/aichateval/selection_test.go
@@ -1,0 +1,109 @@
+package aichateval
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFilterScenariosNoSelectionReturnsAll(t *testing.T) {
+	scenarios := selectionTestScenarios()
+
+	got, err := FilterScenarios(scenarios, ScenarioSelection{})
+
+	if err != nil {
+		t.Fatalf("FilterScenarios() error = %v, want nil", err)
+	}
+	if gotIDs(got) != "prompt-01,prompt-02,prompt-03,prompt-04" {
+		t.Fatalf("FilterScenarios() ids = %s, want all ids", gotIDs(got))
+	}
+}
+
+func TestFilterScenariosSingleIDReturnsOne(t *testing.T) {
+	got, err := FilterScenarios(selectionTestScenarios(), ScenarioSelection{ScenarioID: "prompt-03"})
+
+	if err != nil {
+		t.Fatalf("FilterScenarios() error = %v, want nil", err)
+	}
+	if gotIDs(got) != "prompt-03" {
+		t.Fatalf("FilterScenarios() ids = %s, want prompt-03", gotIDs(got))
+	}
+}
+
+func TestFilterScenariosCommaSeparatedIDsPreservePackOrder(t *testing.T) {
+	got, err := FilterScenarios(selectionTestScenarios(), ScenarioSelection{ScenarioIDs: "prompt-04,prompt-02"})
+
+	if err != nil {
+		t.Fatalf("FilterScenarios() error = %v, want nil", err)
+	}
+	if gotIDs(got) != "prompt-02,prompt-04" {
+		t.Fatalf("FilterScenarios() ids = %s, want default-pack order", gotIDs(got))
+	}
+}
+
+func TestFilterScenariosUnknownIDFails(t *testing.T) {
+	_, err := FilterScenarios(selectionTestScenarios(), ScenarioSelection{ScenarioIDs: "prompt-02,prompt-99"})
+
+	if err == nil {
+		t.Fatal("FilterScenarios() error = nil, want unknown id error")
+	}
+	if !strings.Contains(err.Error(), "unknown scenario id(s): prompt-99") {
+		t.Fatalf("FilterScenarios() error = %q, want unknown id", err.Error())
+	}
+}
+
+func TestFilterScenariosRangeReturnsInclusiveScenarios(t *testing.T) {
+	got, err := FilterScenarios(selectionTestScenarios(), ScenarioSelection{FromID: "prompt-02", ToID: "prompt-04"})
+
+	if err != nil {
+		t.Fatalf("FilterScenarios() error = %v, want nil", err)
+	}
+	if gotIDs(got) != "prompt-02,prompt-03,prompt-04" {
+		t.Fatalf("FilterScenarios() ids = %s, want inclusive range", gotIDs(got))
+	}
+}
+
+func TestFilterScenariosRejectsAmbiguousSelection(t *testing.T) {
+	_, err := FilterScenarios(selectionTestScenarios(), ScenarioSelection{
+		ScenarioID:  "prompt-01",
+		ScenarioIDs: "prompt-02",
+	})
+
+	if err == nil {
+		t.Fatal("FilterScenarios() error = nil, want ambiguous selection error")
+	}
+	if !strings.Contains(err.Error(), "use only one of scenario or scenarios") {
+		t.Fatalf("FilterScenarios() error = %q, want ambiguous selection", err.Error())
+	}
+}
+
+func TestFilterScenariosRejectsRangeCombinedWithIDs(t *testing.T) {
+	_, err := FilterScenarios(selectionTestScenarios(), ScenarioSelection{
+		ScenarioIDs: "prompt-01,prompt-02",
+		FromID:      "prompt-03",
+		ToID:        "prompt-04",
+	})
+
+	if err == nil {
+		t.Fatal("FilterScenarios() error = nil, want range combination error")
+	}
+	if !strings.Contains(err.Error(), "range selection cannot be combined") {
+		t.Fatalf("FilterScenarios() error = %q, want range combination error", err.Error())
+	}
+}
+
+func selectionTestScenarios() []Scenario {
+	return []Scenario{
+		{ID: "prompt-01", Title: "One"},
+		{ID: "prompt-02", Title: "Two"},
+		{ID: "prompt-03", Title: "Three"},
+		{ID: "prompt-04", Title: "Four"},
+	}
+}
+
+func gotIDs(scenarios []Scenario) string {
+	ids := make([]string, 0, len(scenarios))
+	for _, scenario := range scenarios {
+		ids = append(ids, scenario.ID)
+	}
+	return strings.Join(ids, ",")
+}


### PR DESCRIPTION
## Summary
- add CLI selection flags for one scenario, comma-separated scenario ids, and inclusive id ranges
- keep sweep reports and progress scoped to the filtered scenario list
- document selected two-turn sweep examples

## Verification
- cd server && go test ./internal/aichateval ./cmd/ai-chat-scenario-sweep
- cd server && go test ./internal/aichat
- commit hook also ran broader server tests successfully

Did not run a live Gemini sweep; this PR is tooling only.