### PR TITLE
fix: discard zeroed warmup set drafts

### DIFF
--- a/client/src/routes/_layout/workouts/-components/__tests__/workout-form-helpers.test.ts
+++ b/client/src/routes/_layout/workouts/-components/__tests__/workout-form-helpers.test.ts
@@ -29,6 +29,16 @@ describe("workout-form-helpers", () => {
       ).toBe(true);
     });
 
+    it("treats zeroed warmup set as empty", () => {
+      expect(
+        isSetEmptyForDismiss({
+          reps: 0,
+          weight: 0,
+          setType: "warmup",
+        }),
+      ).toBe(true);
+    });
+
     it("treats set with reps as non-empty", () => {
       expect(
         isSetEmptyForDismiss({

--- a/client/src/routes/_layout/workouts/-components/workout-form-helpers.ts
+++ b/client/src/routes/_layout/workouts/-components/workout-form-helpers.ts
@@ -7,17 +7,14 @@ type WorkoutSetLike = {
   setType?: string | null;
 };
 
-const DEFAULT_SET_TYPE = "working";
-
 export const validateSetReps = (value: unknown) =>
   compose(minValue(1), maxValue(1000))(value, "Reps");
 
 export const isSetEmptyForDismiss = (set?: WorkoutSetLike): boolean => {
   const weight = Number(set?.weight ?? 0);
   const reps = Number(set?.reps ?? 0);
-  const setType = set?.setType ?? DEFAULT_SET_TYPE;
 
-  return weight <= 0 && reps <= 0 && setType === DEFAULT_SET_TYPE;
+  return weight <= 0 && reps <= 0;
 };
 
 export const shouldDiscardNewExerciseAfterSetRemoval = (

--- a/client/tests/e2e/demo/workout-create.test.ts
+++ b/client/tests/e2e/demo/workout-create.test.ts
@@ -115,7 +115,9 @@ test.describe("Demo Mode - Workout Create", () => {
     // TODO(issue-81): overlay dismissal currently preserves the zeroed set.
   });
 
-  test("should keep set when only set type changes", async ({ page }) => {
+  test("should discard zeroed warmup set when the dialog is closed", async ({
+    page,
+  }) => {
     await page.getByRole("link", { name: /new workout/i }).click();
 
     await page.getByRole("link", { name: /add exercise/i }).click();
@@ -128,13 +130,15 @@ test.describe("Demo Mode - Workout Create", () => {
     await page
       .locator('[data-slot="select-item"]', { hasText: /warmup/i })
       .click();
-    await expect(
-      page.getByRole("button", { name: /remove set/i }),
-    ).toBeVisible();
+    await expect(page.getByRole("button", { name: /cancel/i })).toBeVisible();
 
     await page.getByRole("button", { name: /close/i }).click();
     await expect(page.getByRole("dialog")).toHaveCount(0);
-    await expect(page.getByTestId("exercise-card")).toHaveCount(1);
+    await expect(
+      page.getByRole("heading", { name: /today's training/i }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/workouts\/new$/);
+    await expect(exerciseCards(page)).toHaveCount(0);
   });
 
   test("should persist created workout to localStorage", async ({ page }) => {


### PR DESCRIPTION
## Summary
- treat zero-rep, zero-weight sets as empty regardless of set type
- update the existing demo E2E coverage so zeroed warm-up drafts are discarded on dialog close
- keep the change scoped to the frontend workout form path

## Verification
- bun run lint
- bun run tsc
- bun run test
- bun run build
- bun run test:e2e -- tests/e2e/demo/workout-create.test.ts -g "discard zeroed warmup"
- pre-commit: oxfmt --check, oxlint, knip, vitest run

Visual verification bundle: C:/Users/lenny/.codex/diagrams/verification-warmup-set/index.html
