### PR TITLE
refactor: move workout route composition into feature

### DIFF
--- a/client/src/features/workouts/pages/workout-route-composition.tsx
+++ b/client/src/features/workouts/pages/workout-route-composition.tsx
@@ -1,0 +1,119 @@
+import { useSuspenseQuery, type QueryClient } from "@tanstack/react-query";
+import type { CurrentInternalUser, CurrentUser } from "@stackframe/react";
+import type { WorkoutUpdateWorkoutRequest } from "@/client";
+import type { DbExercise } from "@/features/exercises/api/exercises";
+import {
+  transformToWorkoutFormValues,
+  type WorkoutFocus,
+} from "@/features/workouts/api/workouts";
+import {
+  getExercisesQueryOptions,
+  getWorkoutByIdQueryOptions,
+  getWorkoutsFocusQueryOptions,
+  getWorkoutsQueryOptions,
+} from "@/lib/api/unified-query-options";
+import { initializeDemoData } from "@/lib/demo-data/storage";
+import { EditWorkoutPage } from "@/features/workouts/pages/edit-workout-page";
+import {
+  NewWorkoutPage,
+  type WorkoutFormSearch,
+} from "@/features/workouts/pages/new-workout-page";
+
+type WorkoutRouteUser = CurrentUser | CurrentInternalUser | null;
+
+type WorkoutRouteLoaderContext = {
+  queryClient: QueryClient;
+  user: WorkoutRouteUser;
+};
+
+export function preloadNewWorkoutRouteData({
+  queryClient,
+  user,
+}: WorkoutRouteLoaderContext) {
+  if (!user) initializeDemoData();
+
+  queryClient.ensureQueryData(getExercisesQueryOptions(user));
+  queryClient.ensureQueryData(getWorkoutsQueryOptions(user));
+  queryClient.ensureQueryData(getWorkoutsFocusQueryOptions(user));
+}
+
+export function preloadEditWorkoutRouteData({
+  queryClient,
+  user,
+  workoutId,
+}: WorkoutRouteLoaderContext & { workoutId: number }) {
+  if (!user) initializeDemoData();
+
+  queryClient.ensureQueryData(getWorkoutByIdQueryOptions(user, workoutId));
+  queryClient.ensureQueryData(getExercisesQueryOptions(user));
+  queryClient.ensureQueryData(getWorkoutsFocusQueryOptions(user));
+
+  return { workoutId };
+}
+
+function toWorkoutFocus(workoutsFocusValues: string[]): WorkoutFocus[] {
+  return workoutsFocusValues.map((name) => ({ name }));
+}
+
+export function NewWorkoutRouteComposition({
+  user,
+  search,
+}: {
+  user: WorkoutRouteUser;
+  search: WorkoutFormSearch;
+}) {
+  const { data: exercisesResponse } = useSuspenseQuery(
+    getExercisesQueryOptions(user),
+  );
+  const { data: workouts } = useSuspenseQuery(getWorkoutsQueryOptions(user));
+  const { data: workoutsFocusValues } = useSuspenseQuery(
+    getWorkoutsFocusQueryOptions(user),
+  );
+
+  const exercises: DbExercise[] = exercisesResponse.map((exercise) => ({
+    id: exercise.id,
+    name: exercise.name,
+  }));
+
+  return (
+    <NewWorkoutPage
+      user={user}
+      exercises={exercises}
+      workouts={workouts}
+      workoutsFocus={toWorkoutFocus(workoutsFocusValues)}
+      search={search}
+    />
+  );
+}
+
+export function EditWorkoutRouteComposition({
+  user,
+  workoutId,
+  search,
+}: {
+  user: WorkoutRouteUser;
+  workoutId: number;
+  search: WorkoutFormSearch;
+}) {
+  const { data: exercises } = useSuspenseQuery(getExercisesQueryOptions(user));
+  const { data: workout } = useSuspenseQuery(
+    getWorkoutByIdQueryOptions(user, workoutId),
+  );
+  const { data: workoutsFocusValues } = useSuspenseQuery(
+    getWorkoutsFocusQueryOptions(user),
+  );
+
+  const workoutFormValues: WorkoutUpdateWorkoutRequest =
+    transformToWorkoutFormValues(workout);
+
+  return (
+    <EditWorkoutPage
+      user={user}
+      exercises={exercises}
+      workout={workoutFormValues}
+      workoutId={workoutId}
+      workoutsFocus={toWorkoutFocus(workoutsFocusValues)}
+      search={search}
+    />
+  );
+}

--- a/client/src/routes/_layout/workouts/$workoutId/edit.tsx
+++ b/client/src/routes/_layout/workouts/$workoutId/edit.tsx
@@ -1,18 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { z } from "zod";
 import {
-  transformToWorkoutFormValues,
-  type WorkoutFocus,
-} from "@/features/workouts/api/workouts";
-import { EditWorkoutPage } from "@/features/workouts/pages/edit-workout-page";
-import type { WorkoutUpdateWorkoutRequest } from "@/client";
-import {
-  getExercisesQueryOptions,
-  getWorkoutByIdQueryOptions,
-  getWorkoutsFocusQueryOptions,
-} from "@/lib/api/unified-query-options";
-import { initializeDemoData } from "@/lib/demo-data/storage";
+  EditWorkoutRouteComposition,
+  preloadEditWorkoutRouteData,
+} from "@/features/workouts/pages/workout-route-composition";
 
 const workoutSearchSchema = z.object({
   addExercise: z.boolean().optional(),
@@ -32,18 +23,10 @@ export const Route = createFileRoute("/_layout/workouts/$workoutId/edit")({
     },
   },
   loader: async ({ context, params }): Promise<{ workoutId: number }> => {
-    const workoutId = params.workoutId;
-    if (!context.user) initializeDemoData();
-
-    context.queryClient.ensureQueryData(
-      getWorkoutByIdQueryOptions(context.user, workoutId),
-    );
-    context.queryClient.ensureQueryData(getExercisesQueryOptions(context.user));
-    context.queryClient.ensureQueryData(
-      getWorkoutsFocusQueryOptions(context.user),
-    );
-
-    return { workoutId };
+    return preloadEditWorkoutRouteData({
+      ...context,
+      workoutId: params.workoutId,
+    });
   },
   component: RouteComponent,
 });
