### PR TITLE
fix: make ai chat generation server owned

### DIFF
--- a/server/internal/aichat/handler.go
+++ b/server/internal/aichat/handler.go
@@ -26,8 +26,8 @@ type chatService interface {
 	SaveLatestWorkoutDraft(ctx context.Context, conversationID int32) (*SaveLatestWorkoutDraftResponse, error)
 	RequestMessageRecovery(ctx context.Context, conversationID int32, reason string) (*RecoverMessageResponse, error)
 	PrepareMessageStream(ctx context.Context, conversationID int32, prompt string, requestID string) (*PreparedMessageStream, error)
+	StartMessageGeneration(ctx context.Context, prepared *PreparedMessageStream) error
 	PrepareResumeMessageStream(ctx context.Context, conversationID int32, runID int32, afterSequence int32) (*PreparedResumeStream, error)
-	StreamMessage(ctx context.Context, prepared *PreparedMessageStream, onChunk func(StreamChunk) error) (*StreamDone, error)
 	ResumeMessageStream(ctx context.Context, prepared *PreparedResumeStream, onChunk func(StreamChunk) error) (*StreamDone, error)
 	AbortPreparedMessageStream(ctx context.Context, prepared *PreparedMessageStream, failure error) error
 }
@@ -365,8 +365,23 @@ func (h *Handler) StreamMessage(w http.ResponseWriter, r *http.Request) {
 		"request_id", request.GetRequestID(r.Context()),
 	)
 
+	if err := h.service.StartMessageGeneration(r.Context(), prepared); err != nil {
+		if !h.writeStreamError(sse, r, prepared.Conversation.ID, prepared.Run.ID, prepared.AssistantMessage.ID, "failed to start ai chat generation", err) {
+			h.logger.Error("failed to start ai chat generation", "error", err, "path", r.URL.Path, "request_id", request.GetRequestID(r.Context()))
+		}
+		return
+	}
+
+	resumePrepared := &PreparedResumeStream{
+		Conversation:     prepared.Conversation,
+		AssistantMessage: prepared.AssistantMessage,
+		Run:              prepared.Run,
+		AfterSequence:    0,
+		LastSequence:     prepared.LastSequence,
+	}
+
 	firstDeltaWritten := false
