### PR TITLE
refactor: move analytics into vertical feature

### DIFF
--- a/client/src/features/analytics/components/analytics-dashboard.tsx
+++ b/client/src/features/analytics/components/analytics-dashboard.tsx
@@ -7,11 +7,11 @@ import { ExerciseMetricCharts } from "@/features/exercises/components/exercise-m
 import { GenericCombobox } from "@/components/generic-combobox";
 import { Card, CardContent } from "@/components/ui/card";
 import { WorkoutContributionGraph } from "@/features/workouts/components/workout-contribution-graph";
-import { getWorkoutSummary } from "@/lib/analytics";
-import { AnalyticsSummaryCards } from "./analytics-summary-cards";
-import { WorkoutVolumeChart } from "./workout-volume-chart";
+import { getWorkoutSummary } from "@/features/analytics/utils/analytics-workouts";
+import { AnalyticsSummaryCards } from "@/features/analytics/components/analytics-summary-cards";
+import { WorkoutVolumeChart } from "@/features/analytics/components/workout-volume-chart";
 
-export interface AnalyticsPageProps {
+export interface AnalyticsDashboardProps {
   isLoadingExercises: boolean;
   exercises: ExerciseExerciseResponse[];
   selectedExerciseId?: number;
@@ -23,7 +23,7 @@ export interface AnalyticsPageProps {
   workoutFocusValues?: string[];
 }
 
-export function AnalyticsPage({
+export function AnalyticsDashboard({
   isLoadingExercises,
   exercises,
   selectedExerciseId,
@@ -33,7 +33,7 @@ export function AnalyticsPage({
   isDemoMode,
   workoutContributionData,
   workoutFocusValues = [],
-}: AnalyticsPageProps) {
+}: AnalyticsDashboardProps) {
   const summary = getWorkoutSummary(workoutContributionData?.days);
 
   if (isLoadingExercises) {

--- a/client/src/features/analytics/components/analytics-summary-cards.tsx
+++ b/client/src/features/analytics/components/analytics-summary-cards.tsx
@@ -1,6 +1,6 @@
 import { Activity, BarChart3, Calendar, TrendingUp } from "lucide-react";
 import { StatsGrid } from "@/components/stats-grid";
-import type { AnalyticsWorkoutSummary } from "@/lib/analytics";
+import type { AnalyticsWorkoutSummary } from "@/features/analytics/utils/analytics-workouts";
 
 export interface AnalyticsSummaryCardsProps {
   summary: AnalyticsWorkoutSummary;

--- a/client/src/features/analytics/components/workout-volume-chart.tsx
+++ b/client/src/features/analytics/components/workout-volume-chart.tsx
@@ -14,7 +14,7 @@ import {
   buildWorkoutVolumeChartData,
   getWorkoutVolumeBucketLabel,
   getWorkoutVolumeTitle,
-} from "@/lib/analytics";
+} from "@/features/analytics/utils/analytics-workouts";
 
 const ALL_FOCUS_VALUE = "all";
 

--- a/client/src/features/analytics/pages/analytics-page.tsx
+++ b/client/src/features/analytics/pages/analytics-page.tsx
@@ -1,0 +1,86 @@
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+
+import { AnalyticsDashboard } from "@/features/analytics/components/analytics-dashboard";
+import {
+  exerciseByIdQueryOptions,
+  exercisesQueryOptions,
+} from "@/features/exercises/api/exercises";
+import {
+  contributionDataQueryOptions,
+  workoutsFocusValuesQueryOptions,
+} from "@/features/workouts/api/workouts";
+import {
+  getDemoContributionDataQueryOptions,
+  getDemoExercisesByIdQueryOptions,
+  getDemoExercisesQueryOptions,
+  getDemoWorkoutsFocusValuesQueryOptions,
+} from "@/lib/demo-data/query-options";
+
+type AnalyticsPageProps = {
+  exerciseId?: number;
+  isDemoMode: boolean;
+};
+
+export function AnalyticsPage({ exerciseId, isDemoMode }: AnalyticsPageProps) {
+  const navigate = useNavigate({ from: "/analytics" });
+
+  const { data: exercises } = isDemoMode
+    ? useSuspenseQuery(getDemoExercisesQueryOptions())
+    : useSuspenseQuery(exercisesQueryOptions());
+
+  const selectedExerciseId =
+    exerciseId && exercises.some((exercise) => exercise.id === exerciseId)
+      ? exerciseId
+      : exercises[0]?.id;
+
+  const exerciseDetailQuery = isDemoMode
+    ? useQuery({
+        ...getDemoExercisesByIdQueryOptions(selectedExerciseId ?? 0),
+        enabled: Boolean(selectedExerciseId),
+      })
+    : useQuery({
+        ...exerciseByIdQueryOptions(selectedExerciseId ?? 0),
+        enabled: Boolean(selectedExerciseId),
+      });
+
+  const authedContributionQuery = useQuery({
+    ...contributionDataQueryOptions(),
+    enabled: !isDemoMode,
+  });
+  const demoContributionQuery = useQuery({
+    ...getDemoContributionDataQueryOptions(),
+    enabled: isDemoMode,
+  });
+  const authedFocusValuesQuery = useQuery({
+    ...workoutsFocusValuesQueryOptions(),
+    enabled: !isDemoMode,
+  });
+  const demoFocusValuesQuery = useQuery({
+    ...getDemoWorkoutsFocusValuesQueryOptions(),
+    enabled: isDemoMode,
+  });
+
+  const workoutContributionData = isDemoMode
+    ? demoContributionQuery.data
+    : authedContributionQuery.data;
+  const workoutFocusValues = isDemoMode
+    ? (demoFocusValuesQuery.data ?? [])
+    : (authedFocusValuesQuery.data ?? []);
+
+  return (
+    <AnalyticsDashboard
+      isLoadingExercises={false}
+      exercises={exercises}
+      selectedExerciseId={selectedExerciseId}
+      onSelectExercise={(id) =>
+        navigate({ search: (prev) => ({ ...prev, exerciseId: id }) })
+      }
+      isLoadingDetails={exerciseDetailQuery.isLoading}
+      exerciseSets={exerciseDetailQuery.data?.sets}
+      isDemoMode={isDemoMode}
+      workoutContributionData={workoutContributionData}
+      workoutFocusValues={workoutFocusValues}
+    />
+  );
+}

--- a/client/src/features/analytics/utils/analytics-workouts.test.ts
+++ b/client/src/features/analytics/utils/analytics-workouts.test.ts
@@ -1,118 +1,65 @@
 import { describe, expect, it } from "vitest";
+import type { WorkoutContributionDataResponse } from "@/client";
 import {
-  buildDemoContributionData,
   buildWorkoutVolumeChartData,
   getWorkoutVolumeBucketLabel,
   getWorkoutVolumeTitle,
   getWorkoutSummary,
-  type DemoContributionWorkout,
-} from "./analytics";
+} from "@/features/analytics/utils/analytics-workouts";
 
-function workout(
-  overrides: Partial<DemoContributionWorkout>,
-): DemoContributionWorkout {
-  return {
-    id: 0,
-    date: "",
-    workout_focus: null,
-    volume: 0,
-    workingSetCount: 0,
-    ...overrides,
-  };
+function contributionDays(
+  days: WorkoutContributionDataResponse["days"],
+): WorkoutContributionDataResponse["days"] {
+  return days;
 }
 
-describe("analytics", () => {
-  it("builds sorted contribution data from demo workouts", () => {
-    const data = buildDemoContributionData([
-      workout({
-        id: 2,
-        date: "2026-03-12T08:00:00.000Z",
-        workout_focus: "Upper",
-        volume: 3600,
-        workingSetCount: 3,
-      }),
-      workout({
-        id: 1,
-        date: "2026-03-10T07:00:00.000Z",
-        workout_focus: "Lower",
-        volume: 2800,
-        workingSetCount: 2,
-      }),
-      workout({
-        id: 3,
-        date: "2026-03-12T17:00:00.000Z",
-        workout_focus: "Conditioning",
-        volume: 1800,
-        workingSetCount: 4,
-      }),
-    ]);
-
-    expect(data).toEqual({
-      days: [
-        {
-          date: "2026-03-10",
-          count: 2,
-          level: 1,
-          workouts: [
-            {
-              id: 1,
-              focus: "Lower",
-              time: "2026-03-10T07:00:00.000Z",
-              volume: 2800,
-            },
-          ],
-        },
-        {
-          date: "2026-03-12",
-          count: 7,
-          level: 2,
-          workouts: [
-            {
-              id: 2,
-              focus: "Upper",
-              time: "2026-03-12T08:00:00.000Z",
-              volume: 3600,
-            },
-            {
-              id: 3,
-              focus: "Conditioning",
-              time: "2026-03-12T17:00:00.000Z",
-              volume: 1800,
-            },
-          ],
-        },
-      ],
-    });
-  });
-
+describe("analytics workout helpers", () => {
   it("builds workout volume buckets for focus-filtered chart ranges", () => {
-    const data = buildDemoContributionData([
-      workout({
-        id: 1,
-        date: "2026-03-21T08:00:00.000Z",
-        workout_focus: "Push",
-        volume: 1800,
-        workingSetCount: 3,
-      }),
-      workout({
-        id: 2,
-        date: "2026-03-22T08:00:00.000Z",
-        workout_focus: "Pull",
-        volume: 2200,
-        workingSetCount: 4,
-      }),
-      workout({
-        id: 3,
-        date: "2026-03-23T08:00:00.000Z",
-        workout_focus: "Push",
-        volume: 2600,
-        workingSetCount: 5,
-      }),
+    const days = contributionDays([
+      {
+        date: "2026-03-21",
+        count: 3,
+        level: 1,
+        workouts: [
+          {
+            id: 1,
+            focus: "Push",
+            time: "2026-03-21T08:00:00.000Z",
+            volume: 1800,
+          },
+        ],
+      },
+      {
+        date: "2026-03-22",
+        count: 4,
+        level: 1,
+        workouts: [
+          {
+            id: 2,
+            focus: "Pull",
+            time: "2026-03-22T08:00:00.000Z",
+            volume: 2200,
+          },
+        ],
+      },
+      {
+        date: "2026-03-23",
+        count: 5,
+        level: 1,
+        workouts: [
+          {
+            id: 3,
+            focus: "Push",
+            time: "2026-03-23T08:00:00.000Z",
+            volume: 2600,
+          },
+        ],
+      },
     ]);
 
     expect(
       buildWorkoutVolumeChartData(
-        data.days,
+        days,
         "W",
         "Push",
         new Date("2026-03-23T12:00:00.000Z"),
@@ -134,33 +81,44 @@ describe("analytics", () => {
   });
 
   it("adds focus types to all-focus daily workout volume buckets", () => {
-    const data = buildDemoContributionData([
-      workout({
-        id: 1,
-        date: "2026-03-21T08:00:00.000Z",
-        workout_focus: "Push",
-        volume: 1800,
-        workingSetCount: 3,
-      }),
-      workout({
-        id: 2,
-        date: "2026-03-21T18:00:00.000Z",
-        workout_focus: "Pull",
-        volume: 2200,
-        workingSetCount: 4,
-      }),
-      workout({
-        id: 3,
-        date: "2026-03-23T08:00:00.000Z",
-        workout_focus: "Push",
-        volume: 2600,
-        workingSetCount: 5,
-      }),
+    const days = contributionDays([
+      {
+        date: "2026-03-21",
+        count: 7,
+        level: 2,
+        workouts: [
+          {
+            id: 1,
+            focus: "Push",
+            time: "2026-03-21T08:00:00.000Z",
+            volume: 1800,
+          },
+          {
+            id: 2,
+            focus: "Pull",
+            time: "2026-03-21T18:00:00.000Z",
+            volume: 2200,
+          },
+        ],
+      },
+      {
+        date: "2026-03-23",
+        count: 5,
+        level: 1,
+        workouts: [
+          {
+            id: 3,
+            focus: "Push",
+            time: "2026-03-23T08:00:00.000Z",
+            volume: 2600,
+          },
+        ],
+      },
     ]);
 
     expect(
       buildWorkoutVolumeChartData(
-        data.days,
+        days,
         "W",
         undefined,
         new Date("2026-03-23T12:00:00.000Z"),
@@ -182,33 +140,51 @@ describe("analytics", () => {
   });
 
   it("adds focus types to all-focus weekly and monthly volume buckets", () => {
-    const data = buildDemoContributionData([
-      workout({
-        id: 1,
-        date: "2026-03-16T08:00:00.000Z",
-        workout_focus: "Push",
-        volume: 1800,
-        workingSetCount: 3,
-      }),
-      workout({
-        id: 2,
-        date: "2026-03-17T18:00:00.000Z",
-        workout_focus: "Pull",
-        volume: 2200,
-        workingSetCount: 4,
-      }),
-      workout({
-        id: 3,
-        date: "2026-04-01T08:00:00.000Z",
-        workout_focus: "Legs",
-        volume: 2600,
-        workingSetCount: 5,
-      }),
+    const days = contributionDays([
+      {
+        date: "2026-03-16",
+        count: 3,
+        level: 1,
+        workouts: [
+          {
+            id: 1,
+            focus: "Push",
+            time: "2026-03-16T08:00:00.000Z",
+            volume: 1800,
+          },
+        ],
+      },
+      {
+        date: "2026-03-17",
+        count: 4,
+        level: 1,
+        workouts: [
+          {
+            id: 2,
+            focus: "Pull",
+            time: "2026-03-17T18:00:00.000Z",
+            volume: 2200,
+          },
+        ],
+      },
+      {
+        date: "2026-04-01",
+        count: 5,
+        level: 1,
+        workouts: [
+          {
+            id: 3,
+            focus: "Legs",
+            time: "2026-04-01T08:00:00.000Z",
+            volume: 2600,
+          },
+        ],
+      },
     ]);
 
     expect(
       buildWorkoutVolumeChartData(
-        data.days,
+        days,
         "6M",
         undefined,
         new Date("2026-04-05T12:00:00.000Z"),
@@ -230,7 +206,7 @@ describe("analytics", () => {
 
     expect(
       buildWorkoutVolumeChartData(
-        data.days,
+        days,
         "Y",
         undefined,
         new Date("2026-04-05T12:00:00.000Z"),

--- a/client/src/features/analytics/utils/analytics-workouts.ts
+++ b/client/src/features/analytics/utils/analytics-workouts.ts
@@ -10,54 +10,6 @@ export interface AnalyticsWorkoutSummary {
   longestStreak: number;
 }
 
-export interface DemoContributionWorkout {
-  id: number;
-  date: string;
-  workout_focus?: string | null;
-  volume: number;
-  workingSetCount: number;
-}
-
-export function buildDemoContributionData(
-  workouts: DemoContributionWorkout[],
-): WorkoutContributionDataResponse {
-  const byDate = new Map<string, DemoContributionWorkout[]>();
-
-  for (const workout of workouts) {
-    const day = (workout.date || "").split("T")[0];
-    if (!day) continue;
-
-    const list = byDate.get(day) ?? [];
-    list.push(workout);
-    byDate.set(day, list);
-  }
-
-  const days = Array.from(byDate.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([date, items]) => {
-      const count = items.reduce(
-        (sum, workout) => sum + workout.workingSetCount,
-        0,
-      );
-      const level =
-        count === 0 ? 0 : count < 6 ? 1 : count < 11 ? 2 : count < 16 ? 3 : 4;
-
-      return {
-        date,
-        count,
-        level,
-        workouts: items.map((workout) => ({
-          id: workout.id,
-          focus: workout.workout_focus ?? undefined,
-          time: workout.date,
-          volume: workout.volume,
-        })),
-      };
-    });
-
-  return { days };
-}
-
 export function getWorkoutSummary(
   days: WorkoutContributionDataResponse["days"] = [],
   today: Date = new Date(),

--- a/client/src/lib/demo-data/contribution-data.test.ts
+++ b/client/src/lib/demo-data/contribution-data.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDemoContributionData,
+  type DemoContributionWorkout,
+} from "@/lib/demo-data/contribution-data";
+
+function workout(
+  overrides: Partial<DemoContributionWorkout>,
+): DemoContributionWorkout {
+  return {
+    id: 0,
+    date: "",
+    workout_focus: null,
+    volume: 0,
+    workingSetCount: 0,
+    ...overrides,
+  };
+}
+
+describe("demo contribution data", () => {
+  it("builds sorted contribution data from demo workouts", () => {
+    const data = buildDemoContributionData([
+      workout({
+        id: 2,
+        date: "2026-03-12T08:00:00.000Z",
+        workout_focus: "Upper",
+        volume: 3600,
+        workingSetCount: 3,
+      }),
+      workout({
+        id: 1,
+        date: "2026-03-10T07:00:00.000Z",
+        workout_focus: "Lower",
+        volume: 2800,
+        workingSetCount: 2,
+      }),
+      workout({
+        id: 3,
+        date: "2026-03-12T17:00:00.000Z",
+        workout_focus: "Conditioning",
+        volume: 1800,
+        workingSetCount: 4,
+      }),
+    ]);
+
+    expect(data).toEqual({
+      days: [
+        {
+          date: "2026-03-10",
+          count: 2,
+          level: 1,
+          workouts: [
+            {
+              id: 1,
+              focus: "Lower",
+              time: "2026-03-10T07:00:00.000Z",
+              volume: 2800,
+            },
+          ],
+        },
+        {
+          date: "2026-03-12",
+          count: 7,
+          level: 2,
+          workouts: [
+            {
+              id: 2,
+              focus: "Upper",
+              time: "2026-03-12T08:00:00.000Z",
+              volume: 3600,
+            },
+            {
+              id: 3,
+              focus: "Conditioning",
+              time: "2026-03-12T17:00:00.000Z",
+              volume: 1800,
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/client/src/lib/demo-data/contribution-data.ts
+++ b/client/src/lib/demo-data/contribution-data.ts
@@ -1,0 +1,49 @@
+import type { WorkoutContributionDataResponse } from "@/client";
+
+export interface DemoContributionWorkout {
+  id: number;
+  date: string;
+  workout_focus?: string | null;
+  volume: number;
+  workingSetCount: number;
+}
+
+export function buildDemoContributionData(
+  workouts: DemoContributionWorkout[],
+): WorkoutContributionDataResponse {
+  const byDate = new Map<string, DemoContributionWorkout[]>();
+
+  for (const workout of workouts) {
+    const day = (workout.date || "").split("T")[0];
+    if (!day) continue;
+
+    const list = byDate.get(day) ?? [];
+    list.push(workout);
+    byDate.set(day, list);
+  }
+
+  const days = Array.from(byDate.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, items]) => {
+      const count = items.reduce(
+        (sum, workout) => sum + workout.workingSetCount,
+        0,
+      );
+      const level =
+        count === 0 ? 0 : count < 6 ? 1 : count < 11 ? 2 : count < 16 ? 3 : 4;
+
+      return {
+        date,
+        count,
+        level,
+        workouts: items.map((workout) => ({
+          id: workout.id,
+          focus: workout.workout_focus ?? undefined,
+          time: workout.date,
+          volume: workout.volume,
+        })),
+      };
+    });
+
+  return { days };
+}

--- a/client/src/lib/demo-data/query-options.ts
+++ b/client/src/lib/demo-data/query-options.ts
@@ -11,7 +11,7 @@ import type {
   WorkoutUpdateWorkoutRequest,
   ResponseSuccessResponse,
 } from "./types";
-import { buildDemoContributionData } from "@/lib/analytics";
+import { buildDemoContributionData } from "@/lib/demo-data/contribution-data";
 import {
   getAllExercises,
   getAllWorkoutsForContribution,

--- a/client/src/lib/demo-data/storage.ts
+++ b/client/src/lib/demo-data/storage.ts
@@ -27,7 +27,7 @@ import {
   handleDemoWorkoutUpdated,
   resetDemoHistorical1Rm,
 } from "./historical-1rm";
-import type { DemoContributionWorkout } from "@/lib/analytics";
+import type { DemoContributionWorkout } from "@/lib/demo-data/contribution-data";
 
 // ===========================
 // localStorage Utilities

--- a/client/src/routes/_layout/analytics.tsx
+++ b/client/src/routes/_layout/analytics.tsx
@@ -1,18 +1,13 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
-import { AnalyticsPage } from "@/components/analytics/analytics-page";
-import {
-  exerciseByIdQueryOptions,
-  exercisesQueryOptions,
-} from "@/features/exercises/api/exercises";
+import { AnalyticsPage } from "@/features/analytics/pages/analytics-page";
+import { exercisesQueryOptions } from "@/features/exercises/api/exercises";
 import {
   contributionDataQueryOptions,
   workoutsFocusValuesQueryOptions,
 } from "@/features/workouts/api/workouts";
 import {
   getDemoContributionDataQueryOptions,
-  getDemoExercisesByIdQueryOptions,
   getDemoExercisesQueryOptions,
   getDemoWorkoutsFocusValuesQueryOptions,
 } from "@/lib/demo-data/query-options";
@@ -53,64 +48,11 @@ export const Route = createFileRoute("/_layout/analytics")({
 function RouteComponent() {
   const { exerciseId } = Route.useSearch();
   const { user } = Route.useRouteContext();
-  const navigate = useNavigate({ from: Route.fullPath });
-
-  const { data: exercises } = user
-    ? useSuspenseQuery(exercisesQueryOptions())
-    : useSuspenseQuery(getDemoExercisesQueryOptions());
-
-  const selectedExerciseId =
-    exerciseId && exercises.some((exercise) => exercise.id === exerciseId)
-      ? exerciseId
-      : exercises[0]?.id;
-
-  const exerciseDetailQuery = user
-    ? useQuery({
-        ...exerciseByIdQueryOptions(selectedExerciseId ?? 0),
-        enabled: Boolean(selectedExerciseId),
-      })
-    : useQuery({
-        ...getDemoExercisesByIdQueryOptions(selectedExerciseId ?? 0),
-        enabled: Boolean(selectedExerciseId),
-      });
-
-  const authedContributionQuery = useQuery({
-    ...contributionDataQueryOptions(),
-    enabled: Boolean(user),
-  });
-  const demoContributionQuery = useQuery({
-    ...getDemoContributionDataQueryOptions(),
-    enabled: !user,
-  });
-  const authedFocusValuesQuery = useQuery({
-    ...workoutsFocusValuesQueryOptions(),
-    enabled: Boolean(user),
-  });
-  const demoFocusValuesQuery = useQuery({
-    ...getDemoWorkoutsFocusValuesQueryOptions(),
-    enabled: !user,
-  });
-
-  const workoutContributionData = user
-    ? authedContributionQuery.data
-    : demoContributionQuery.data;
-  const workoutFocusValues = user
-    ? (authedFocusValuesQuery.data ?? [])
-    : (demoFocusValuesQuery.data ?? []);
 
   return (
     <AnalyticsPage
-      isLoadingExercises={false}
-      exercises={exercises}
-      selectedExerciseId={selectedExerciseId}
-      onSelectExercise={(id) =>
-        navigate({ search: (prev) => ({ ...prev, exerciseId: id }) })
-      }
-      isLoadingDetails={exerciseDetailQuery.isLoading}
-      exerciseSets={exerciseDetailQuery.data?.sets}
+      exerciseId={exerciseId}
       isDemoMode={!user}
-      workoutContributionData={workoutContributionData}
-      workoutFocusValues={workoutFocusValues}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Move analytics page composition and analytics-owned cards/charts into `client/src/features/analytics`
- Thin the analytics route so it keeps TanStack Router search, loader prefetching, and context handoff only
- Split analytics workout helpers into the analytics feature while keeping demo contribution data helpers under `client/src/lib/demo-data`

## Verification
- `bun run fmt`
- `bun run tsc`
- `bun run lint`
- `bun run test`
- `bun run build`
- commit hook: `oxfmt --check`, `oxlint`, `knip`, `vitest run`

## Notes
- Existing Radix dialog accessibility warnings still appear in combobox tests.
- Existing Vite chunk-size warning still appears during build.