@@ -53,28 +36,10 @@ function RouteComponent() {
   const { user } = Route.useRouteContext();
   const search = Route.useSearch();
 
-  const { data: exercises } = useSuspenseQuery(getExercisesQueryOptions(user));
-  const { data: workout } = useSuspenseQuery(
-    getWorkoutByIdQueryOptions(user, workoutId),
-  );
-  const { data: workoutsFocusValues } = useSuspenseQuery(
-    getWorkoutsFocusQueryOptions(user),
-  );
-
-  const workoutFormValues: WorkoutUpdateWorkoutRequest =
-    transformToWorkoutFormValues(workout);
-
-  const workoutsFocus: WorkoutFocus[] = workoutsFocusValues.map((name) => ({
-    name,
-  }));
-
   return (
-    <EditWorkoutPage
+    <EditWorkoutRouteComposition
       user={user}
-      exercises={exercises}
-      workout={workoutFormValues}
       workoutId={workoutId}
-      workoutsFocus={workoutsFocus}
       search={search}
     />
   );

--- a/client/src/routes/_layout/workouts/new.tsx
+++ b/client/src/routes/_layout/workouts/new.tsx
@@ -1,15 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { z } from "zod";
-import type { WorkoutFocus } from "@/features/workouts/api/workouts";
-import { NewWorkoutPage } from "@/features/workouts/pages/new-workout-page";
-import type { DbExercise } from "@/features/exercises/api/exercises";
 import {
-  getExercisesQueryOptions,
-  getWorkoutsFocusQueryOptions,
-  getWorkoutsQueryOptions,
-} from "@/lib/api/unified-query-options";
-import { initializeDemoData } from "@/lib/demo-data/storage";
+  NewWorkoutRouteComposition,
+  preloadNewWorkoutRouteData,
+} from "@/features/workouts/pages/workout-route-composition";
 
 const workoutSearchSchema = z.object({
   addExercise: z.boolean().optional(),
@@ -20,12 +14,7 @@ const workoutSearchSchema = z.object({
 export const Route = createFileRoute("/_layout/workouts/new")({
   validateSearch: workoutSearchSchema,
   loader: ({ context }) => {
-    if (!context.user) initializeDemoData();
-    context.queryClient.ensureQueryData(getExercisesQueryOptions(context.user));
-    context.queryClient.ensureQueryData(getWorkoutsQueryOptions(context.user));
-    context.queryClient.ensureQueryData(
-      getWorkoutsFocusQueryOptions(context.user),
-    );
+    preloadNewWorkoutRouteData(context);
   },
   component: RouteComponent,
 });
@@ -34,29 +23,9 @@ function RouteComponent() {
   const { user } = Route.useRouteContext();
   const search = Route.useSearch();
 
-  const { data: exercisesResponse } = useSuspenseQuery(
-    getExercisesQueryOptions(user),
-  );
-  const { data: workouts } = useSuspenseQuery(getWorkoutsQueryOptions(user));
-  const { data: workoutsFocusValues } = useSuspenseQuery(
-    getWorkoutsFocusQueryOptions(user),
-  );
-
-  const exercises: DbExercise[] = exercisesResponse.map((exercise) => ({
-    id: exercise.id,
-    name: exercise.name,
-  }));
-
-  const workoutsFocus: WorkoutFocus[] = workoutsFocusValues.map((name) => ({
-    name,
-  }));
-
   return (
-    <NewWorkoutPage
+    <NewWorkoutRouteComposition
       user={user}
-      exercises={exercises}
-      workouts={workouts}
-      workoutsFocus={workoutsFocus}
       search={search}
     />
   );


### PR DESCRIPTION
## Summary
- Keep workout route files responsible for route identity, params, and search validation
- Move new/edit workout route preloading and data shaping into `features/workouts/pages/workout-route-composition.tsx`
- Preserve existing route paths, search params, demo initialization, suspense queries, and page props

## User Impact
No product behavior change expected. `/workouts/new` and `/workouts/$workoutId/edit` should behave the same while route ownership becomes thinner.

## Product Behavior Risk
Low to moderate because this touches route loaders and route component composition. The change intentionally avoids route path changes and generated route churn.

## Verification
- Commit hook: `oxfmt --check`, `oxlint`, `knip`, `vitest run` passed
- `bun run tsc` passed
- Earlier worker verification: `bun run test src/features/workouts` passed, `bun run build` passed with existing-style large chunk warnings
- Earlier combined focused suite: `bun run test -- ai-chat billing feature-access ai-workout-draft ai-chat-observability use-ai-chat chat-page src/features/workouts` passed, 22 files / 124 tests

## Coordination
This PR intentionally avoids chat API/helper ownership, demo-data restructuring, unified query options, charts, stats-grid, and `routeTree.gen.ts`.