### PR TITLE
Fix exercise creation for partial-name matches

### DIFF
--- a/client/src/routes/_layout/workouts/-components/__tests__/add-exercise-screen.test.tsx
+++ b/client/src/routes/_layout/workouts/-components/__tests__/add-exercise-screen.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  WorkoutCreateWorkoutRequest,
+  WorkoutExerciseInput,
+} from "@/client";
+import { useAppForm } from "@/hooks/form";
+import { AddExerciseScreen } from "../add-exercise-screen";
+
+const navigateMock = vi.fn();
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-router")>();
+
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock("@/routes/_layout/workouts/new", () => ({
+  Route: {
+    fullPath: "/_layout/workouts/new",
+  },
+}));
+
+function AddExerciseScreenHarness() {
+  const defaultValues: WorkoutCreateWorkoutRequest = {
+    date: new Date().toISOString(),
+    exercises: [] as WorkoutExerciseInput[],
+    notes: "",
+    workoutFocus: "",
+  };
+  const form = useAppForm({
+    defaultValues,
+    onSubmit: async () => undefined,
+  });
+
+  return (
+    <AddExerciseScreen
+      form={form}
+      exercises={[{ id: 1, name: "Incline Hammer Curl" }]}
+      onBack={vi.fn()}
+    />
+  );
+}
+
+describe("AddExerciseScreen", () => {
+  it("allows creating an exercise when the search is only a partial match", () => {
+    render(<AddExerciseScreenHarness />);
+
+    fireEvent.change(screen.getByLabelText("Search exercises"), {
+      target: { value: "Hammer Curl" },
+    });
+
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+    expect(screen.getByText("Incline Hammer Curl")).toBeInTheDocument();
+  });
+
+  it("does not show Add when the search exactly matches an existing exercise", () => {
+    render(<AddExerciseScreenHarness />);
+
+    fireEvent.change(screen.getByLabelText("Search exercises"), {
+      target: { value: " incline hammer curl " },
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Add" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/src/routes/_layout/workouts/-components/add-exercise-screen.tsx
+++ b/client/src/routes/_layout/workouts/-components/add-exercise-screen.tsx
@@ -18,6 +18,10 @@ type AddExerciseScreenProps = {
   onAddExercise?: (index: number, isNewExercise?: boolean) => void; // Optional callback for when exercise is added (used by edit.tsx)
 };
 
+function normalizeExerciseName(name: string) {
+  return name.trim().toLowerCase();
+}
+
 export const AddExerciseScreen = withForm({
   defaultValues: MOCK_VALUES,
   props: {} as AddExerciseScreenProps,
@@ -31,6 +35,14 @@ export const AddExerciseScreen = withForm({
     const filteredExercises = workingExercises.filter((exercise) =>
       exercise.name.toLowerCase().includes(searchQuery.toLowerCase()),
     );
+    const trimmedSearchQuery = searchQuery.trim();
+    const canCreateExercise =
+      normalizeExerciseName(trimmedSearchQuery).length > 0 &&
+      !workingExercises.some(
+        (exercise) =>
+          normalizeExerciseName(exercise.name) ===
+          normalizeExerciseName(trimmedSearchQuery),
+      );
 
     return (
       <main>
@@ -53,17 +65,17 @@ export const AddExerciseScreen = withForm({
               mode="array"
               children={(field) => (
                 <>
-                  {filteredExercises.length === 0 && (
+                  {canCreateExercise && (
                     <Button
                       size="sm"
                       onClick={() => {
                         const newExercise: ExerciseOption = {
                           id: null, // null ID for new exercises not yet in the database
-                          name: searchQuery,
+                          name: trimmedSearchQuery,
                         };
                         setWorkingExercises((prev) => [...prev, newExercise]);
                         field.pushValue({
-                          name: searchQuery,
+                          name: trimmedSearchQuery,
                           sets: [],
                         });
                         const exerciseIndex = field.state.value.length - 1;


### PR DESCRIPTION
## Summary
- Allow creating a new exercise when the search text is only a partial match for existing exercise variants.
- Keep exact duplicate protection by comparing trimmed, case-insensitive exercise names.
- Add regression coverage for the Hammer Curl vs Incline Hammer Curl behavior.

## Verification
- `bun run lint`
- `bun run tsc`
- `bun run test`
- `bun run build`
- Focused format check for `add-exercise-screen.test.tsx`

## Notes
- Built a local visual explainer with video at `C:\Users\lenny\.codex\diagrams\exercise-add-partial-match-demo\index.html`.