### PR TITLE
fix: handle Stack Auth session load failures

### DIFF
--- a/client/src/lib/api/client-config.test.ts
+++ b/client/src/lib/api/client-config.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type RequestInterceptor = (request: Request) => Promise<Request>;
+
+const mocks = vi.hoisted(() => ({
+  applyLocalDevAuthHeader: vi.fn((headers: Headers) => headers),
+  getUser: vi.fn(),
+  requestInterceptors: [] as RequestInterceptor[],
+  setConfig: vi.fn(),
+}));
+
+vi.mock("@/client/client.gen", () => ({
+  client: {
+    setConfig: mocks.setConfig,
+    interceptors: {
+      request: {
+        use: vi.fn((fn: RequestInterceptor) => {
+          mocks.requestInterceptors.push(fn);
+        }),
+      },
+      response: {
+        use: vi.fn(),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/local-dev-auth", () => ({
+  applyLocalDevAuthHeader: mocks.applyLocalDevAuthHeader,
+}));
+
+vi.mock("@/stack", () => ({
+  stackClientApp: {
+    getUser: mocks.getUser,
+  },
+}));
+
+async function loadRequestInterceptor(): Promise<RequestInterceptor> {
+  mocks.requestInterceptors.length = 0;
+  await import("./client-config");
+
+  const interceptor = mocks.requestInterceptors.at(0);
+  if (!interceptor) {
+    throw new Error("request interceptor was not registered");
+  }
+  return interceptor;
+}
+
+describe("client auth request interceptor", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.applyLocalDevAuthHeader.mockClear();
+    mocks.getUser.mockReset();
+    mocks.setConfig.mockClear();
+  });
+
+  it("adds the Stack access token when the session is available", async () => {
+    mocks.getUser.mockResolvedValue({
+      getAuthJson: vi.fn().mockResolvedValue({ accessToken: "token-123" }),
+    });
+    const interceptor = await loadRequestInterceptor();
+
+    const request = await interceptor(new Request("http://localhost/api"));
+
+    expect(request.headers.get("x-stack-access-token")).toBe("token-123");
+    expect(mocks.applyLocalDevAuthHeader).not.toHaveBeenCalled();
+  });
+
+  it("throws a friendly retry message when Stack cannot verify the session", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.getUser.mockRejectedValue(new TypeError("Load failed"));
+    const { AUTH_SESSION_UNAVAILABLE_MESSAGE } =
+      await import("./client-config");
+    const interceptor = mocks.requestInterceptors.at(0);
+    if (!interceptor) {
+      throw new Error("request interceptor was not registered");
+    }
+
+    await expect(
+      interceptor(new Request("http://localhost/api/workouts")),
+    ).rejects.toEqual({
+      message: AUTH_SESSION_UNAVAILABLE_MESSAGE,
+    });
+    expect(mocks.applyLocalDevAuthHeader).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+});

--- a/client/src/lib/api/client-config.ts
+++ b/client/src/lib/api/client-config.ts
@@ -4,6 +4,9 @@ import { stackClientApp } from "@/stack";
 import type { ApiError } from "@/lib/errors";
 import { toast } from "sonner";
 
+export const AUTH_SESSION_UNAVAILABLE_MESSAGE =
+  "We couldn't verify your session. Please check your connection and try again.";
+
 const BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
   (import.meta.env.MODE === "test" ? "http://localhost/api" : "/api");
@@ -18,16 +21,24 @@ client.interceptors.request.use(async (request) => {
     return request;
   }
 
-  const user = await stackClientApp.getUser();
-  if (!user) {
-    applyLocalDevAuthHeader(request.headers);
-    return request;
-  }
+  try {
+    const user = await stackClientApp.getUser();
+    if (!user) {
+      applyLocalDevAuthHeader(request.headers);
+      return request;
+    }
 
-  const { accessToken } = await user.getAuthJson();
-  if (accessToken) {
-    request.headers.set("x-stack-access-token", accessToken);
-    return request;
+    const { accessToken } = await user.getAuthJson();
+    if (accessToken) {
+      request.headers.set("x-stack-access-token", accessToken);
+      return request;
+    }
+  } catch (err) {
+    console.error("Failed to verify Stack Auth session.", err);
+    const authUnavailableError: ApiError = {
+      message: AUTH_SESSION_UNAVAILABLE_MESSAGE,
+    };
+    throw authUnavailableError;
   }
 
   applyLocalDevAuthHeader(request.headers);


### PR DESCRIPTION
## Summary
- Convert Stack Auth session lookup failures into a concise retryable auth error before workout submit
- Keep local dev auth fallback for actual no-user/dev paths, but avoid falling back when Stack fails unexpectedly
- Add regression coverage for the successful token path and the Stack `Load failed` path

## Verification
- `bun run lint`
- `bun run tsc`
- `bun run test`
- `bun run fmt:check`
- `bun run build`
- `autoreview` clean: no accepted/actionable findings

## Notes
- Fly logs around the reported production failure showed no `POST /api/workouts` reaching the backend, which matches the client failing during Stack session verification before submit.
- `go test ./...` was blocked locally by Postgres not running on `127.0.0.1:5432`; no server code changed in this branch.