-	done, err := h.service.StreamMessage(r.Context(), prepared, func(chunk StreamChunk) error {
+	done, err := h.service.ResumeMessageStream(r.Context(), resumePrepared, func(chunk StreamChunk) error {
 		err := sse.write("delta", StreamEvent{
 			Type:     "delta",
 			Delta:    chunk.Delta,
@@ -387,7 +402,7 @@ func (h *Handler) StreamMessage(w http.ResponseWriter, r *http.Request) {
 		return err
 	})
 	if err != nil {
-		if errors.Is(err, ErrStreamAwaitingRecovery) {
+		if errors.Is(err, ErrStreamAwaitingRecovery) || errors.Is(err, ErrStreamDisconnected) || errors.Is(err, context.Canceled) {
 			return
 		}
 		if !h.writeStreamError(sse, r, prepared.Conversation.ID, prepared.Run.ID, prepared.AssistantMessage.ID, "failed to generate ai chat response", err) {
@@ -481,7 +496,7 @@ func (h *Handler) ResumeMessageStream(w http.ResponseWriter, r *http.Request) {
 		})
 	})
 	if err != nil {
-		if errors.Is(err, ErrStreamAwaitingRecovery) {
+		if errors.Is(err, ErrStreamAwaitingRecovery) || errors.Is(err, ErrStreamDisconnected) || errors.Is(err, context.Canceled) {
 			return
 		}
 		if !h.writeStreamError(sse, r, prepared.Conversation.ID, prepared.Run.ID, prepared.AssistantMessage.ID, "failed to resume ai chat response", err) {

--- a/server/internal/aichat/handler_test.go
+++ b/server/internal/aichat/handler_test.go
@@ -109,6 +109,11 @@ func (m *mockChatService) PrepareMessageStream(ctx context.Context, conversation
 	return prepared, args.Error(1)
 }
 
+func (m *mockChatService) StartMessageGeneration(ctx context.Context, prepared *PreparedMessageStream) error {
+	args := m.Called(ctx, prepared)
+	return args.Error(0)
+}
+
 func (m *mockChatService) PrepareResumeMessageStream(ctx context.Context, conversationID int32, runID int32, afterSequence int32) (*PreparedResumeStream, error) {
 	args := m.Called(ctx, conversationID, runID, afterSequence)
 	prepared, _ := args.Get(0).(*PreparedResumeStream)
@@ -531,7 +536,8 @@ func TestHandlerStreamMessage(t *testing.T) {
 		handler := NewHandler(logger, service)
 		prepared := preparedStreamFixture()
 		service.On("PrepareMessageStream", mock.Anything, int32(41), "prove streaming", "req-123").Return(prepared, nil).Once()
-		service.On("StreamMessage", mock.Anything, prepared, mock.Anything).Return(&StreamDone{
+		service.On("StartMessageGeneration", mock.Anything, prepared).Return(nil).Once()
+		service.On("ResumeMessageStream", mock.Anything, mock.AnythingOfType("*aichat.PreparedResumeStream"), mock.Anything).Return(&StreamDone{
 			ConversationID: 41,
 			RunID:          51,
 			MessageID:      61,
@@ -555,7 +561,7 @@ func TestHandlerStreamMessage(t *testing.T) {
 		assert.Contains(t, body, `"run_id":51`)
 		assert.Contains(t, body, `"message_id":61`)
 		assert.Contains(t, body, "event: delta")
-		assert.Contains(t, body, `"delta":"hello "`)
+		assert.Contains(t, body, `"delta":"replayed "`)
 		assert.Contains(t, body, "event: done")
 		assert.Contains(t, body, `"text":"hello world"`)
 		service.AssertExpectations(t)
@@ -567,7 +573,8 @@ func TestHandlerStreamMessage(t *testing.T) {
 		prepared := preparedStreamFixture()
 		workoutFocus := "pull"
 		service.On("PrepareMessageStream", mock.Anything, int32(41), "build workout", "req-123").Return(prepared, nil).Once()
-		service.On("StreamMessage", mock.Anything, prepared, mock.Anything).Return(&StreamDone{
+		service.On("StartMessageGeneration", mock.Anything, prepared).Return(nil).Once()
+		service.On("ResumeMessageStream", mock.Anything, mock.AnythingOfType("*aichat.PreparedResumeStream"), mock.Anything).Return(&StreamDone{
 			ConversationID: 41,
 			RunID:          51,
 			MessageID:      61,
@@ -605,7 +612,8 @@ func TestHandlerStreamMessage(t *testing.T) {
 		handler := NewHandler(logger, service)
 		prepared := preparedStreamFixture()
 		service.On("PrepareMessageStream", mock.Anything, int32(41), "prove streaming", "req-123").Return(prepared, nil).Once()
-		service.On("StreamMessage", mock.Anything, prepared, mock.Anything).Return((*StreamDone)(nil), errors.New("provider failed")).Once()
+		service.On("StartMessageGeneration", mock.Anything, prepared).Return(nil).Once()
+		service.On("ResumeMessageStream", mock.Anything, mock.AnythingOfType("*aichat.PreparedResumeStream"), mock.Anything).Return((*StreamDone)(nil), errors.New("provider failed")).Once()
 
 		req := httptest.NewRequest(http.MethodPost, "/api/ai/conversations/41/messages/stream", strings.NewReader(`{"prompt":"prove streaming"}`))
 		req = req.WithContext(request.WithRequestID(req.Context(), "req-123"))

--- a/server/internal/aichat/models.go
+++ b/server/internal/aichat/models.go
@@ -34,6 +34,7 @@ var (
 
 const (
 	streamInterruptedFailureMessage = "ai chat stream was interrupted before completion"
+	interruptionReasonStalePartial  = "stale_partial"
 )
 
 type ValidateRequest struct {
@@ -102,6 +103,13 @@ type ChatRun struct {
 	RequestID          *string                       `json:"request_id,omitempty"`
 	ErrorMessage       *string                       `json:"error_message,omitempty"`
 	WorkoutDraft       *workout.CreateWorkoutRequest `json:"workout_draft,omitempty"`
+	GenerationStatus   string                        `json:"generation_status"`
+	GenerationOwner    *string                       `json:"generation_owner,omitempty"`
+	LeaseExpiresAt     *time.Time                    `json:"generation_lease_expires_at,omitempty"`
+	HeartbeatAt        *time.Time                    `json:"generation_heartbeat_at,omitempty"`
+	GenerationAttempt  int32                         `json:"generation_attempt"`
+	InterruptedAt      *time.Time                    `json:"interrupted_at,omitempty"`
+	InterruptionReason *string                       `json:"interruption_reason,omitempty"`
 	CreatedAt          time.Time                     `json:"created_at"`
 	UpdatedAt          time.Time                     `json:"updated_at"`
 	StartedAt          time.Time                     `json:"started_at"`

--- a/server/internal/aichat/models.go
+++ b/server/internal/aichat/models.go
@@ -33,8 +33,9 @@ var (
 )
 
 const (
-	streamInterruptedFailureMessage = "ai chat stream was interrupted before completion"
-	interruptionReasonStalePartial  = "stale_partial"
+	streamInterruptedFailureMessage     = "ai chat stream was interrupted before completion"
+	interruptionReasonStalePartial      = "stale_partial"
+	interruptionReasonAttemptsExhausted = "generation_attempts_exhausted"
 )
 
 type ValidateRequest struct {

--- a/server/internal/aichat/repository.go
+++ b/server/internal/aichat/repository.go
@@ -30,9 +30,10 @@ type Repository interface {
 	LoadPreparedRunForResume(ctx context.Context, conversationID int32, runID int32, userID string, afterSequence int32) (*PreparedResumeStream, error)
 	ListStreamChunksAfter(ctx context.Context, runID int32, userID string, afterSequence int32) ([]StreamChunk, error)
 	PrepareMessageStream(ctx context.Context, conversationID int32, userID string, prompt string, model string, requestID string) (*PreparedMessageStream, error)
+	ClaimRunGeneration(ctx context.Context, run *ChatRun, owner runOwner, now time.Time) error
+	HeartbeatRunGeneration(ctx context.Context, run *ChatRun, owner runOwner, now time.Time) (bool, error)
 	AppendStreamChunk(ctx context.Context, prepared *PreparedMessageStream, delta string, partialText string, updatedAt time.Time) (int32, error)
-	MarkRunAwaitingRecovery(ctx context.Context, prepared *PreparedMessageStream, partialText string, updatedAt time.Time) error
-	ClaimRunRecovery(ctx context.Context, run *ChatRun) error
+	InterruptRun(ctx context.Context, prepared *PreparedMessageStream, partialText string, reason string, completedAt time.Time) error
 	CompleteRun(ctx context.Context, prepared *PreparedMessageStream, assistantText string, workoutDraft *workout.CreateWorkoutRequest, completedAt time.Time) (*ChatMessage, *ChatRun, error)
 	FailRun(ctx context.Context, prepared *PreparedMessageStream, partialText string, failure error, completedAt time.Time) error
 }
@@ -632,6 +633,70 @@ func (r *repository) PrepareMessageStream(ctx context.Context, conversationID in
 	}, nil
 }
 
+func (r *repository) ClaimRunGeneration(ctx context.Context, run *ChatRun, owner runOwner, now time.Time) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	runRow, err := r.queries.ClaimAIChatRunGeneration(ctx, db.ClaimAIChatRunGenerationParams{
+		ID:     run.ID,
+		UserID: run.UserID,
+		GenerationOwner: pgtype.Text{
+			String: owner.Value(),
+			Valid:  true,
+		},
+		GenerationLeaseExpiresAt: pgtype.Timestamptz{
+			Time:  owner.LeaseExpiresAt(now),
+			Valid: true,
+		},
+		GenerationHeartbeatAt: pgtype.Timestamptz{
+			Time:  now.UTC(),
+			Valid: true,
+		},
+		GenerationAttempt: maxGenerationAttempts,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return err
+		}
+		return fmt.Errorf("claim ai chat run generation: %w", err)
+	}
+
+	claimedRun, err := mapRun(runRow)
+	if err != nil {
+		return err
+	}
+	*run = *claimedRun
+
+	return nil
+}
+
+func (r *repository) HeartbeatRunGeneration(ctx context.Context, run *ChatRun, owner runOwner, now time.Time) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	rows, err := r.queries.HeartbeatAIChatRunGeneration(ctx, db.HeartbeatAIChatRunGenerationParams{
+		ID:     run.ID,
+		UserID: run.UserID,
+		GenerationLeaseExpiresAt: pgtype.Timestamptz{
+			Time:  owner.LeaseExpiresAt(now),
+			Valid: true,
+		},
+		GenerationHeartbeatAt: pgtype.Timestamptz{
+			Time:  now.UTC(),
+			Valid: true,
+		},
+		GenerationOwner: pgtype.Text{
+			String: owner.Value(),
+			Valid:  true,
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("heartbeat ai chat run generation: %w", err)
+	}
+
+	return rows > 0, nil
+}
+
 func (r *repository) AppendStreamChunk(ctx context.Context, prepared *PreparedMessageStream, delta string, partialText string, updatedAt time.Time) (int32, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -649,6 +714,7 @@ func (r *repository) AppendStreamChunk(ctx context.Context, prepared *PreparedMe
 		UserID:    prepared.Run.UserID,
 		Sequence:  nextSequence,
 		DeltaText: delta,
+		Column5:   textValue(prepared.Run.GenerationOwner),
 	}); err != nil {
 		return 0, fmt.Errorf("create ai chat stream chunk: %w", err)
 	}
@@ -680,78 +746,51 @@ func (r *repository) AppendStreamChunk(ctx context.Context, prepared *PreparedMe
 	return nextSequence, nil
 }
 
-func (r *repository) MarkRunAwaitingRecovery(ctx context.Context, prepared *PreparedMessageStream, partialText string, updatedAt time.Time) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+func (r *repository) InterruptRun(ctx context.Context, prepared *PreparedMessageStream, partialText string, reason string, completedAt time.Time) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("begin ai chat recovery handoff transaction: %w", err)
+		return fmt.Errorf("begin ai chat interruption transaction: %w", err)
 	}
 	defer tx.Rollback(ctx)
 
 	qtx := r.queries.WithTx(tx)
-	partialText = strings.TrimSpace(partialText)
-	if partialText != "" {
-		if _, err := qtx.UpdateAIChatMessageStreaming(ctx, db.UpdateAIChatMessageStreamingParams{
-			ID:      prepared.AssistantMessage.ID,
-			UserID:  prepared.AssistantMessage.UserID,
-			Content: partialText,
-		}); err != nil {
-			return fmt.Errorf("update ai chat assistant message for recovery handoff: %w", err)
-		}
+	completedTS := pgtype.Timestamptz{Time: completedAt.UTC(), Valid: true}
+	errorText := truncateForStorage(streamInterruptedFailureMessage, 512)
+
+	if _, err := qtx.UpdateAIChatMessageFailed(ctx, db.UpdateAIChatMessageFailedParams{
+		ID:           prepared.AssistantMessage.ID,
+		UserID:       prepared.AssistantMessage.UserID,
+		Content:      strings.TrimSpace(partialText),
+		ErrorMessage: textToPg(errorText),
+		CompletedAt:  completedTS,
+	}); err != nil {
+		return fmt.Errorf("interrupt ai chat assistant message: %w", err)
 	}
 
-	runRow, err := qtx.MarkAIChatRunAwaitingRecovery(ctx, db.MarkAIChatRunAwaitingRecoveryParams{
-		ID:           prepared.Run.ID,
-		UserID:       prepared.Run.UserID,
-		ErrorMessage: textToPg(runAwaitingRecoveryMarker),
-	})
-	if err != nil {
-		return fmt.Errorf("mark ai chat run awaiting recovery: %w", err)
+	if _, err := qtx.UpdateAIChatRunInterrupted(ctx, db.UpdateAIChatRunInterruptedParams{
+		ID:                 prepared.Run.ID,
+		UserID:             prepared.Run.UserID,
+		ErrorMessage:       textToPg(errorText),
+		CompletedAt:        completedTS,
+		InterruptionReason: textToPg(reason),
+	}); err != nil {
+		return fmt.Errorf("interrupt ai chat run: %w", err)
+	}
+
+	if err := qtx.TouchAIChatConversation(ctx, db.TouchAIChatConversationParams{
+		ID:            prepared.Conversation.ID,
+		UserID:        prepared.Conversation.UserID,
+		LastMessageAt: completedTS,
+	}); err != nil {
+		return fmt.Errorf("touch ai chat conversation after interruption: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("commit ai chat recovery handoff transaction: %w", err)
+		return fmt.Errorf("commit ai chat interruption transaction: %w", err)
 	}
-
-	if partialText != "" {
-		prepared.AssistantMessage.Content = partialText
-		prepared.AssistantMessage.UpdatedAt = updatedAt.UTC()
-	}
-
-	run, err := mapRun(runRow)
-	if err != nil {
-		return err
-	}
-	prepared.Run = run
-
-	return nil
-}
-
-func (r *repository) ClaimRunRecovery(ctx context.Context, run *ChatRun) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	runRow, err := r.queries.ClaimAIChatRunRecovery(ctx, db.ClaimAIChatRunRecoveryParams{
-		ID:             run.ID,
-		UserID:         run.UserID,
-		ErrorMessage:   textToPg(strings.TrimSpace(textValue(run.ErrorMessage))),
-		UpdatedAt:      pgtype.Timestamptz{Time: run.UpdatedAt.UTC(), Valid: true},
-		ErrorMessage_2: textToPg(runRecoveryClaimedMarker),
-	})
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return err
-		}
-		return fmt.Errorf("claim ai chat recovery run: %w", err)
-	}
-
-	claimedRun, err := mapRun(runRow)
-	if err != nil {
-		return err
-	}
-	*run = *claimedRun
 
 	return nil
 }
@@ -788,6 +827,7 @@ func (r *repository) CompleteRun(ctx context.Context, prepared *PreparedMessageS
 		UserID:      prepared.Run.UserID,
 		CompletedAt: completedTS,
 		Column4:     string(workoutDraftJSON),
+		Column5:     textValue(prepared.Run.GenerationOwner),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("complete ai chat run: %w", err)
@@ -861,6 +901,7 @@ func (r *repository) FailRun(ctx context.Context, prepared *PreparedMessageStrea
 		UserID:       prepared.Run.UserID,
 		ErrorMessage: textToPg(errorText),
 		CompletedAt:  completedTS,
+		Column5:      textValue(prepared.Run.GenerationOwner),
 	}); err != nil {
 		return fmt.Errorf("fail ai chat run: %w", err)
 	}
@@ -1053,6 +1094,18 @@ func mapRun(row db.AiChatRun) (*ChatRun, error) {
 	if err != nil {
 		return nil, err
 	}
+	leaseExpiresAt, err := timePtrFromPg(row.GenerationLeaseExpiresAt)
+	if err != nil {
+		return nil, err
+	}
+	heartbeatAt, err := timePtrFromPg(row.GenerationHeartbeatAt)
+	if err != nil {
+		return nil, err
+	}
+	interruptedAt, err := timePtrFromPg(row.InterruptedAt)
+	if err != nil {
+		return nil, err
+	}
 	workoutDraft, err := parseStoredWorkoutDraft(row.WorkoutDraft)
 	if err != nil {
 		return nil, err
@@ -1069,6 +1122,13 @@ func mapRun(row db.AiChatRun) (*ChatRun, error) {
 		RequestID:          textPtr(row.RequestID),
 		ErrorMessage:       textPtr(row.ErrorMessage),
 		WorkoutDraft:       workoutDraft,
+		GenerationStatus:   row.GenerationStatus,
+		GenerationOwner:    textPtr(row.GenerationOwner),
+		LeaseExpiresAt:     leaseExpiresAt,
+		HeartbeatAt:        heartbeatAt,
+		GenerationAttempt:  row.GenerationAttempt,
+		InterruptedAt:      interruptedAt,
+		InterruptionReason: textPtr(row.InterruptionReason),
 		CreatedAt:          createdAt,
 		UpdatedAt:          updatedAt,
 		StartedAt:          startedAt,

--- a/server/internal/aichat/repository.go
+++ b/server/internal/aichat/repository.go
@@ -771,11 +771,15 @@ func (r *repository) InterruptRun(ctx context.Context, prepared *PreparedMessage
 	}
 
 	if _, err := qtx.UpdateAIChatRunInterrupted(ctx, db.UpdateAIChatRunInterruptedParams{
-		ID:                 prepared.Run.ID,
-		UserID:             prepared.Run.UserID,
-		ErrorMessage:       textToPg(errorText),
-		CompletedAt:        completedTS,
-		InterruptionReason: textToPg(reason),
+		ID:                               prepared.Run.ID,
+		UserID:                           prepared.Run.UserID,
+		ErrorMessage:                     textToPg(errorText),
+		CompletedAt:                      completedTS,
+		InterruptionReason:               textToPg(reason),
+		ExpectedGenerationStatus:         prepared.Run.GenerationStatus,
+		ExpectedGenerationOwner:          textPtrToPg(prepared.Run.GenerationOwner),
+		ExpectedGenerationLeaseExpiresAt: timePtrToPg(prepared.Run.LeaseExpiresAt),
+		ExpectedGenerationAttempt:        prepared.Run.GenerationAttempt,
 	}); err != nil {
 		return fmt.Errorf("interrupt ai chat run: %w", err)
 	}
@@ -1006,6 +1010,20 @@ func textToPg(value string) pgtype.Text {
 		return pgtype.Text{}
 	}
 	return pgtype.Text{String: value, Valid: true}
+}
+
+func textPtrToPg(value *string) pgtype.Text {
+	if value == nil {
+		return pgtype.Text{}
+	}
+	return textToPg(*value)
+}
+
+func timePtrToPg(value *time.Time) pgtype.Timestamptz {
+	if value == nil {
+		return pgtype.Timestamptz{}
+	}
+	return pgtype.Timestamptz{Time: value.UTC(), Valid: true}
 }
 
 func textValue(value *string) string {

--- a/server/internal/aichat/repository_integration_test.go
+++ b/server/internal/aichat/repository_integration_test.go
@@ -15,6 +15,7 @@ import (
 	db "github.com/Andrewy-gh/fittrack/server/internal/database"
 	"github.com/Andrewy-gh/fittrack/server/internal/exercise"
 	"github.com/Andrewy-gh/fittrack/server/internal/workout"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
@@ -132,6 +133,77 @@ func TestRepositoryCompleteRun_AllowsNilWorkoutDraft(t *testing.T) {
 	err = pool.QueryRow(ctx, "SELECT workout_draft FROM ai_chat_run WHERE id = $1 AND user_id = $2", run.ID, userID).Scan(&storedRunDraft)
 	require.NoError(t, err)
 	assert.Nil(t, storedRunDraft)
+}
+
+func TestRepositoryInterruptRun_RequiresLoadedGenerationSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database-backed AI chat repository test in short mode")
+	}
+
+	pool, cleanup := setupAIChatRepositoryTestDatabase(t)
+	if pool == nil {
+		return
+	}
+	defer cleanup()
+
+	const userID = "aichat-interrupt-snapshot-user"
+
+	ctx := context.Background()
+	seedAIChatRepositoryTestUser(t, pool, userID)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	queries := db.New(pool)
+	exerciseRepo := exercise.NewRepository(logger, queries, pool)
+	repo := NewRepository(logger, queries, pool, workout.NewTxSaver(logger, exerciseRepo))
+
+	conversation, err := repo.CreateConversation(ctx, userID)
+	require.NoError(t, err)
+
+	prepared, err := repo.PrepareMessageStream(ctx, conversation.ID, userID, "Keep generating while recovery races.", defaultModelName, "req-interrupt-snapshot")
+	require.NoError(t, err)
+
+	claimAt := time.Date(2026, 4, 22, 16, 0, 0, 0, time.UTC)
+	owner := newRunOwner(runOwnerKindAPI, "stale-owner")
+	err = repo.ClaimRunGeneration(ctx, prepared.Run, owner, claimAt)
+	require.NoError(t, err)
+
+	_, err = repo.AppendStreamChunk(ctx, prepared, "partial", "partial", claimAt.Add(time.Second))
+	require.NoError(t, err)
+
+	renewedLease := prepared.Run.LeaseExpiresAt.Add(generationLeaseDuration)
+	heartbeatAt := claimAt.Add(5 * time.Second)
+	_, err = pool.Exec(ctx, `
+		UPDATE ai_chat_run
+		SET generation_lease_expires_at = $1,
+		    generation_heartbeat_at = $2,
+		    updated_at = $2
+		WHERE id = $3 AND user_id = $4
+	`, renewedLease, heartbeatAt, prepared.Run.ID, userID)
+	require.NoError(t, err)
+
+	err = repo.InterruptRun(ctx, prepared, "partial", interruptionReasonStalePartial, claimAt.Add(10*time.Second))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, pgx.ErrNoRows), "expected stale interrupt to miss the renewed run, got %v", err)
+
+	var runStatus, generationStatus string
+	err = pool.QueryRow(ctx, `
+		SELECT status, generation_status
+		FROM ai_chat_run
+		WHERE id = $1 AND user_id = $2
+	`, prepared.Run.ID, userID).Scan(&runStatus, &generationStatus)
+	require.NoError(t, err)
+	assert.Equal(t, statusStreaming, runStatus)
+	assert.Equal(t, generationStatusGenerating, generationStatus)
+
+	var messageStatus, content string
+	err = pool.QueryRow(ctx, `
+		SELECT status, content
+		FROM ai_chat_message
+		WHERE id = $1 AND user_id = $2
+	`, prepared.AssistantMessage.ID, userID).Scan(&messageStatus, &content)
+	require.NoError(t, err)
+	assert.Equal(t, statusStreaming, messageStatus)
+	assert.Equal(t, "partial", content)
 }
 
 func TestRepositoryCompleteRun_PersistsWorkoutDraftWithNullByteText(t *testing.T) {
@@ -401,6 +473,8 @@ func setupAIChatRepositoryTestDatabase(t *testing.T) (*pgxpool.Pool, func()) {
 		_, err = pool.Exec(ctx, "DELETE FROM users WHERE user_id = $1", "aichat-complete-run-nil-draft-user")
 		require.NoError(t, err)
 		_, err = pool.Exec(ctx, "DELETE FROM users WHERE user_id = $1", "aichat-complete-run-null-byte-draft-user")
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx, "DELETE FROM users WHERE user_id = $1", "aichat-interrupt-snapshot-user")
 		require.NoError(t, err)
 		_, err = pool.Exec(ctx, "DELETE FROM users WHERE user_id = $1", "aichat-save-draft-race-user")
 		require.NoError(t, err)

--- a/server/internal/aichat/repository_test.go
+++ b/server/internal/aichat/repository_test.go
@@ -42,6 +42,19 @@ func TestTruncateForStorage_TruncatesWithoutBreakingUTF8(t *testing.T) {
 	}
 }
 
+func TestTextPtrToPg_PreservesNilAsNull(t *testing.T) {
+	nullText := textPtrToPg(nil)
+	if nullText.Valid {
+		t.Fatal("nil pointer should map to SQL NULL")
+	}
+
+	owner := "api:worker-1"
+	text := textPtrToPg(&owner)
+	if !text.Valid || text.String != owner {
+		t.Fatalf("owner pointer should map to valid text, got valid=%t value=%q", text.Valid, text.String)
+	}
+}
+
 func TestIsStreamingRunStale(t *testing.T) {
 	now := time.Date(2026, 3, 26, 18, 30, 0, 0, time.UTC)
 

--- a/server/internal/aichat/run_owner.go
+++ b/server/internal/aichat/run_owner.go
@@ -1,0 +1,60 @@
+package aichat
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	generationStatusQueued      = "queued"
+	generationStatusGenerating  = "generating"
+	generationStatusCompleted   = "completed"
+	generationStatusFailed      = "failed"
+	generationStatusInterrupted = "interrupted"
+
+	generationHeartbeatInterval = 5 * time.Second
+	generationLeaseDuration     = 30 * time.Second
+	chatGenerationTimeout       = 75 * time.Second
+	maxGenerationAttempts       = 2
+
+	runOwnerKindAPI     = "api"
+	runOwnerKindInngest = "inngest"
+)
+
+type runOwner struct {
+	value string
+}
+
+func newAPIRunOwner() runOwner {
+	host, err := os.Hostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		host = "unknown"
+	}
+	return newRunOwner(runOwnerKindAPI, fmt.Sprintf("%s-%d", host, os.Getpid()))
+}
+
+func newInngestRunOwner(runID int32) runOwner {
+	return newRunOwner(runOwnerKindInngest, fmt.Sprintf("run-%d", runID))
+}
+
+func newRunOwner(kind string, id string) runOwner {
+	kind = strings.TrimSpace(kind)
+	id = strings.TrimSpace(id)
+	if kind == "" {
+		kind = "unknown"
+	}
+	if id == "" {
+		id = "unknown"
+	}
+	return runOwner{value: kind + ":" + id}
+}
+
+func (o runOwner) Value() string {
+	return o.value
+}
+
+func (o runOwner) LeaseExpiresAt(now time.Time) time.Time {
+	return now.UTC().Add(generationLeaseDuration)
+}

--- a/server/internal/aichat/runtime.go
+++ b/server/internal/aichat/runtime.go
@@ -19,7 +19,7 @@ import (
 const (
 	geminiAPIKeyEnvVar = "GEMINI_API_KEY"
 	googleAPIKeyEnvVar = "GOOGLE_API_KEY"
-	chatStreamTimeout  = 45 * time.Second
+	chatStreamTimeout  = chatGenerationTimeout
 	chatMaxTurns       = 6
 )
 

--- a/server/internal/aichat/service.go
+++ b/server/internal/aichat/service.go
@@ -372,6 +372,15 @@ func (s *Service) RecoverStreamingRun(ctx context.Context, request RunRecoveryRe
 			time.Now().UTC(),
 		)
 	}
+	if generationAttemptsExhausted(prepared.Run) {
+		return s.repo.InterruptRun(
+			context.WithoutCancel(ctx),
+			prepared,
+			strings.TrimSpace(prepared.AssistantMessage.Content),
+			interruptionReasonAttemptsExhausted,
+			time.Now().UTC(),
+		)
+	}
 
 	owner := newInngestRunOwner(prepared.Run.ID)
 	if err := s.repo.ClaimRunGeneration(ctx, prepared.Run, owner, now); err != nil {
@@ -678,6 +687,10 @@ func shouldRecoverRun(run *ChatRun, now time.Time) bool {
 	default:
 		return false
 	}
+}
+
+func generationAttemptsExhausted(run *ChatRun) bool {
+	return run != nil && run.GenerationAttempt >= maxGenerationAttempts
 }
 
 func shouldStopResumeAndRecover(run *ChatRun, now time.Time) bool {

--- a/server/internal/aichat/service.go
+++ b/server/internal/aichat/service.go
@@ -48,8 +48,6 @@ const (
 	recoverStatusQueued          = "queued"
 	recoverStatusNotNeeded       = "not_needed"
 	recoverReasonStreamReconnect = "stream_reconnect"
-	runAwaitingRecoveryMarker    = "ai chat stream interrupted and awaiting recovery handoff"
-	runRecoveryClaimedMarker     = "ai chat recovery claimed and in progress"
 )
 
 func NewService(logger *slog.Logger, featureAccess featureAccessService, runtime runtime, repo Repository, workouts workoutCreator) *Service {
@@ -240,7 +238,21 @@ func (s *Service) PrepareMessageStream(ctx context.Context, conversationID int32
 }
 
 func (s *Service) StreamMessage(ctx context.Context, prepared *PreparedMessageStream, onChunk func(StreamChunk) error) (*StreamDone, error) {
-	return s.executePreparedRun(ctx, prepared, onChunk, true)
+	return s.executePreparedRun(ctx, prepared, onChunk)
+}
+
+func (s *Service) StartMessageGeneration(ctx context.Context, prepared *PreparedMessageStream) error {
+	owner := newAPIRunOwner()
+	now := time.Now().UTC()
+	if err := s.repo.ClaimRunGeneration(context.WithoutCancel(ctx), prepared.Run, owner, now); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrConversationBusy
+		}
+		return err
+	}
+
+	go s.runOwnedGeneration(context.WithoutCancel(ctx), prepared, owner)
+	return nil
 }
 
 func (s *Service) PrepareResumeMessageStream(ctx context.Context, conversationID int32, runID int32, afterSequence int32) (*PreparedResumeStream, error) {
@@ -351,32 +363,87 @@ func (s *Service) RecoverStreamingRun(ctx context.Context, request RunRecoveryRe
 	if !shouldRecoverRun(prepared.Run, now) {
 		return nil
 	}
-	if err := s.repo.ClaimRunRecovery(ctx, prepared.Run); err != nil {
+	if prepared.LastSequence > 0 || strings.TrimSpace(prepared.AssistantMessage.Content) != "" {
+		return s.repo.InterruptRun(
+			context.WithoutCancel(ctx),
+			prepared,
+			strings.TrimSpace(prepared.AssistantMessage.Content),
+			interruptionReasonStalePartial,
+			time.Now().UTC(),
+		)
+	}
+
+	owner := newInngestRunOwner(prepared.Run.ID)
+	if err := s.repo.ClaimRunGeneration(ctx, prepared.Run, owner, now); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
 		return err
 	}
 
-	_, err = s.executePreparedRun(ctx, prepared, nil, false)
-	if err == nil || prepared.Run == nil || prepared.Run.Status != statusStreaming {
-		return err
-	}
-
-	restoreErr := s.repo.MarkRunAwaitingRecovery(
-		context.WithoutCancel(ctx),
-		prepared,
-		strings.TrimSpace(prepared.AssistantMessage.Content),
-		time.Now().UTC(),
-	)
-	if restoreErr != nil {
-		return errors.Join(err, restoreErr)
-	}
-
+	_, err = s.executeOwnedRun(ctx, prepared, owner)
 	return err
 }
 
-func (s *Service) executePreparedRun(ctx context.Context, prepared *PreparedMessageStream, onChunk func(StreamChunk) error, allowRecovery bool) (*StreamDone, error) {
+func (s *Service) runOwnedGeneration(ctx context.Context, prepared *PreparedMessageStream, owner runOwner) {
+	if _, err := s.executeOwnedRun(ctx, prepared, owner); err != nil {
+		s.logger.Error("failed to complete owned ai chat generation",
+			"error", err,
+			"conversation_id", prepared.Conversation.ID,
+			"run_id", prepared.Run.ID,
+			"owner", owner.Value(),
+		)
+	}
+}
+
+func (s *Service) executeOwnedRun(ctx context.Context, prepared *PreparedMessageStream, owner runOwner) (*StreamDone, error) {
+	generationCtx, cancel := context.WithTimeout(ctx, chatGenerationTimeout)
+	defer cancel()
+
+	heartbeatDone := make(chan struct{})
+	go s.heartbeatRunGeneration(generationCtx, cancel, prepared, owner, heartbeatDone)
+
+	done, err := s.executePreparedRun(generationCtx, prepared, nil)
+	cancel()
+	<-heartbeatDone
+	return done, err
+}
+
+func (s *Service) heartbeatRunGeneration(ctx context.Context, cancel context.CancelFunc, prepared *PreparedMessageStream, owner runOwner, done chan<- struct{}) {
+	defer close(done)
+
+	ticker := time.NewTicker(generationHeartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			ok, err := s.repo.HeartbeatRunGeneration(context.WithoutCancel(ctx), prepared.Run, owner, now.UTC())
+			if err != nil {
+				s.logger.Error("failed to heartbeat ai chat generation",
+					"error", err,
+					"conversation_id", prepared.Conversation.ID,
+					"run_id", prepared.Run.ID,
+					"owner", owner.Value(),
+				)
+				continue
+			}
+			if !ok {
+				s.logger.Warn("ai chat generation lost ownership lease",
+					"conversation_id", prepared.Conversation.ID,
+					"run_id", prepared.Run.ID,
+					"owner", owner.Value(),
+				)
+				cancel()
+				return
+			}
+		}
+	}
+}
+
+func (s *Service) executePreparedRun(ctx context.Context, prepared *PreparedMessageStream, onChunk func(StreamChunk) error) (*StreamDone, error) {
 	traceStartedAt := time.Now()
 	history := toRuntimeHistory(prepared.History)
 	var partial strings.Builder
@@ -417,12 +484,6 @@ func (s *Service) executePreparedRun(ctx context.Context, prepared *PreparedMess
 		return nil
 	})
 	if err != nil {
-		if allowRecovery && errors.Is(err, ErrStreamDisconnected) {
-			if markErr := s.repo.MarkRunAwaitingRecovery(persistCtx, prepared, strings.TrimSpace(partial.String()), time.Now().UTC()); markErr != nil {
-				return nil, markErr
-			}
-			return nil, ErrStreamAwaitingRecovery
-		}
 		if failErr := s.failPreparedRun(persistCtx, prepared, partial.String(), err); failErr != nil {
 			s.logger.Error("failed to persist ai chat run failure", "error", failErr, "conversation_id", prepared.Conversation.ID, "run_id", prepared.Run.ID)
 		}
@@ -605,28 +666,18 @@ func isClientSafeError(err error) bool {
 		errors.Is(err, ErrGenerationTimeout)
 }
 
-func isRunAwaitingRecovery(run *ChatRun) bool {
-	if run == nil || run.ErrorMessage == nil {
-		return false
-	}
-	return strings.TrimSpace(*run.ErrorMessage) == runAwaitingRecoveryMarker
-}
-
-func isRunRecoveryClaimed(run *ChatRun) bool {
-	if run == nil || run.ErrorMessage == nil {
-		return false
-	}
-	return strings.TrimSpace(*run.ErrorMessage) == runRecoveryClaimedMarker
-}
-
 func shouldRecoverRun(run *ChatRun, now time.Time) bool {
 	if run == nil || run.Status != statusStreaming {
 		return false
 	}
-	if isRunAwaitingRecovery(run) {
-		return true
+	switch run.GenerationStatus {
+	case generationStatusGenerating:
+		return run.LeaseExpiresAt != nil && now.UTC().After(run.LeaseExpiresAt.UTC())
+	case generationStatusQueued:
+		return isStreamingRunStale(run.UpdatedAt, now)
+	default:
+		return false
 	}
-	return isRunRecoveryClaimed(run) && isStreamingRunStale(run.UpdatedAt, now)
 }
 
 func shouldStopResumeAndRecover(run *ChatRun, now time.Time) bool {

--- a/server/internal/aichat/service_test.go
+++ b/server/internal/aichat/service_test.go
@@ -128,18 +128,23 @@ func (m *mockRepository) PrepareMessageStream(ctx context.Context, conversationI
 	return prepared, args.Error(1)
 }
 
+func (m *mockRepository) ClaimRunGeneration(ctx context.Context, run *ChatRun, owner runOwner, now time.Time) error {
+	args := m.Called(ctx, run, owner, now)
+	return args.Error(0)
+}
+
+func (m *mockRepository) HeartbeatRunGeneration(ctx context.Context, run *ChatRun, owner runOwner, now time.Time) (bool, error) {
+	args := m.Called(ctx, run, owner, now)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *mockRepository) AppendStreamChunk(ctx context.Context, prepared *PreparedMessageStream, delta string, partialText string, updatedAt time.Time) (int32, error) {
 	args := m.Called(ctx, prepared, delta, partialText, updatedAt)
 	return args.Get(0).(int32), args.Error(1)
 }
 
-func (m *mockRepository) MarkRunAwaitingRecovery(ctx context.Context, prepared *PreparedMessageStream, partialText string, updatedAt time.Time) error {
-	args := m.Called(ctx, prepared, partialText, updatedAt)
-	return args.Error(0)
-}
-
-func (m *mockRepository) ClaimRunRecovery(ctx context.Context, run *ChatRun) error {
-	args := m.Called(ctx, run)
+func (m *mockRepository) InterruptRun(ctx context.Context, prepared *PreparedMessageStream, partialText string, reason string, completedAt time.Time) error {
+	args := m.Called(ctx, prepared, partialText, reason, completedAt)
 	return args.Error(0)
 }
 
@@ -596,15 +601,17 @@ func TestServiceRequestMessageRecovery_QueuesActiveRun(t *testing.T) {
 	service := NewService(logger, featureAccess, runtime, repo, nil)
 	service.SetRecoveryDispatcher(recovery)
 	ctx := user.WithContext(context.Background(), "user-123")
+	expiredLease := time.Now().UTC().Add(-time.Second)
 
 	featureAccess.On("HasCurrentUserFeatureAccess", mock.Anything, featureKeyAIChatbot).Return(true, nil).Once()
 	repo.On("GetConversation", mock.Anything, int32(41), "user-123").Return(&Conversation{ID: 41, UserID: "user-123"}, nil).Once()
 	repo.On("GetActiveRunForConversation", mock.Anything, int32(41), "user-123").Return(&ChatRun{
-		ID:             51,
-		ConversationID: 41,
-		UserID:         "user-123",
-		Status:         statusStreaming,
-		ErrorMessage:   stringPtr(runAwaitingRecoveryMarker),
+		ID:               51,
+		ConversationID:   41,
+		UserID:           "user-123",
+		Status:           statusStreaming,
+		GenerationStatus: generationStatusGenerating,
+		LeaseExpiresAt:   &expiredLease,
 	}, nil).Once()
 	recovery.On("EnqueueRunRecovery", mock.Anything, RunRecoveryRequest{
 		ConversationID: 41,
@@ -633,17 +640,17 @@ func TestServiceRequestMessageRecovery_QueuesStaleClaimedRun(t *testing.T) {
 	service := NewService(logger, featureAccess, runtime, repo, nil)
 	service.SetRecoveryDispatcher(recovery)
 	ctx := user.WithContext(context.Background(), "user-123")
-	staleUpdatedAt := time.Now().UTC().Add(-streamingRunStaleAfter - time.Second)
+	expiredLease := time.Now().UTC().Add(-time.Second)
 
 	featureAccess.On("HasCurrentUserFeatureAccess", mock.Anything, featureKeyAIChatbot).Return(true, nil).Once()
 	repo.On("GetConversation", mock.Anything, int32(41), "user-123").Return(&Conversation{ID: 41, UserID: "user-123"}, nil).Once()
 	repo.On("GetActiveRunForConversation", mock.Anything, int32(41), "user-123").Return(&ChatRun{
-		ID:             51,
-		ConversationID: 41,
-		UserID:         "user-123",
-		Status:         statusStreaming,
-		ErrorMessage:   stringPtr(runRecoveryClaimedMarker),
-		UpdatedAt:      staleUpdatedAt,
+		ID:               51,
+		ConversationID:   41,
+		UserID:           "user-123",
+		Status:           statusStreaming,
+		GenerationStatus: generationStatusGenerating,
+		LeaseExpiresAt:   &expiredLease,
 	}, nil).Once()
 	recovery.On("EnqueueRunRecovery", mock.Anything, RunRecoveryRequest{
 		ConversationID: 41,
@@ -753,7 +760,6 @@ func TestServiceStreamMessage_CompletesRun(t *testing.T) {
 			AssistantMessageID: 61,
 			Model:              defaultModelName,
 			Status:             statusStreaming,
-			ErrorMessage:       stringPtr(runAwaitingRecoveryMarker),
 		},
 		AssistantMessage: &ChatMessage{
 			ID:             61,
@@ -827,7 +833,7 @@ func TestServiceStreamMessage_CompletesRun(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
-func TestServiceStreamMessage_LeavesRunStreamingOnDisconnect(t *testing.T) {
+func TestServiceStreamMessage_FailsRunOnDisconnect(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	featureAccess := new(mockFeatureAccessService)
 	runtime := new(mockRuntime)
@@ -842,7 +848,6 @@ func TestServiceStreamMessage_LeavesRunStreamingOnDisconnect(t *testing.T) {
 			AssistantMessageID: 61,
 			Model:              defaultModelName,
 			Status:             statusStreaming,
-			ErrorMessage:       stringPtr(runAwaitingRecoveryMarker),
 		},
 		AssistantMessage: &ChatMessage{
 			ID:             61,
@@ -859,7 +864,7 @@ func TestServiceStreamMessage_LeavesRunStreamingOnDisconnect(t *testing.T) {
 		require.ErrorIs(t, err, ErrStreamDisconnected)
 	}).Return((*StreamDone)(nil), ErrStreamDisconnected).Once()
 	repo.On("AppendStreamChunk", mock.Anything, prepared, "partial ", "partial", mock.AnythingOfType("time.Time")).Return(int32(1), nil).Once()
-	repo.On("MarkRunAwaitingRecovery", mock.Anything, prepared, "partial", mock.AnythingOfType("time.Time")).Return(nil).Once()
+	repo.On("FailRun", mock.Anything, prepared, "partial", ErrStreamDisconnected, mock.AnythingOfType("time.Time")).Return(nil).Once()
 
 	done, err := service.StreamMessage(context.Background(), prepared, func(StreamChunk) error {
 		return errors.New("broken pipe")
@@ -867,8 +872,7 @@ func TestServiceStreamMessage_LeavesRunStreamingOnDisconnect(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, done)
-	assert.ErrorIs(t, err, ErrStreamAwaitingRecovery)
-	repo.AssertNotCalled(t, "FailRun", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	assert.ErrorIs(t, err, ErrStreamDisconnected)
 	repo.AssertNotCalled(t, "CompleteRun", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	runtime.AssertExpectations(t)
 	repo.AssertExpectations(t)
@@ -889,7 +893,6 @@ func TestServiceStreamMessage_FailsRunOnRuntimeError(t *testing.T) {
 			AssistantMessageID: 61,
 			Model:              defaultModelName,
 			Status:             statusStreaming,
-			ErrorMessage:       stringPtr(runAwaitingRecoveryMarker),
 		},
 		AssistantMessage: &ChatMessage{
 			ID:             61,
@@ -918,7 +921,7 @@ func TestServiceStreamMessage_FailsRunOnRuntimeError(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
-func TestServiceRecoverStreamingRun_CompletesActiveRun(t *testing.T) {
+func TestServiceStartMessageGeneration_ContinuesAfterCallerContextCanceled(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	featureAccess := new(mockFeatureAccessService)
 	runtime := new(mockRuntime)
@@ -928,13 +931,90 @@ func TestServiceRecoverStreamingRun_CompletesActiveRun(t *testing.T) {
 	prepared := &PreparedMessageStream{
 		Conversation: &Conversation{ID: 41, UserID: "user-123"},
 		Run: &ChatRun{
+			ID:               51,
+			ConversationID:   41,
+			UserID:           "user-123",
+			Model:            defaultModelName,
+			Status:           statusStreaming,
+			GenerationStatus: generationStatusQueued,
+		},
+		AssistantMessage: &ChatMessage{
+			ID:             61,
+			ConversationID: 41,
+			UserID:         "user-123",
+			Status:         statusStreaming,
+		},
+		Prompt: "new prompt",
+	}
+	completed := make(chan struct{})
+
+	repo.On("ClaimRunGeneration", mock.Anything, prepared.Run, mock.Anything, mock.AnythingOfType("time.Time")).Run(func(args mock.Arguments) {
+		run := args.Get(1).(*ChatRun)
+		run.GenerationStatus = generationStatusGenerating
+		run.GenerationOwner = stringPtr("api:test")
+	}).Return(nil).Once()
+	runtime.On("StreamChat", mock.Anything, "new prompt", []RuntimeChatMessage{}, mock.Anything).Run(func(args mock.Arguments) {
+		streamCtx := args.Get(0).(context.Context)
+		require.NoError(t, streamCtx.Err())
+	}).Return(&StreamDone{
+		Model: defaultModelName,
+		Text:  "hello",
+	}, nil).Once()
+	repo.On("CompleteRun", mock.Anything, prepared, "hello", (*workout.CreateWorkoutRequest)(nil), mock.AnythingOfType("time.Time")).Run(func(mock.Arguments) {
+		close(completed)
+	}).Return(&ChatMessage{
+		ID:             61,
+		ConversationID: 41,
+		UserID:         "user-123",
+		Status:         statusCompleted,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		CompletedAt:    &now,
+	}, &ChatRun{
+		ID:             51,
+		ConversationID: 41,
+		UserID:         "user-123",
+		Model:          defaultModelName,
+		Status:         statusCompleted,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		StartedAt:      now,
+		CompletedAt:    &now,
+	}, nil).Once()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, service.StartMessageGeneration(ctx, prepared))
+	cancel()
+
+	select {
+	case <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("generation did not complete after caller context cancellation")
+	}
+
+	runtime.AssertExpectations(t)
+	repo.AssertExpectations(t)
+}
+
+func TestServiceRecoverStreamingRun_CompletesActiveRun(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	featureAccess := new(mockFeatureAccessService)
+	runtime := new(mockRuntime)
+	repo := new(mockRepository)
+	service := NewService(logger, featureAccess, runtime, repo, nil)
+	now := time.Date(2026, 3, 26, 17, 30, 0, 0, time.UTC)
+	expiredLease := now.Add(-time.Second)
+	prepared := &PreparedMessageStream{
+		Conversation: &Conversation{ID: 41, UserID: "user-123"},
+		Run: &ChatRun{
 			ID:                 51,
 			ConversationID:     41,
 			UserID:             "user-123",
 			AssistantMessageID: 61,
 			Model:              defaultModelName,
 			Status:             statusStreaming,
-			ErrorMessage:       stringPtr(runAwaitingRecoveryMarker),
+			GenerationStatus:   generationStatusGenerating,
+			LeaseExpiresAt:     &expiredLease,
 		},
 		AssistantMessage: &ChatMessage{
 			ID:             61,
@@ -950,9 +1030,10 @@ func TestServiceRecoverStreamingRun_CompletesActiveRun(t *testing.T) {
 
 	runtime.On("Available").Return(true).Once()
 	repo.On("LoadPreparedRunForRecovery", mock.Anything, int32(51), "user-123").Return(prepared, nil).Once()
-	repo.On("ClaimRunRecovery", mock.Anything, prepared.Run).Run(func(args mock.Arguments) {
+	repo.On("ClaimRunGeneration", mock.Anything, prepared.Run, mock.Anything, mock.AnythingOfType("time.Time")).Run(func(args mock.Arguments) {
 		run := args.Get(1).(*ChatRun)
-		run.ErrorMessage = stringPtr(runRecoveryClaimedMarker)
+		run.GenerationStatus = generationStatusGenerating
+		run.GenerationOwner = stringPtr("inngest:run-51")
 		run.UpdatedAt = now
 	}).Return(nil).Once()
 	runtime.On("StreamChat", mock.Anything, "new prompt", []RuntimeChatMessage{
@@ -1000,13 +1081,14 @@ func TestServiceRecoverStreamingRun_CompletesActiveRun(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
-func TestServiceRecoverStreamingRun_ReclaimsStaleClaimedRun(t *testing.T) {
+func TestServiceRecoverStreamingRun_InterruptsStalePartialRun(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	featureAccess := new(mockFeatureAccessService)
 	runtime := new(mockRuntime)
 	repo := new(mockRepository)
 	service := NewService(logger, featureAccess, runtime, repo, nil)
 	now := time.Date(2026, 3, 26, 17, 30, 0, 0, time.UTC)
+	expiredLease := now.Add(-time.Second)
 	prepared := &PreparedMessageStream{
 		Conversation: &Conversation{ID: 41, UserID: "user-123"},
 		Run: &ChatRun{
@@ -1016,8 +1098,58 @@ func TestServiceRecoverStreamingRun_ReclaimsStaleClaimedRun(t *testing.T) {
 			AssistantMessageID: 61,
 			Model:              defaultModelName,
 			Status:             statusStreaming,
-			ErrorMessage:       stringPtr(runRecoveryClaimedMarker),
-			UpdatedAt:          now.Add(-streamingRunStaleAfter - time.Second),
+			GenerationStatus:   generationStatusGenerating,
+			LeaseExpiresAt:     &expiredLease,
+		},
+		AssistantMessage: &ChatMessage{
+			ID:             61,
+			ConversationID: 41,
+			UserID:         "user-123",
+			Content:        "partial answer",
+			Status:         statusStreaming,
+		},
+		Prompt:       "new prompt",
+		LastSequence: 1,
+	}
+
+	runtime.On("Available").Return(true).Once()
+	repo.On("LoadPreparedRunForRecovery", mock.Anything, int32(51), "user-123").Return(prepared, nil).Once()
+	repo.On("InterruptRun", mock.Anything, prepared, "partial answer", interruptionReasonStalePartial, mock.AnythingOfType("time.Time")).Return(nil).Once()
+
+	err := service.RecoverStreamingRun(context.Background(), RunRecoveryRequest{
+		ConversationID: 41,
+		RunID:          51,
+		UserID:         "user-123",
+		Reason:         recoverReasonStreamReconnect,
+	})
+
+	require.NoError(t, err)
+	repo.AssertNotCalled(t, "ClaimRunGeneration", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	runtime.AssertNotCalled(t, "StreamChat", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	runtime.AssertExpectations(t)
+	repo.AssertExpectations(t)
+}
+
+func TestServiceRecoverStreamingRun_ReclaimsStaleClaimedRun(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	featureAccess := new(mockFeatureAccessService)
+	runtime := new(mockRuntime)
+	repo := new(mockRepository)
+	service := NewService(logger, featureAccess, runtime, repo, nil)
+	now := time.Date(2026, 3, 26, 17, 30, 0, 0, time.UTC)
+	expiredLease := now.Add(-time.Second)
+	prepared := &PreparedMessageStream{
+		Conversation: &Conversation{ID: 41, UserID: "user-123"},
+		Run: &ChatRun{
+			ID:                 51,
+			ConversationID:     41,
+			UserID:             "user-123",
+			AssistantMessageID: 61,
+			Model:              defaultModelName,
+			Status:             statusStreaming,
+			GenerationStatus:   generationStatusGenerating,
+			LeaseExpiresAt:     &expiredLease,
+			UpdatedAt:          now,
 		},
 		AssistantMessage: &ChatMessage{
 			ID:             61,
@@ -1033,9 +1165,10 @@ func TestServiceRecoverStreamingRun_ReclaimsStaleClaimedRun(t *testing.T) {
 
 	runtime.On("Available").Return(true).Once()
 	repo.On("LoadPreparedRunForRecovery", mock.Anything, int32(51), "user-123").Return(prepared, nil).Once()
-	repo.On("ClaimRunRecovery", mock.Anything, prepared.Run).Run(func(args mock.Arguments) {
+	repo.On("ClaimRunGeneration", mock.Anything, prepared.Run, mock.Anything, mock.AnythingOfType("time.Time")).Run(func(args mock.Arguments) {
 		run := args.Get(1).(*ChatRun)
-		run.ErrorMessage = stringPtr(runRecoveryClaimedMarker)
+		run.GenerationStatus = generationStatusGenerating
+		run.GenerationOwner = stringPtr("inngest:run-51")
 		run.UpdatedAt = now
 	}).Return(nil).Once()
 	runtime.On("StreamChat", mock.Anything, "new prompt", []RuntimeChatMessage{
@@ -1089,6 +1222,7 @@ func TestServiceRecoverStreamingRun_SkipsFreshClaimedRun(t *testing.T) {
 	runtime := new(mockRuntime)
 	repo := new(mockRepository)
 	service := NewService(logger, featureAccess, runtime, repo, nil)
+	validLease := time.Now().UTC().Add(generationLeaseDuration)
 	prepared := &PreparedMessageStream{
 		Conversation: &Conversation{ID: 41, UserID: "user-123"},
 		Run: &ChatRun{
@@ -1098,7 +1232,8 @@ func TestServiceRecoverStreamingRun_SkipsFreshClaimedRun(t *testing.T) {
 			AssistantMessageID: 61,
 			Model:              defaultModelName,
 			Status:             statusStreaming,
-			ErrorMessage:       stringPtr(runRecoveryClaimedMarker),
+			GenerationStatus:   generationStatusGenerating,
+			LeaseExpiresAt:     &validLease,
 			UpdatedAt:          time.Now().UTC(),
 		},
 		AssistantMessage: &ChatMessage{
@@ -1121,7 +1256,7 @@ func TestServiceRecoverStreamingRun_SkipsFreshClaimedRun(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	repo.AssertNotCalled(t, "ClaimRunRecovery", mock.Anything, mock.Anything)
+	repo.AssertNotCalled(t, "ClaimRunGeneration", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	repo.AssertExpectations(t)
 	runtime.AssertExpectations(t)
 }
@@ -1218,6 +1353,7 @@ func TestServiceResumeMessageStream_EndsWhenRunAwaitsRecovery(t *testing.T) {
 	runtime := new(mockRuntime)
 	repo := new(mockRepository)
 	service := NewService(logger, featureAccess, runtime, repo, nil)
+	expiredLease := time.Now().UTC().Add(-time.Second)
 	prepared := &PreparedResumeStream{
 		Conversation: &Conversation{ID: 41, UserID: "user-123"},
 		Run: &ChatRun{
@@ -1227,6 +1363,8 @@ func TestServiceResumeMessageStream_EndsWhenRunAwaitsRecovery(t *testing.T) {
 			AssistantMessageID: 61,
 			Model:              defaultModelName,
 			Status:             statusStreaming,
+			GenerationStatus:   generationStatusGenerating,
+			LeaseExpiresAt:     &expiredLease,
 		},
 		AssistantMessage: &ChatMessage{
 			ID:             61,
@@ -1247,7 +1385,8 @@ func TestServiceResumeMessageStream_EndsWhenRunAwaitsRecovery(t *testing.T) {
 			AssistantMessageID: 61,
 			Model:              defaultModelName,
 			Status:             statusStreaming,
-			ErrorMessage:       stringPtr(runAwaitingRecoveryMarker),
+			GenerationStatus:   generationStatusGenerating,
+			LeaseExpiresAt:     &expiredLease,
 		},
 		AssistantMessage: prepared.AssistantMessage,
 		AfterSequence:    1,
@@ -1278,6 +1417,8 @@ func TestServiceResumeMessageStream_EndsWhenClaimedRunTurnsStale(t *testing.T) {
 	repo := new(mockRepository)
 	service := NewService(logger, featureAccess, runtime, repo, nil)
 	now := time.Now().UTC()
+	validLease := now.Add(generationLeaseDuration)
+	expiredLease := now.Add(-time.Second)
 	prepared := &PreparedResumeStream{
 		Conversation: &Conversation{ID: 41, UserID: "user-123"},
 		Run: &ChatRun{
@@ -1287,7 +1428,8 @@ func TestServiceResumeMessageStream_EndsWhenClaimedRunTurnsStale(t *testing.T) {
 			AssistantMessageID: 61,
 			Model:              defaultModelName,
 			Status:             statusStreaming,
-			ErrorMessage:       stringPtr(runRecoveryClaimedMarker),
+			GenerationStatus:   generationStatusGenerating,
+			LeaseExpiresAt:     &validLease,
 			UpdatedAt:          now,
 		},
 		AssistantMessage: &ChatMessage{
@@ -1309,8 +1451,9 @@ func TestServiceResumeMessageStream_EndsWhenClaimedRunTurnsStale(t *testing.T) {
 			AssistantMessageID: 61,
 			Model:              defaultModelName,
 			Status:             statusStreaming,
-			ErrorMessage:       stringPtr(runRecoveryClaimedMarker),
-			UpdatedAt:          now.Add(-streamingRunStaleAfter - time.Second),
+			GenerationStatus:   generationStatusGenerating,
+			LeaseExpiresAt:     &expiredLease,
+			UpdatedAt:          now,
 		},
 		AssistantMessage: prepared.AssistantMessage,
 		AfterSequence:    1,
@@ -1363,7 +1506,6 @@ func TestServiceRecoverStreamingRun_IgnoresRunsWithoutRecoveryMarker(t *testing.
 	})
 
 	require.NoError(t, err)
-	repo.AssertNotCalled(t, "ClaimRunRecovery", mock.Anything, mock.Anything, mock.Anything)
 	runtime.AssertExpectations(t)
 	repo.AssertExpectations(t)
 }

--- a/server/internal/aichat/service_test.go
+++ b/server/internal/aichat/service_test.go
@@ -1130,6 +1130,54 @@ func TestServiceRecoverStreamingRun_InterruptsStalePartialRun(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestServiceRecoverStreamingRun_InterruptsRunWhenGenerationAttemptsExhausted(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	featureAccess := new(mockFeatureAccessService)
+	runtime := new(mockRuntime)
+	repo := new(mockRepository)
+	service := NewService(logger, featureAccess, runtime, repo, nil)
+	now := time.Date(2026, 3, 26, 17, 30, 0, 0, time.UTC)
+	expiredLease := now.Add(-time.Second)
+	prepared := &PreparedMessageStream{
+		Conversation: &Conversation{ID: 41, UserID: "user-123"},
+		Run: &ChatRun{
+			ID:                 51,
+			ConversationID:     41,
+			UserID:             "user-123",
+			AssistantMessageID: 61,
+			Model:              defaultModelName,
+			Status:             statusStreaming,
+			GenerationStatus:   generationStatusGenerating,
+			LeaseExpiresAt:     &expiredLease,
+			GenerationAttempt:  maxGenerationAttempts,
+		},
+		AssistantMessage: &ChatMessage{
+			ID:             61,
+			ConversationID: 41,
+			UserID:         "user-123",
+			Status:         statusStreaming,
+		},
+		Prompt: "new prompt",
+	}
+
+	runtime.On("Available").Return(true).Once()
+	repo.On("LoadPreparedRunForRecovery", mock.Anything, int32(51), "user-123").Return(prepared, nil).Once()
+	repo.On("InterruptRun", mock.Anything, prepared, "", interruptionReasonAttemptsExhausted, mock.AnythingOfType("time.Time")).Return(nil).Once()
+
+	err := service.RecoverStreamingRun(context.Background(), RunRecoveryRequest{
+		ConversationID: 41,
+		RunID:          51,
+		UserID:         "user-123",
+		Reason:         recoverReasonStreamReconnect,
+	})
+
+	require.NoError(t, err)
+	repo.AssertNotCalled(t, "ClaimRunGeneration", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	runtime.AssertNotCalled(t, "StreamChat", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	runtime.AssertExpectations(t)
+	repo.AssertExpectations(t)
+}
+
 func TestServiceRecoverStreamingRun_ReclaimsStaleClaimedRun(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	featureAccess := new(mockFeatureAccessService)

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -35,20 +35,27 @@ type AiChatMessage struct {
 }
 
 type AiChatRun struct {
-	ID                 int32              `json:"id"`
-	ConversationID     int32              `json:"conversation_id"`
-	UserID             string             `json:"user_id"`
-	UserMessageID      int32              `json:"user_message_id"`
-	AssistantMessageID int32              `json:"assistant_message_id"`
-	Model              string             `json:"model"`
-	Status             string             `json:"status"`
-	RequestID          pgtype.Text        `json:"request_id"`
-	ErrorMessage       pgtype.Text        `json:"error_message"`
-	WorkoutDraft       []byte             `json:"workout_draft"`
-	CreatedAt          pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
-	StartedAt          pgtype.Timestamptz `json:"started_at"`
-	CompletedAt        pgtype.Timestamptz `json:"completed_at"`
+	ID                       int32              `json:"id"`
+	ConversationID           int32              `json:"conversation_id"`
+	UserID                   string             `json:"user_id"`
+	UserMessageID            int32              `json:"user_message_id"`
+	AssistantMessageID       int32              `json:"assistant_message_id"`
+	Model                    string             `json:"model"`
+	Status                   string             `json:"status"`
+	RequestID                pgtype.Text        `json:"request_id"`
+	ErrorMessage             pgtype.Text        `json:"error_message"`
+	WorkoutDraft             []byte             `json:"workout_draft"`
+	GenerationStatus         string             `json:"generation_status"`
+	GenerationOwner          pgtype.Text        `json:"generation_owner"`
+	GenerationLeaseExpiresAt pgtype.Timestamptz `json:"generation_lease_expires_at"`
+	GenerationHeartbeatAt    pgtype.Timestamptz `json:"generation_heartbeat_at"`
+	GenerationAttempt        int32              `json:"generation_attempt"`
+	InterruptedAt            pgtype.Timestamptz `json:"interrupted_at"`
+	InterruptionReason       pgtype.Text        `json:"interruption_reason"`
+	CreatedAt                pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt                pgtype.Timestamptz `json:"updated_at"`
+	StartedAt                pgtype.Timestamptz `json:"started_at"`
+	CompletedAt              pgtype.Timestamptz `json:"completed_at"`
 }
 
 type AiChatStreamChunk struct {

--- a/server/internal/database/query.sql.go
+++ b/server/internal/database/query.sql.go
@@ -11,15 +11,27 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const claimAIChatRunRecovery = `-- name: ClaimAIChatRunRecovery :one
+const claimAIChatRunGeneration = `-- name: ClaimAIChatRunGeneration :one
 UPDATE ai_chat_run
-SET error_message = $5,
+SET generation_status = 'generating',
+    generation_owner = $3,
+    generation_lease_expires_at = $4,
+    generation_heartbeat_at = $5,
+    generation_attempt = generation_attempt + 1,
+    error_message = NULL,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1
   AND user_id = $2
   AND status = 'streaming'
-  AND error_message = $3
-  AND updated_at = $4
+  AND generation_attempt < $6
+  AND (
+    generation_status = 'queued'
+    OR (
+      generation_status = 'generating'
+      AND generation_lease_expires_at IS NOT NULL
+      AND generation_lease_expires_at < $5
+    )
+  )
 RETURNING
     id,
     conversation_id,
@@ -31,27 +43,36 @@ RETURNING
     request_id,
     error_message,
     workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
     created_at,
     updated_at,
     started_at,
     completed_at
 `
 
-type ClaimAIChatRunRecoveryParams struct {
-	ID             int32              `json:"id"`
-	UserID         string             `json:"user_id"`
-	ErrorMessage   pgtype.Text        `json:"error_message"`
-	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
-	ErrorMessage_2 pgtype.Text        `json:"error_message_2"`
+type ClaimAIChatRunGenerationParams struct {
+	ID                       int32              `json:"id"`
+	UserID                   string             `json:"user_id"`
+	GenerationOwner          pgtype.Text        `json:"generation_owner"`
+	GenerationLeaseExpiresAt pgtype.Timestamptz `json:"generation_lease_expires_at"`
+	GenerationHeartbeatAt    pgtype.Timestamptz `json:"generation_heartbeat_at"`
+	GenerationAttempt        int32              `json:"generation_attempt"`
 }
 
-func (q *Queries) ClaimAIChatRunRecovery(ctx context.Context, arg ClaimAIChatRunRecoveryParams) (AiChatRun, error) {
-	row := q.db.QueryRow(ctx, claimAIChatRunRecovery,
+func (q *Queries) ClaimAIChatRunGeneration(ctx context.Context, arg ClaimAIChatRunGenerationParams) (AiChatRun, error) {
+	row := q.db.QueryRow(ctx, claimAIChatRunGeneration,
 		arg.ID,
 		arg.UserID,
-		arg.ErrorMessage,
-		arg.UpdatedAt,
-		arg.ErrorMessage_2,
+		arg.GenerationOwner,
+		arg.GenerationLeaseExpiresAt,
+		arg.GenerationHeartbeatAt,
+		arg.GenerationAttempt,
 	)
 	var i AiChatRun
 	err := row.Scan(
@@ -65,6 +86,13 @@ func (q *Queries) ClaimAIChatRunRecovery(ctx context.Context, arg ClaimAIChatRun
 		&i.RequestID,
 		&i.ErrorMessage,
 		&i.WorkoutDraft,
+		&i.GenerationStatus,
+		&i.GenerationOwner,
+		&i.GenerationLeaseExpiresAt,
+		&i.GenerationHeartbeatAt,
+		&i.GenerationAttempt,
+		&i.InterruptedAt,
+		&i.InterruptionReason,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.StartedAt,
@@ -280,6 +308,13 @@ RETURNING
     request_id,
     error_message,
     workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
     created_at,
     updated_at,
     started_at,
@@ -322,6 +357,13 @@ func (q *Queries) CreateAIChatRun(ctx context.Context, arg CreateAIChatRunParams
 		&i.RequestID,
 		&i.ErrorMessage,
 		&i.WorkoutDraft,
+		&i.GenerationStatus,
+		&i.GenerationOwner,
+		&i.GenerationLeaseExpiresAt,
+		&i.GenerationHeartbeatAt,
+		&i.GenerationAttempt,
+		&i.InterruptedAt,
+		&i.InterruptionReason,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.StartedAt,
@@ -337,7 +379,19 @@ INSERT INTO ai_chat_stream_chunk (
     sequence,
     delta_text
 )
-VALUES ($1, $2, $3, $4)
+SELECT $1, $2, $3, $4
+WHERE (
+    NULLIF($5::text, '') IS NULL
+    OR EXISTS (
+        SELECT 1
+        FROM ai_chat_run
+        WHERE id = $1
+          AND user_id = $2
+          AND status = 'streaming'
+          AND generation_status = 'generating'
+          AND generation_owner = $5
+    )
+)
 RETURNING
     run_id,
     user_id,
@@ -351,6 +405,7 @@ type CreateAIChatStreamChunkParams struct {
 	UserID    string `json:"user_id"`
 	Sequence  int32  `json:"sequence"`
 	DeltaText string `json:"delta_text"`
+	Column5   string `json:"column_5"`
 }
 
 func (q *Queries) CreateAIChatStreamChunk(ctx context.Context, arg CreateAIChatStreamChunkParams) (AiChatStreamChunk, error) {
@@ -359,6 +414,7 @@ func (q *Queries) CreateAIChatStreamChunk(ctx context.Context, arg CreateAIChatS
 		arg.UserID,
 		arg.Sequence,
 		arg.DeltaText,
+		arg.Column5,
 	)
 	var i AiChatStreamChunk
 	err := row.Scan(
@@ -636,6 +692,13 @@ SELECT
     request_id,
     error_message,
     workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
     created_at,
     updated_at,
     started_at,
@@ -664,6 +727,13 @@ func (q *Queries) GetAIChatRun(ctx context.Context, arg GetAIChatRunParams) (AiC
 		&i.RequestID,
 		&i.ErrorMessage,
 		&i.WorkoutDraft,
+		&i.GenerationStatus,
+		&i.GenerationOwner,
+		&i.GenerationLeaseExpiresAt,
+		&i.GenerationHeartbeatAt,
+		&i.GenerationAttempt,
+		&i.InterruptedAt,
+		&i.InterruptionReason,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.StartedAt,
@@ -709,6 +779,13 @@ SELECT
     request_id,
     error_message,
     workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
     created_at,
     updated_at,
     started_at,
@@ -740,6 +817,13 @@ func (q *Queries) GetActiveAIChatRunForConversation(ctx context.Context, arg Get
 		&i.RequestID,
 		&i.ErrorMessage,
 		&i.WorkoutDraft,
+		&i.GenerationStatus,
+		&i.GenerationOwner,
+		&i.GenerationLeaseExpiresAt,
+		&i.GenerationHeartbeatAt,
+		&i.GenerationAttempt,
+		&i.InterruptedAt,
+		&i.InterruptionReason,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.StartedAt,
@@ -1944,6 +2028,40 @@ func (q *Queries) HasProcessedStripeWebhookEvent(ctx context.Context, stripeEven
 	return exists, err
 }
 
+const heartbeatAIChatRunGeneration = `-- name: HeartbeatAIChatRunGeneration :execrows
+UPDATE ai_chat_run
+SET generation_lease_expires_at = $3,
+    generation_heartbeat_at = $4,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = $1
+  AND user_id = $2
+  AND status = 'streaming'
+  AND generation_status = 'generating'
+  AND generation_owner = $5
+`
+
+type HeartbeatAIChatRunGenerationParams struct {
+	ID                       int32              `json:"id"`
+	UserID                   string             `json:"user_id"`
+	GenerationLeaseExpiresAt pgtype.Timestamptz `json:"generation_lease_expires_at"`
+	GenerationHeartbeatAt    pgtype.Timestamptz `json:"generation_heartbeat_at"`
+	GenerationOwner          pgtype.Text        `json:"generation_owner"`
+}
+
+func (q *Queries) HeartbeatAIChatRunGeneration(ctx context.Context, arg HeartbeatAIChatRunGenerationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, heartbeatAIChatRunGeneration,
+		arg.ID,
+		arg.UserID,
+		arg.GenerationLeaseExpiresAt,
+		arg.GenerationHeartbeatAt,
+		arg.GenerationOwner,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const listAIChatMessagesByConversation = `-- name: ListAIChatMessagesByConversation :many
 SELECT
     id,
@@ -2379,58 +2497,6 @@ func (q *Queries) MarkAIChatConversationLatestWorkoutDraftSaved(ctx context.Cont
 	return i, err
 }
 
-const markAIChatRunAwaitingRecovery = `-- name: MarkAIChatRunAwaitingRecovery :one
-UPDATE ai_chat_run
-SET error_message = $3,
-    updated_at = CURRENT_TIMESTAMP
-WHERE id = $1
-  AND user_id = $2
-  AND status = 'streaming'
-RETURNING
-    id,
-    conversation_id,
-    user_id,
-    user_message_id,
-    assistant_message_id,
-    model,
-    status,
-    request_id,
-    error_message,
-    workout_draft,
-    created_at,
-    updated_at,
-    started_at,
-    completed_at
-`
-
-type MarkAIChatRunAwaitingRecoveryParams struct {
-	ID           int32       `json:"id"`
-	UserID       string      `json:"user_id"`
-	ErrorMessage pgtype.Text `json:"error_message"`
-}
-
-func (q *Queries) MarkAIChatRunAwaitingRecovery(ctx context.Context, arg MarkAIChatRunAwaitingRecoveryParams) (AiChatRun, error) {
-	row := q.db.QueryRow(ctx, markAIChatRunAwaitingRecovery, arg.ID, arg.UserID, arg.ErrorMessage)
-	var i AiChatRun
-	err := row.Scan(
-		&i.ID,
-		&i.ConversationID,
-		&i.UserID,
-		&i.UserMessageID,
-		&i.AssistantMessageID,
-		&i.Model,
-		&i.Status,
-		&i.RequestID,
-		&i.ErrorMessage,
-		&i.WorkoutDraft,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.StartedAt,
-		&i.CompletedAt,
-	)
-	return i, err
-}
-
 const markStripeWebhookEventProcessed = `-- name: MarkStripeWebhookEventProcessed :exec
 INSERT INTO stripe_webhook_events (
     stripe_event_id,
@@ -2740,8 +2806,16 @@ SET status = 'completed',
     error_message = NULL,
     completed_at = $3,
     workout_draft = NULLIF($4::text, '')::jsonb,
+    generation_status = 'completed',
+    generation_owner = NULL,
+    generation_lease_expires_at = NULL,
+    generation_heartbeat_at = NULL,
+    interrupted_at = NULL,
+    interruption_reason = NULL,
     updated_at = CURRENT_TIMESTAMP
-WHERE id = $1 AND user_id = $2
+WHERE id = $1
+  AND user_id = $2
+  AND (NULLIF($5::text, '') IS NULL OR generation_owner = $5)
 RETURNING
     id,
     conversation_id,
@@ -2753,6 +2827,13 @@ RETURNING
     request_id,
     error_message,
     workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
     created_at,
     updated_at,
     started_at,
@@ -2764,6 +2845,7 @@ type UpdateAIChatRunCompletedParams struct {
 	UserID      string             `json:"user_id"`
 	CompletedAt pgtype.Timestamptz `json:"completed_at"`
 	Column4     string             `json:"column_4"`
+	Column5     string             `json:"column_5"`
 }
 
 func (q *Queries) UpdateAIChatRunCompleted(ctx context.Context, arg UpdateAIChatRunCompletedParams) (AiChatRun, error) {
@@ -2772,6 +2854,7 @@ func (q *Queries) UpdateAIChatRunCompleted(ctx context.Context, arg UpdateAIChat
 		arg.UserID,
 		arg.CompletedAt,
 		arg.Column4,
+		arg.Column5,
 	)
 	var i AiChatRun
 	err := row.Scan(
@@ -2785,6 +2868,13 @@ func (q *Queries) UpdateAIChatRunCompleted(ctx context.Context, arg UpdateAIChat
 		&i.RequestID,
 		&i.ErrorMessage,
 		&i.WorkoutDraft,
+		&i.GenerationStatus,
+		&i.GenerationOwner,
+		&i.GenerationLeaseExpiresAt,
+		&i.GenerationHeartbeatAt,
+		&i.GenerationAttempt,
+		&i.InterruptedAt,
+		&i.InterruptionReason,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.StartedAt,
@@ -2799,8 +2889,16 @@ SET status = 'failed',
     error_message = $3,
     completed_at = $4,
     workout_draft = NULL,
+    generation_status = 'failed',
+    generation_owner = NULL,
+    generation_lease_expires_at = NULL,
+    generation_heartbeat_at = NULL,
+    interrupted_at = NULL,
+    interruption_reason = NULL,
     updated_at = CURRENT_TIMESTAMP
-WHERE id = $1 AND user_id = $2
+WHERE id = $1
+  AND user_id = $2
+  AND (NULLIF($5::text, '') IS NULL OR generation_owner = $5)
 RETURNING
     id,
     conversation_id,
@@ -2812,6 +2910,13 @@ RETURNING
     request_id,
     error_message,
     workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
     created_at,
     updated_at,
     started_at,
@@ -2823,6 +2928,7 @@ type UpdateAIChatRunFailedParams struct {
 	UserID       string             `json:"user_id"`
 	ErrorMessage pgtype.Text        `json:"error_message"`
 	CompletedAt  pgtype.Timestamptz `json:"completed_at"`
+	Column5      string             `json:"column_5"`
 }
 
 func (q *Queries) UpdateAIChatRunFailed(ctx context.Context, arg UpdateAIChatRunFailedParams) (AiChatRun, error) {
@@ -2831,6 +2937,7 @@ func (q *Queries) UpdateAIChatRunFailed(ctx context.Context, arg UpdateAIChatRun
 		arg.UserID,
 		arg.ErrorMessage,
 		arg.CompletedAt,
+		arg.Column5,
 	)
 	var i AiChatRun
 	err := row.Scan(
@@ -2844,6 +2951,94 @@ func (q *Queries) UpdateAIChatRunFailed(ctx context.Context, arg UpdateAIChatRun
 		&i.RequestID,
 		&i.ErrorMessage,
 		&i.WorkoutDraft,
+		&i.GenerationStatus,
+		&i.GenerationOwner,
+		&i.GenerationLeaseExpiresAt,
+		&i.GenerationHeartbeatAt,
+		&i.GenerationAttempt,
+		&i.InterruptedAt,
+		&i.InterruptionReason,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+	)
+	return i, err
+}
+
+const updateAIChatRunInterrupted = `-- name: UpdateAIChatRunInterrupted :one
+UPDATE ai_chat_run
+SET status = 'failed',
+    error_message = $3,
+    completed_at = $4,
+    workout_draft = NULL,
+    generation_status = 'interrupted',
+    generation_owner = NULL,
+    generation_lease_expires_at = NULL,
+    generation_heartbeat_at = NULL,
+    interrupted_at = $4,
+    interruption_reason = $5,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = $1 AND user_id = $2
+RETURNING
+    id,
+    conversation_id,
+    user_id,
+    user_message_id,
+    assistant_message_id,
+    model,
+    status,
+    request_id,
+    error_message,
+    workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
+    created_at,
+    updated_at,
+    started_at,
+    completed_at
+`
+
+type UpdateAIChatRunInterruptedParams struct {
+	ID                 int32              `json:"id"`
+	UserID             string             `json:"user_id"`
+	ErrorMessage       pgtype.Text        `json:"error_message"`
+	CompletedAt        pgtype.Timestamptz `json:"completed_at"`
+	InterruptionReason pgtype.Text        `json:"interruption_reason"`
+}
+
+func (q *Queries) UpdateAIChatRunInterrupted(ctx context.Context, arg UpdateAIChatRunInterruptedParams) (AiChatRun, error) {
+	row := q.db.QueryRow(ctx, updateAIChatRunInterrupted,
+		arg.ID,
+		arg.UserID,
+		arg.ErrorMessage,
+		arg.CompletedAt,
+		arg.InterruptionReason,
+	)
+	var i AiChatRun
+	err := row.Scan(
+		&i.ID,
+		&i.ConversationID,
+		&i.UserID,
+		&i.UserMessageID,
+		&i.AssistantMessageID,
+		&i.Model,
+		&i.Status,
+		&i.RequestID,
+		&i.ErrorMessage,
+		&i.WorkoutDraft,
+		&i.GenerationStatus,
+		&i.GenerationOwner,
+		&i.GenerationLeaseExpiresAt,
+		&i.GenerationHeartbeatAt,
+		&i.GenerationAttempt,
+		&i.InterruptedAt,
+		&i.InterruptionReason,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.StartedAt,

--- a/server/internal/database/query.sql.go
+++ b/server/internal/database/query.sql.go
@@ -2979,7 +2979,13 @@ SET status = 'failed',
     interrupted_at = $4,
     interruption_reason = $5,
     updated_at = CURRENT_TIMESTAMP
-WHERE id = $1 AND user_id = $2
+WHERE id = $1
+  AND user_id = $2
+  AND status = 'streaming'
+  AND generation_status = $6
+  AND generation_owner IS NOT DISTINCT FROM $7
+  AND generation_lease_expires_at IS NOT DISTINCT FROM $8
+  AND generation_attempt = $9
 RETURNING
     id,
     conversation_id,
@@ -3005,11 +3011,15 @@ RETURNING
 `
 
 type UpdateAIChatRunInterruptedParams struct {
-	ID                 int32              `json:"id"`
-	UserID             string             `json:"user_id"`
-	ErrorMessage       pgtype.Text        `json:"error_message"`
-	CompletedAt        pgtype.Timestamptz `json:"completed_at"`
-	InterruptionReason pgtype.Text        `json:"interruption_reason"`
+	ID                               int32              `json:"id"`
+	UserID                           string             `json:"user_id"`
+	ErrorMessage                     pgtype.Text        `json:"error_message"`
+	CompletedAt                      pgtype.Timestamptz `json:"completed_at"`
+	InterruptionReason               pgtype.Text        `json:"interruption_reason"`
+	ExpectedGenerationStatus         string             `json:"expected_generation_status"`
+	ExpectedGenerationOwner          pgtype.Text        `json:"expected_generation_owner"`
+	ExpectedGenerationLeaseExpiresAt pgtype.Timestamptz `json:"expected_generation_lease_expires_at"`
+	ExpectedGenerationAttempt        int32              `json:"expected_generation_attempt"`
 }
 
 func (q *Queries) UpdateAIChatRunInterrupted(ctx context.Context, arg UpdateAIChatRunInterruptedParams) (AiChatRun, error) {
@@ -3019,6 +3029,10 @@ func (q *Queries) UpdateAIChatRunInterrupted(ctx context.Context, arg UpdateAICh
 		arg.ErrorMessage,
 		arg.CompletedAt,
 		arg.InterruptionReason,
+		arg.ExpectedGenerationStatus,
+		arg.ExpectedGenerationOwner,
+		arg.ExpectedGenerationLeaseExpiresAt,
+		arg.ExpectedGenerationAttempt,
 	)
 	var i AiChatRun
 	err := row.Scan(

--- a/server/migrations/00022_add_ai_chat_generation_state.sql
+++ b/server/migrations/00022_add_ai_chat_generation_state.sql
@@ -1,0 +1,119 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE ai_chat_run
+ADD COLUMN generation_status VARCHAR(32),
+ADD COLUMN generation_owner VARCHAR(128),
+ADD COLUMN generation_lease_expires_at TIMESTAMPTZ,
+ADD COLUMN generation_heartbeat_at TIMESTAMPTZ,
+ADD COLUMN generation_attempt INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN interrupted_at TIMESTAMPTZ,
+ADD COLUMN interruption_reason VARCHAR(128);
+
+UPDATE ai_chat_run
+SET status = CASE
+    WHEN status = 'streaming'
+      AND error_message = 'ai chat stream interrupted and awaiting recovery handoff'
+      THEN 'failed'
+    ELSE status
+END,
+error_message = CASE
+    WHEN status = 'streaming'
+      AND error_message = 'ai chat stream interrupted and awaiting recovery handoff'
+      THEN 'ai chat stream was interrupted before completion'
+    ELSE error_message
+END,
+completed_at = CASE
+    WHEN status = 'streaming'
+      AND error_message = 'ai chat stream interrupted and awaiting recovery handoff'
+      THEN updated_at
+    ELSE completed_at
+END,
+generation_status = CASE
+    WHEN status = 'completed' THEN 'completed'
+    WHEN status = 'failed' THEN 'failed'
+    WHEN status = 'streaming'
+      AND error_message = 'ai chat stream interrupted and awaiting recovery handoff'
+      THEN 'interrupted'
+    WHEN status = 'streaming'
+      AND error_message = 'ai chat recovery claimed and in progress'
+      THEN 'generating'
+    ELSE 'queued'
+END,
+generation_owner = CASE
+    WHEN status = 'streaming'
+      AND error_message = 'ai chat recovery claimed and in progress'
+      THEN 'legacy:recovery'
+    ELSE generation_owner
+END,
+generation_lease_expires_at = CASE
+    WHEN status = 'streaming'
+      AND error_message = 'ai chat recovery claimed and in progress'
+      THEN updated_at + INTERVAL '60 seconds'
+    ELSE generation_lease_expires_at
+END,
+generation_heartbeat_at = CASE
+    WHEN status = 'streaming'
+      AND error_message = 'ai chat recovery claimed and in progress'
+      THEN updated_at
+    ELSE generation_heartbeat_at
+END,
+interrupted_at = CASE
+    WHEN status = 'streaming'
+      AND error_message = 'ai chat stream interrupted and awaiting recovery handoff'
+      THEN updated_at
+    ELSE interrupted_at
+END,
+interruption_reason = CASE
+    WHEN status = 'streaming'
+      AND error_message = 'ai chat stream interrupted and awaiting recovery handoff'
+      THEN 'client_disconnect'
+    ELSE interruption_reason
+END;
+
+UPDATE ai_chat_message message
+SET status = 'failed',
+    error_message = 'ai chat stream was interrupted before completion',
+    completed_at = run.updated_at,
+    updated_at = CURRENT_TIMESTAMP
+FROM ai_chat_run run
+WHERE message.id = run.assistant_message_id
+  AND message.user_id = run.user_id
+  AND run.generation_status = 'interrupted'
+  AND message.status = 'streaming';
+
+ALTER TABLE ai_chat_run
+ALTER COLUMN generation_status SET NOT NULL,
+ALTER COLUMN generation_status SET DEFAULT 'queued';
+
+ALTER TABLE ai_chat_run
+ADD CONSTRAINT ai_chat_run_generation_status_valid CHECK (
+    generation_status IN ('queued', 'generating', 'completed', 'failed', 'interrupted')
+),
+ADD CONSTRAINT ai_chat_run_generation_owner_not_empty CHECK (
+    generation_owner IS NULL OR btrim(generation_owner) <> ''
+),
+ADD CONSTRAINT ai_chat_run_generation_attempt_non_negative CHECK (
+    generation_attempt >= 0
+),
+ADD CONSTRAINT ai_chat_run_interruption_reason_not_empty CHECK (
+    interruption_reason IS NULL OR btrim(interruption_reason) <> ''
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE ai_chat_run
+DROP CONSTRAINT ai_chat_run_interruption_reason_not_empty,
+DROP CONSTRAINT ai_chat_run_generation_attempt_non_negative,
+DROP CONSTRAINT ai_chat_run_generation_owner_not_empty,
+DROP CONSTRAINT ai_chat_run_generation_status_valid;
+
+ALTER TABLE ai_chat_run
+DROP COLUMN interruption_reason,
+DROP COLUMN interrupted_at,
+DROP COLUMN generation_attempt,
+DROP COLUMN generation_heartbeat_at,
+DROP COLUMN generation_lease_expires_at,
+DROP COLUMN generation_owner,
+DROP COLUMN generation_status;
+-- +goose StatementEnd

--- a/server/query.sql
+++ b/server/query.sql
@@ -1275,7 +1275,13 @@ SET status = 'failed',
     interrupted_at = $4,
     interruption_reason = $5,
     updated_at = CURRENT_TIMESTAMP
-WHERE id = $1 AND user_id = $2
+WHERE id = $1
+  AND user_id = $2
+  AND status = 'streaming'
+  AND generation_status = sqlc.arg(expected_generation_status)
+  AND generation_owner IS NOT DISTINCT FROM sqlc.narg(expected_generation_owner)
+  AND generation_lease_expires_at IS NOT DISTINCT FROM sqlc.narg(expected_generation_lease_expires_at)
+  AND generation_attempt = sqlc.arg(expected_generation_attempt)
 RETURNING
     id,
     conversation_id,

--- a/server/query.sql
+++ b/server/query.sql
@@ -864,6 +864,13 @@ SELECT
     request_id,
     error_message,
     workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
     created_at,
     updated_at,
     started_at,
@@ -887,6 +894,13 @@ SELECT
     request_id,
     error_message,
     workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
     created_at,
     updated_at,
     started_at,
@@ -921,7 +935,19 @@ INSERT INTO ai_chat_stream_chunk (
     sequence,
     delta_text
 )
-VALUES ($1, $2, $3, $4)
+SELECT $1, $2, $3, $4
+WHERE (
+    NULLIF($5::text, '') IS NULL
+    OR EXISTS (
+        SELECT 1
+        FROM ai_chat_run
+        WHERE id = $1
+          AND user_id = $2
+          AND status = 'streaming'
+          AND generation_status = 'generating'
+          AND generation_owner = $5
+    )
+)
 RETURNING
     run_id,
     user_id,
@@ -976,6 +1002,13 @@ RETURNING
     request_id,
     error_message,
     workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
     created_at,
     updated_at,
     started_at,
@@ -1095,8 +1128,16 @@ SET status = 'completed',
     error_message = NULL,
     completed_at = $3,
     workout_draft = NULLIF($4::text, '')::jsonb,
+    generation_status = 'completed',
+    generation_owner = NULL,
+    generation_lease_expires_at = NULL,
+    generation_heartbeat_at = NULL,
+    interrupted_at = NULL,
+    interruption_reason = NULL,
     updated_at = CURRENT_TIMESTAMP
-WHERE id = $1 AND user_id = $2
+WHERE id = $1
+  AND user_id = $2
+  AND (NULLIF($5::text, '') IS NULL OR generation_owner = $5)
 RETURNING
     id,
     conversation_id,
@@ -1108,6 +1149,13 @@ RETURNING
     request_id,
     error_message,
     workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
     created_at,
     updated_at,
     started_at,
@@ -1120,13 +1168,27 @@ WHERE id = $1
   AND user_id = $2
   AND status = 'streaming';
 
--- name: MarkAIChatRunAwaitingRecovery :one
+-- name: ClaimAIChatRunGeneration :one
 UPDATE ai_chat_run
-SET error_message = $3,
+SET generation_status = 'generating',
+    generation_owner = $3,
+    generation_lease_expires_at = $4,
+    generation_heartbeat_at = $5,
+    generation_attempt = generation_attempt + 1,
+    error_message = NULL,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1
   AND user_id = $2
   AND status = 'streaming'
+  AND generation_attempt < $6
+  AND (
+    generation_status = 'queued'
+    OR (
+      generation_status = 'generating'
+      AND generation_lease_expires_at IS NOT NULL
+      AND generation_lease_expires_at < $5
+    )
+  )
 RETURNING
     id,
     conversation_id,
@@ -1138,35 +1200,28 @@ RETURNING
     request_id,
     error_message,
     workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
     created_at,
     updated_at,
     started_at,
     completed_at;
 
--- name: ClaimAIChatRunRecovery :one
+-- name: HeartbeatAIChatRunGeneration :execrows
 UPDATE ai_chat_run
-SET error_message = $5,
+SET generation_lease_expires_at = $3,
+    generation_heartbeat_at = $4,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1
   AND user_id = $2
   AND status = 'streaming'
-  AND error_message = $3
-  AND updated_at = $4
-RETURNING
-    id,
-    conversation_id,
-    user_id,
-    user_message_id,
-    assistant_message_id,
-    model,
-    status,
-    request_id,
-    error_message,
-    workout_draft,
-    created_at,
-    updated_at,
-    started_at,
-    completed_at;
+  AND generation_status = 'generating'
+  AND generation_owner = $5;
 
 -- name: UpdateAIChatRunFailed :one
 UPDATE ai_chat_run
@@ -1174,6 +1229,51 @@ SET status = 'failed',
     error_message = $3,
     completed_at = $4,
     workout_draft = NULL,
+    generation_status = 'failed',
+    generation_owner = NULL,
+    generation_lease_expires_at = NULL,
+    generation_heartbeat_at = NULL,
+    interrupted_at = NULL,
+    interruption_reason = NULL,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = $1
+  AND user_id = $2
+  AND (NULLIF($5::text, '') IS NULL OR generation_owner = $5)
+RETURNING
+    id,
+    conversation_id,
+    user_id,
+    user_message_id,
+    assistant_message_id,
+    model,
+    status,
+    request_id,
+    error_message,
+    workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
+    created_at,
+    updated_at,
+    started_at,
+    completed_at;
+
+-- name: UpdateAIChatRunInterrupted :one
+UPDATE ai_chat_run
+SET status = 'failed',
+    error_message = $3,
+    completed_at = $4,
+    workout_draft = NULL,
+    generation_status = 'interrupted',
+    generation_owner = NULL,
+    generation_lease_expires_at = NULL,
+    generation_heartbeat_at = NULL,
+    interrupted_at = $4,
+    interruption_reason = $5,
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1 AND user_id = $2
 RETURNING
@@ -1187,6 +1287,13 @@ RETURNING
     request_id,
     error_message,
     workout_draft,
+    generation_status,
+    generation_owner,
+    generation_lease_expires_at,
+    generation_heartbeat_at,
+    generation_attempt,
+    interrupted_at,
+    interruption_reason,
     created_at,
     updated_at,
     started_at,

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -123,6 +123,13 @@ CREATE TABLE ai_chat_run (
     request_id VARCHAR(128),
     error_message VARCHAR(512),
     workout_draft JSONB,
+    generation_status VARCHAR(32) NOT NULL DEFAULT 'queued',
+    generation_owner VARCHAR(128),
+    generation_lease_expires_at TIMESTAMPTZ,
+    generation_heartbeat_at TIMESTAMPTZ,
+    generation_attempt INTEGER NOT NULL DEFAULT 0,
+    interrupted_at TIMESTAMPTZ,
+    interruption_reason VARCHAR(128),
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     started_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -136,6 +143,18 @@ CREATE TABLE ai_chat_run (
     ),
     CONSTRAINT ai_chat_run_error_not_empty CHECK (
         error_message IS NULL OR btrim(error_message) <> ''
+    ),
+    CONSTRAINT ai_chat_run_generation_status_valid CHECK (
+        generation_status IN ('queued', 'generating', 'completed', 'failed', 'interrupted')
+    ),
+    CONSTRAINT ai_chat_run_generation_owner_not_empty CHECK (
+        generation_owner IS NULL OR btrim(generation_owner) <> ''
+    ),
+    CONSTRAINT ai_chat_run_generation_attempt_non_negative CHECK (
+        generation_attempt >= 0
+    ),
+    CONSTRAINT ai_chat_run_interruption_reason_not_empty CHECK (
+        interruption_reason IS NULL OR btrim(interruption_reason) <> ''
     ),
     CONSTRAINT ai_chat_run_user_message_unique UNIQUE (user_message_id),
     CONSTRAINT ai_chat_run_assistant_message_unique UNIQUE (assistant_message_id)


### PR DESCRIPTION
## Summary
- add explicit AI chat generation state, owner, lease, heartbeat, attempt, and interruption fields
- make the initial SSE request start server-owned generation and subscribe through persisted chunk replay
- use expired generation leases for Inngest recovery and mark stale partial runs interrupted instead of rerunning divergent output

## Tests
- go test ./internal/aichat
- make test-fast
- make vet
- make build
- make test-short

## Notes
- Public client stream/resume contract is unchanged.
- Postgres remains the source of truth for chunks, completed messages, and latest workout drafts.