### PR TITLE
feat: add AI chat plan cancellation flow

### DIFF
--- a/client/src/features/chat/api/billing.test.ts
+++ b/client/src/features/chat/api/billing.test.ts
@@ -25,6 +25,7 @@ import {
   billingStatusQueryOptions,
   createBillingCheckoutSession,
   createBillingCustomerPortalSession,
+  createBillingSubscriptionCancelPortalSession,
   getBillingStatus,
 } from "./billing";
 
@@ -130,5 +131,30 @@ describe("billing api wrapper", () => {
     );
     expect(latestRequest().method).toBe("POST");
     expect(session.url).toBe("https://billing.stripe.test/session");
+  });
+
+  it("creates a Stripe-hosted subscription cancellation portal session", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          url: "https://billing.stripe.test/cancel-session",
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      ),
+    );
+
+    const session = await createBillingSubscriptionCancelPortalSession();
+
+    expect(fetch).toHaveBeenCalledWith(expect.any(Request));
+    expect(latestRequest().url).toContain(
+      "/api/billing/subscription-cancel-portal-session",
+    );
+    expect(latestRequest().method).toBe("POST");
+    expect(session.url).toBe("https://billing.stripe.test/cancel-session");
   });
 });

--- a/client/src/features/chat/api/billing.ts
+++ b/client/src/features/chat/api/billing.ts
@@ -99,6 +99,19 @@ export async function createBillingCustomerPortalSession(): Promise<BillingCusto
   return response.data;
 }
 
+export async function createBillingSubscriptionCancelPortalSession(): Promise<BillingCustomerPortalSessionResponse> {
+  const response = await client.post<
+    BillingCustomerPortalSessionResponses,
+    ApiError,
+    true
+  >({
+    url: "/billing/subscription-cancel-portal-session",
+    throwOnError: true,
+  });
+
+  return response.data;
+}
+
 export function redirectToBillingCheckout(url: string): void {
   window.location.assign(url);
 }

--- a/client/src/features/chat/components/ai-chat-billing-card.test.tsx
+++ b/client/src/features/chat/components/ai-chat-billing-card.test.tsx
@@ -13,6 +13,7 @@ function renderCard(
 ) {
   const onStartCheckout = vi.fn();
   const onManageBilling = vi.fn();
+  const onCancelPlan = vi.fn();
   const onRefreshAccess = vi.fn();
   render(
     <AIChatBillingCard
@@ -22,11 +23,12 @@ function renderCard(
       }
       onStartCheckout={onStartCheckout}
       onManageBilling={onManageBilling}
+      onCancelPlan={onCancelPlan}
       onRefreshAccess={onRefreshAccess}
     />,
   );
 
-  return { onStartCheckout, onManageBilling, onRefreshAccess };
+  return { onStartCheckout, onManageBilling, onCancelPlan, onRefreshAccess };
 }
 
 describe("AIChatBillingCard", () => {
@@ -51,6 +53,7 @@ describe("AIChatBillingCard", () => {
         accessState="billing-error"
         onStartCheckout={vi.fn()}
         onManageBilling={vi.fn()}
+        onCancelPlan={vi.fn()}
         onRefreshAccess={vi.fn()}
       />,
     );
@@ -80,6 +83,7 @@ describe("AIChatBillingCard", () => {
         }}
         onStartCheckout={onStartCheckout}
         onManageBilling={vi.fn()}
+        onCancelPlan={vi.fn()}
         onRefreshAccess={onRefreshAccess}
       />,
     );
@@ -126,8 +130,9 @@ describe("AIChatBillingCard", () => {
     expect(onStartCheckout).not.toHaveBeenCalled();
   });
 
-  it("shows the trial badge and prompt usage while trialing", () => {
-    renderCard({
+  it("opens plan management while trialing", async () => {
+    const user = userEvent.setup();
+    const { onManageBilling, onCancelPlan, onStartCheckout } = renderCard({
       feature_key: "ai_chatbot",
       has_access: true,
       subscription: {
@@ -146,10 +151,21 @@ describe("AIChatBillingCard", () => {
     expect(
       screen.queryByRole("button", { name: "Start 7-day trial" }),
     ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Manage plan" }));
+
+    expect(onManageBilling).toHaveBeenCalledTimes(1);
+    expect(onCancelPlan).not.toHaveBeenCalled();
+    expect(onStartCheckout).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Cancel plan" }));
+
+    expect(onCancelPlan).toHaveBeenCalledTimes(1);
   });
 
-  it("shows premium status when active", () => {
-    renderCard({
+  it("opens plan management when premium is active", async () => {
+    const user = userEvent.setup();
+    const { onManageBilling, onCancelPlan, onStartCheckout } = renderCard({
       feature_key: "ai_chatbot",
       has_access: true,
       subscription: {
@@ -163,6 +179,59 @@ describe("AIChatBillingCard", () => {
     expect(
       screen.getByText("Premium is active. AI chat is available."),
     ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Manage plan" }));
+
+    expect(onManageBilling).toHaveBeenCalledTimes(1);
+    expect(onCancelPlan).not.toHaveBeenCalled();
+    expect(onStartCheckout).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Cancel plan" }));
+
+    expect(onCancelPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables both portal actions while either active plan action is opening", () => {
+    const activeStatus = {
+      feature_key: "ai_chatbot",
+      has_access: true,
+      subscription: {
+        stripe_subscription_id: "sub_active",
+        status: "active",
+        cancel_at_period_end: false,
+      },
+    } satisfies BillingStatusResponse;
+    const props = {
+      status: activeStatus,
+      accessState: "ready" as const,
+      onStartCheckout: vi.fn(),
+      onManageBilling: vi.fn(),
+      onCancelPlan: vi.fn(),
+      onRefreshAccess: vi.fn(),
+    };
+    const { rerender } = render(
+      <AIChatBillingCard
+        {...props}
+        isBillingPortalLoading
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Opening billing..." }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cancel plan" })).toBeDisabled();
+
+    rerender(
+      <AIChatBillingCard
+        {...props}
+        isCancelPlanLoading
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Manage plan" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Opening cancellation..." }),
+    ).toBeDisabled();
   });
 
   it("shows active access without Checkout when access comes from a non-Stripe grant", () => {
@@ -262,6 +331,9 @@ describe("AIChatBillingCard", () => {
     expect(
       screen.getByText("Access continues until May 30, 2026."),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Cancel plan" }),
+    ).not.toBeInTheDocument();
   });
 
   it.each([

--- a/client/src/features/chat/components/ai-chat-billing-card.tsx
+++ b/client/src/features/chat/components/ai-chat-billing-card.tsx
@@ -23,8 +23,10 @@ type AIChatBillingCardProps = {
   isRefreshingAccess?: boolean;
   isCheckoutLoading?: boolean;
   isBillingPortalLoading?: boolean;
+  isCancelPlanLoading?: boolean;
   onStartCheckout: () => void;
   onManageBilling: () => void;
+  onCancelPlan: () => void;
   onRefreshAccess: () => void;
 };
 
@@ -48,6 +50,12 @@ const billingPortalStatuses = new Set<BillingSubscriptionStatus>([
   "unpaid",
 ]);
 
+const planManagementStatuses = new Set<BillingSubscriptionStatus>([
+  "trialing",
+  "active",
+  ...billingPortalStatuses,
+]);
+
 export function AIChatBillingCard({
   status,
   accessState,
@@ -56,8 +64,10 @@ export function AIChatBillingCard({
   isRefreshingAccess = false,
   isCheckoutLoading = false,
   isBillingPortalLoading = false,
+  isCancelPlanLoading = false,
   onStartCheckout,
   onManageBilling,
+  onCancelPlan,
   onRefreshAccess,
 }: AIChatBillingCardProps) {
   const subscription = status?.subscription;
@@ -74,12 +84,19 @@ export function AIChatBillingCard({
     billingAction &&
     (!isError || billingAction === "refresh") &&
     (accessState !== "ready" || billingAction === "portal");
+  const shouldShowCancelPlan =
+    !isLoading &&
+    !isError &&
+    accessState === "ready" &&
+    (subscription ? isCancelableSubscription(subscription) : false);
   const isActionLoading = getActionLoadingState({
     billingAction,
     isBillingPortalLoading,
     isCheckoutLoading,
     isRefreshingAccess,
   });
+  const isPortalActionLoading =
+    (billingAction === "portal" && isActionLoading) || isCancelPlanLoading;
 
   return (
     <Card className="rounded-lg">
@@ -102,28 +119,46 @@ export function AIChatBillingCard({
             </p>
           </div>
 
-          {shouldShowBillingAction ? (
-            <Button
-              type="button"
-              className="w-full sm:w-auto"
-              onClick={
-                billingAction === "portal"
-                  ? onManageBilling
-                  : billingAction === "refresh"
-                    ? onRefreshAccess
-                    : onStartCheckout
-              }
-              disabled={isActionLoading || isLoading}
-            >
-              {billingAction === "refresh" ? (
-                <RefreshCw className="size-4" />
-              ) : (
-                <CreditCard className="size-4" />
-              )}
-              {isActionLoading
-                ? billingActionLoadingLabel(billingAction)
-                : billingActionLabel(status, billingAction)}
-            </Button>
+          {shouldShowBillingAction || shouldShowCancelPlan ? (
+            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+              {shouldShowBillingAction ? (
+                <Button
+                  type="button"
+                  className="w-full sm:w-auto"
+                  onClick={
+                    billingAction === "portal"
+                      ? onManageBilling
+                      : billingAction === "refresh"
+                        ? onRefreshAccess
+                        : onStartCheckout
+                  }
+                  disabled={isActionLoading || isCancelPlanLoading || isLoading}
+                >
+                  {billingAction === "refresh" ? (
+                    <RefreshCw className="size-4" />
+                  ) : (
+                    <CreditCard className="size-4" />
+                  )}
+                  {isActionLoading
+                    ? billingActionLoadingLabel(billingAction)
+                    : billingActionLabel(status, billingAction)}
+                </Button>
+              ) : null}
+              {shouldShowCancelPlan ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full border-destructive/30 text-destructive hover:bg-destructive/10 hover:text-destructive sm:w-auto"
+                  onClick={onCancelPlan}
+                  disabled={isPortalActionLoading}
+                >
+                  <CreditCard className="size-4" />
+                  {isCancelPlanLoading
+                    ? "Opening cancellation..."
+                    : "Cancel plan"}
+                </Button>
+              ) : null}
+            </div>
           ) : null}
         </div>
 
@@ -380,7 +415,7 @@ function getBillingAction(
     return null;
   }
 
-  if (billingPortalStatuses.has(status?.subscription?.status ?? "active")) {
+  if (planManagementStatuses.has(status?.subscription?.status ?? "canceled")) {
     return "portal";
   }
 
@@ -396,7 +431,9 @@ function billingActionLabel(
   }
 
   if (action === "portal") {
-    return "Update billing";
+    return billingPortalStatuses.has(status?.subscription?.status ?? "active")
+      ? "Update billing"
+      : "Manage plan";
   }
 
   if (!status?.subscription) {
@@ -454,6 +491,13 @@ function getActionLoadingState({
 function isBlockedStatus(status: BillingSubscriptionStatus): boolean {
   return (
     checkoutBlockedStatuses.has(status) || billingPortalStatuses.has(status)
+  );
+}
+
+function isCancelableSubscription(subscription: BillingSubscription): boolean {
+  return (
+    !subscription.cancel_at_period_end &&
+    (subscription.status === "trialing" || subscription.status === "active")
   );
 }
 

--- a/client/src/features/chat/hooks/use-ai-chat-billing-access.hook.test.tsx
+++ b/client/src/features/chat/hooks/use-ai-chat-billing-access.hook.test.tsx
@@ -8,6 +8,7 @@ import type { FeatureAccessGrant } from "@/features/chat/api/feature-access";
 const mocks = vi.hoisted(() => ({
   mockCreateBillingCheckoutSession: vi.fn(),
   mockCreateBillingCustomerPortalSession: vi.fn(),
+  mockCreateBillingSubscriptionCancelPortalSession: vi.fn(),
   mockGetBaseBillingStatus: vi.fn(),
   mockGetBaseFeatureAccess: vi.fn(),
   mockGetCheckoutBillingStatus: vi.fn(),
@@ -29,6 +30,8 @@ vi.mock("@/features/chat/api/billing", async () => {
     createBillingCheckoutSession: mocks.mockCreateBillingCheckoutSession,
     createBillingCustomerPortalSession:
       mocks.mockCreateBillingCustomerPortalSession,
+    createBillingSubscriptionCancelPortalSession:
+      mocks.mockCreateBillingSubscriptionCancelPortalSession,
     getBillingStatus: mocks.mockGetCheckoutBillingStatus,
     redirectToBillingCheckout: mocks.mockRedirectToBillingCheckout,
     redirectToBillingPortal: mocks.mockRedirectToBillingPortal,
@@ -83,6 +86,7 @@ describe("useAIChatBillingAccess checkout polling", () => {
   beforeEach(() => {
     mocks.mockCreateBillingCheckoutSession.mockReset();
     mocks.mockCreateBillingCustomerPortalSession.mockReset();
+    mocks.mockCreateBillingSubscriptionCancelPortalSession.mockReset();
     mocks.mockGetBaseBillingStatus.mockReset();
     mocks.mockGetBaseFeatureAccess.mockReset();
     mocks.mockGetCheckoutBillingStatus.mockReset();
@@ -308,11 +312,40 @@ describe("useAIChatBillingAccess checkout polling", () => {
     });
     expect(result.current.isBillingError).toBe(true);
   });
+
+  it("polls cancellation return until billing reflects the canceled state", async () => {
+    mocks.mockGetBaseBillingStatus.mockResolvedValue(activeBillingStatus);
+    mocks.mockGetBaseFeatureAccess.mockResolvedValue([aiChatFeatureGrant]);
+    mocks.mockGetCheckoutBillingStatus
+      .mockResolvedValueOnce(activeBillingStatus)
+      .mockResolvedValue({
+        ...activeBillingStatus,
+        subscription: {
+          ...activeBillingStatus.subscription!,
+          cancel_at_period_end: true,
+          current_period_end: "2026-06-10T12:00:00Z",
+        },
+      });
+    mocks.mockGetCheckoutFeatureAccess.mockResolvedValue([aiChatFeatureGrant]);
+
+    const { result } = renderBillingAccessHook({
+      checkout: undefined,
+      billing: "cancelled",
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.billingStatus?.subscription?.cancel_at_period_end,
+      ).toBe(true);
+    });
+    expect(mocks.mockGetCheckoutBillingStatus).toHaveBeenCalledTimes(2);
+  });
 });
 
 function renderBillingAccessHook(
   options: {
     checkout?: "success";
+    billing?: "cancelled";
   } = { checkout: "success" },
 ) {
   const navigate = vi.fn();
@@ -329,6 +362,7 @@ function renderBillingAccessHook(
       useAIChatBillingAccess({
         userId: "user-123",
         checkout: options.checkout,
+        billing: options.billing,
         conversationId: "41",
         navigate,
       }),

--- a/client/src/features/chat/hooks/use-ai-chat-billing-access.ts
+++ b/client/src/features/chat/hooks/use-ai-chat-billing-access.ts
@@ -5,6 +5,7 @@ import {
   billingStatusQueryOptions,
   createBillingCheckoutSession,
   createBillingCustomerPortalSession,
+  createBillingSubscriptionCancelPortalSession,
   getBillingStatus,
   redirectToBillingCheckout,
   redirectToBillingPortal,
@@ -19,10 +20,12 @@ import {
 import { showErrorToast } from "@/lib/errors";
 
 type CheckoutSearch = "success" | "cancelled";
+type BillingSearch = "cancelled" | "portal-return";
 
 type UseAIChatBillingAccessOptions = {
   userId?: string;
   checkout?: CheckoutSearch;
+  billing?: BillingSearch;
   conversationId?: string;
   navigate: NavigateFn;
 };
@@ -43,6 +46,7 @@ export type CheckoutAccessPollingView =
 export type AIChatBillingAccess = {
   billingStatus?: BillingStatusResponse;
   checkoutNotice: CheckoutSearch | null;
+  billingNotice: BillingSearch | null;
   accessState: AIChatAccessState;
   hasChatAccess: boolean;
   isCheckingAccess: boolean;
@@ -51,8 +55,10 @@ export type AIChatBillingAccess = {
   isRefreshingAccess: boolean;
   isCheckoutLoading: boolean;
   isBillingPortalLoading: boolean;
+  isCancelPlanLoading: boolean;
   startCheckout: () => void;
   manageBilling: () => void;
+  cancelPlan: () => void;
   refreshAccess: () => void;
 };
 
@@ -82,18 +88,34 @@ class CheckoutAccessPendingError extends Error {
   }
 }
 
+class BillingCancellationPendingError extends Error {
+  result: CheckoutAccessPollResult;
+
+  constructor(result: CheckoutAccessPollResult) {
+    super("billing cancellation is still pending");
+    this.name = "BillingCancellationPendingError";
+    this.result = result;
+  }
+}
+
 export function useAIChatBillingAccess({
   userId,
   checkout,
+  billing,
   conversationId,
   navigate,
 }: UseAIChatBillingAccessOptions): AIChatBillingAccess {
   const [checkoutNotice, setCheckoutNotice] = useState<CheckoutSearch | null>(
     checkout ?? null,
   );
+  const [billingNotice, setBillingNotice] = useState<BillingSearch | null>(
+    billing ?? null,
+  );
   const [shouldPollCheckoutAccess, setShouldPollCheckoutAccess] = useState(
     checkout === "success",
   );
+  const [shouldPollBillingCancellation, setShouldPollBillingCancellation] =
+    useState(billing === "cancelled");
   const [settledCheckoutPollingView, setSettledCheckoutPollingView] =
     useState<CheckoutAccessPollingView>({ status: "idle" });
   const isSignedIn = Boolean(userId);
@@ -125,6 +147,25 @@ export function useAIChatBillingAccess({
         )
       ],
   });
+  const billingCancellationQuery = useQuery({
+    queryKey: [
+      "billing",
+      "ai-chatbot",
+      "billing-cancellation",
+      userId,
+      conversationId,
+    ],
+    queryFn: waitForBillingCancellation,
+    enabled: isSignedIn && shouldPollBillingCancellation,
+    retry: checkoutAccessRetryDelaysMs.length,
+    retryDelay: (failureCount) =>
+      checkoutAccessRetryDelaysMs[
+        Math.min(
+          Math.max(failureCount - 1, 0),
+          checkoutAccessRetryDelaysMs.length - 1,
+        )
+      ],
+  });
 
   const checkoutMutation = useMutation({
     mutationFn: createBillingCheckoutSession,
@@ -135,6 +176,11 @@ export function useAIChatBillingAccess({
     mutationFn: createBillingCustomerPortalSession,
     onSuccess: (session) => redirectToBillingPortal(session.url),
     onError: (error) => showErrorToast(error, "Could not open billing"),
+  });
+  const subscriptionCancelMutation = useMutation({
+    mutationFn: createBillingSubscriptionCancelPortalSession,
+    onSuccess: (session) => redirectToBillingPortal(session.url),
+    onError: (error) => showErrorToast(error, "Could not open cancellation"),
   });
   const restartCheckoutAccessPolling = useCallback(() => {
     setSettledCheckoutPollingView({ status: "idle" });
@@ -159,6 +205,40 @@ export function useAIChatBillingAccess({
       replace: true,
     });
   }, [checkout, conversationId, navigate]);
+
+  useEffect(() => {
+    if (!billing) {
+      return;
+    }
+
+    setBillingNotice(billing);
+    if (billing === "cancelled") {
+      setShouldPollBillingCancellation(true);
+    } else {
+      void billingQuery.refetch();
+      void featureAccessQuery.refetch();
+    }
+    void navigate({
+      to: "/chat",
+      search: { conversationId },
+      replace: true,
+    });
+  }, [
+    billing,
+    billingQuery.refetch,
+    conversationId,
+    featureAccessQuery.refetch,
+    navigate,
+  ]);
+
+  useEffect(() => {
+    if (
+      billingCancellationQuery.isSuccess ||
+      billingCancellationQuery.isError
+    ) {
+      setShouldPollBillingCancellation(false);
+    }
+  }, [billingCancellationQuery.isError, billingCancellationQuery.isSuccess]);
 
   const currentCheckoutPollingView = useMemo(
     () =>
@@ -208,26 +288,38 @@ export function useAIChatBillingAccess({
     checkoutPollingView,
     featureAccess: featureAccessQuery.data,
   });
+  const billingCancellationOverride = getBillingCancellationOverride({
+    data: billingCancellationQuery.data,
+    error: billingCancellationQuery.error,
+    isError: billingCancellationQuery.isError,
+  });
   const errorSource = getAIChatAccessErrorSource({
     isBillingError: billingQuery.isError || featureAccessQuery.isError,
     checkoutPollingView,
     isCheckoutReturn: checkoutNotice === "success",
   });
   const accessView = resolveAIChatAccessView({
-    billingStatus: checkoutAccessOverride?.billingStatus ?? billingQuery.data,
+    billingStatus:
+      checkoutAccessOverride?.billingStatus ??
+      billingCancellationOverride?.billingStatus ??
+      billingQuery.data,
     featureAccess:
-      checkoutAccessOverride?.featureAccess ?? featureAccessQuery.data,
+      checkoutAccessOverride?.featureAccess ??
+      billingCancellationOverride?.featureAccess ??
+      featureAccessQuery.data,
     isPaymentConfirming: checkoutPollingView.status === "payment-confirming",
     isChecking:
       billingQuery.isLoading ||
       billingQuery.isPending ||
       featureAccessQuery.isLoading ||
       featureAccessQuery.isPending ||
-      checkoutPollingView.status === "polling",
+      checkoutPollingView.status === "polling" ||
+      billingCancellationQuery.isFetching,
     errorSource,
   });
   const isRefreshingAccess =
     checkoutAccessQuery.isFetching ||
+    billingCancellationQuery.isFetching ||
     Boolean(billingQuery.isFetching) ||
     Boolean(featureAccessQuery.isFetching);
 
@@ -263,6 +355,7 @@ export function useAIChatBillingAccess({
   return {
     billingStatus: accessView.billingStatus,
     checkoutNotice,
+    billingNotice,
     accessState: accessView.state,
     hasChatAccess: accessView.hasChatAccess,
     isCheckingAccess: accessView.state === "checking",
@@ -271,8 +364,10 @@ export function useAIChatBillingAccess({
     isRefreshingAccess,
     isCheckoutLoading: checkoutMutation.isPending,
     isBillingPortalLoading: billingPortalMutation.isPending,
+    isCancelPlanLoading: subscriptionCancelMutation.isPending,
     startCheckout: () => checkoutMutation.mutate(),
     manageBilling: () => billingPortalMutation.mutate(),
+    cancelPlan: () => subscriptionCancelMutation.mutate(),
     refreshAccess: () => {
       if (
         accessView.state === "activating" ||
@@ -371,6 +466,26 @@ function getCheckoutAccessOverride({
     case "failed":
       return undefined;
   }
+}
+
+function getBillingCancellationOverride({
+  data,
+  error,
+  isError,
+}: {
+  data?: CheckoutAccessPollResult;
+  error?: unknown;
+  isError?: boolean;
+}): CheckoutAccessPollResult | undefined {
+  if (data) {
+    return data;
+  }
+
+  if (error instanceof BillingCancellationPendingError && isError !== false) {
+    return error.result;
+  }
+
+  return undefined;
 }
 
 function resolveCheckoutAccessSettledView(
@@ -485,4 +600,28 @@ async function waitForCheckoutAccess(): Promise<CheckoutAccessPollResult> {
   }
 
   return { billingStatus, featureAccess };
+}
+
+async function waitForBillingCancellation(): Promise<CheckoutAccessPollResult> {
+  const [featureAccess, billingStatus] = await Promise.all([
+    getFeatureAccess(),
+    getBillingStatus(),
+  ]);
+
+  if (!isBillingCancellationReflected(billingStatus)) {
+    throw new BillingCancellationPendingError({ billingStatus, featureAccess });
+  }
+
+  return { billingStatus, featureAccess };
+}
+
+function isBillingCancellationReflected(
+  billingStatus: BillingStatusResponse,
+): boolean {
+  const subscription = billingStatus.subscription;
+  return (
+    !subscription ||
+    subscription.cancel_at_period_end ||
+    subscription.status === "canceled"
+  );
 }

--- a/client/src/features/chat/pages/chat-billing-page.test.tsx
+++ b/client/src/features/chat/pages/chat-billing-page.test.tsx
@@ -5,13 +5,16 @@ import {
   ChatRouteComponent,
   conversationDetail,
   mockBillingQueryResult,
+  mockBillingCancellationQueryResult,
   mockCheckoutAccessQueryResult,
   mockCreateBillingCheckoutSession,
   mockCreateBillingCustomerPortalSession,
+  mockCreateBillingSubscriptionCancelPortalSession,
   mockFeatureAccessQueryResult,
   mockGetConversation,
   mockNavigate,
   mockRedirectToBillingCheckout,
+  mockRedirectToBillingPortal,
   mockRefetchBillingStatus,
   mockRefetchFeatureAccess,
   mockSearch,
@@ -275,6 +278,118 @@ describe("ChatRouteComponent", () => {
         "Ask about training, recovery, exercise choices, or FitTrack usage...",
       ),
     ).toBeDisabled();
+  });
+
+  it("opens billing portal plan management for active subscribers", async () => {
+    const user = userEvent.setup();
+    mockBillingQueryResult.value = {
+      data: {
+        feature_key: "ai_chatbot",
+        has_access: true,
+        subscription: {
+          stripe_subscription_id: "sub_active",
+          status: "active",
+          cancel_at_period_end: false,
+        },
+      },
+      isLoading: false,
+      isPending: false,
+      refetch: mockRefetchBillingStatus,
+    };
+    mockFeatureAccessQueryResult.value = {
+      data: [
+        {
+          feature_key: "ai_chatbot",
+        },
+      ],
+      isLoading: false,
+      isPending: false,
+      refetch: mockRefetchFeatureAccess,
+    };
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+
+    render(<ChatRouteComponent />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Manage plan" }),
+    );
+
+    await waitFor(() => {
+      expect(mockCreateBillingCustomerPortalSession).toHaveBeenCalledTimes(1);
+    });
+    expect(mockCreateBillingCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("opens the Stripe cancellation flow for active subscribers", async () => {
+    const user = userEvent.setup();
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+
+    render(<ChatRouteComponent />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Cancel plan" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        mockCreateBillingSubscriptionCancelPortalSession,
+      ).toHaveBeenCalledTimes(1);
+    });
+    expect(mockRedirectToBillingPortal).toHaveBeenCalledWith(
+      "https://billing.stripe.test/cancel-session",
+    );
+    expect(mockCreateBillingCustomerPortalSession).not.toHaveBeenCalled();
+    expect(mockCreateBillingCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("shows a cancellation return notice and refreshes billing state", async () => {
+    mockSearch.billing = "cancelled";
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+
+    render(<ChatRouteComponent />);
+
+    expect(
+      await screen.findByText(
+        "Cancellation received. We are refreshing your AI chat billing status.",
+      ),
+    ).toBeInTheDocument();
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/chat",
+      search: { conversationId: "41" },
+      replace: true,
+    });
+  });
+
+  it("uses cancellation polling data after Stripe returns before the webhook has refreshed base billing", async () => {
+    mockSearch.billing = "cancelled";
+    mockBillingCancellationQueryResult.value = {
+      data: {
+        billingStatus: {
+          feature_key: "ai_chatbot",
+          has_access: true,
+          subscription: {
+            stripe_subscription_id: "sub_active",
+            status: "active",
+            cancel_at_period_end: true,
+            current_period_end: "2026-06-10T12:00:00Z",
+          },
+        },
+        featureAccess: [{ feature_key: "ai_chatbot" }],
+      },
+      isFetching: false,
+      isError: false,
+      isSuccess: true,
+    };
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+
+    render(<ChatRouteComponent />);
+
+    expect(
+      await screen.findByText("Access continues until Jun 10, 2026."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Cancel plan" }),
+    ).not.toBeInTheDocument();
   });
 
   it("starts Checkout from the no-access trial CTA", async () => {

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -20,12 +20,14 @@ import { useAIChatBillingAccess } from "../hooks/use-ai-chat-billing-access";
 import { useAIChatSession } from "../hooks/use-ai-chat-session";
 
 type ChatCheckoutSearch = "success" | "cancelled";
+type ChatBillingSearch = "cancelled" | "portal-return";
 
 type ChatPageProps = {
   userId?: string;
   conversationId: number | null;
   conversationIdSearch?: string;
   checkout?: ChatCheckoutSearch;
+  billing?: ChatBillingSearch;
 };
 
 const COMPOSER_PLACEHOLDER =
@@ -38,6 +40,7 @@ export function ChatPage({
   conversationId,
   conversationIdSearch,
   checkout,
+  billing,
 }: ChatPageProps) {
   const navigate = useNavigate({ from: "/chat" });
   const {
@@ -66,6 +69,7 @@ export function ChatPage({
   const billingAccess = useAIChatBillingAccess({
     userId,
     checkout,
+    billing,
     conversationId: conversationIdSearch,
     navigate,
   });
@@ -208,8 +212,10 @@ export function ChatPage({
               isRefreshingAccess={billingAccess.isRefreshingAccess}
               isCheckoutLoading={billingAccess.isCheckoutLoading}
               isBillingPortalLoading={billingAccess.isBillingPortalLoading}
+              isCancelPlanLoading={billingAccess.isCancelPlanLoading}
               onStartCheckout={billingAccess.startCheckout}
               onManageBilling={billingAccess.manageBilling}
+              onCancelPlan={billingAccess.cancelPlan}
               onRefreshAccess={billingAccess.refreshAccess}
             />
           </div>
@@ -230,6 +236,11 @@ export function ChatPage({
       {billingAccess.checkoutNotice ? (
         <div className="mx-auto w-full max-w-3xl px-4">
           <CheckoutNotice checkout={billingAccess.checkoutNotice} />
+        </div>
+      ) : null}
+      {billingAccess.billingNotice ? (
+        <div className="mx-auto w-full max-w-3xl px-4">
+          <BillingReturnNotice billing={billingAccess.billingNotice} />
         </div>
       ) : null}
 
@@ -337,6 +348,24 @@ function CheckoutNotice({ checkout }: { checkout: ChatCheckoutSearch }) {
       {isSuccess
         ? "Checkout complete. We are refreshing your AI chat access."
         : "Checkout was cancelled. You can restart the trial when you are ready."}
+    </div>
+  );
+}
+
+function BillingReturnNotice({ billing }: { billing: ChatBillingSearch }) {
+  const isCancelled = billing === "cancelled";
+
+  return (
+    <div
+      className={`rounded-md border p-3 text-sm ${
+        isCancelled
+          ? "border-primary/30 bg-primary/5 text-foreground"
+          : "border-border bg-muted/40 text-muted-foreground"
+      }`}
+    >
+      {isCancelled
+        ? "Cancellation received. We are refreshing your AI chat billing status."
+        : "Returned from billing. We are refreshing your AI chat billing status."}
     </div>
   );
 }

--- a/client/src/features/chat/test/chat-page-test-utils.tsx
+++ b/client/src/features/chat/test/chat-page-test-utils.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   mockSearch: {
     conversationId: "41" as string | undefined,
     checkout: undefined as "success" | "cancelled" | undefined,
+    billing: undefined as "cancelled" | "portal-return" | undefined,
   },
   mockNavigate: vi.fn(),
   mockCreateConversation: vi.fn(),
@@ -24,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   mockFeatureAccessQueryOptions: vi.fn(),
   mockCreateBillingCheckoutSession: vi.fn(),
   mockCreateBillingCustomerPortalSession: vi.fn(),
+  mockCreateBillingSubscriptionCancelPortalSession: vi.fn(),
   mockGetBillingStatus: vi.fn(),
   mockRedirectToBillingCheckout: vi.fn(),
   mockRedirectToBillingPortal: vi.fn(),
@@ -35,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   mockBillingQueryResult: { value: undefined as unknown },
   mockFeatureAccessQueryResult: { value: undefined as unknown },
   mockCheckoutAccessQueryResult: { value: undefined as unknown },
+  mockBillingCancellationQueryResult: { value: undefined as unknown },
 }));
 
 export const {
@@ -54,6 +57,7 @@ export const {
   mockFeatureAccessQueryOptions,
   mockCreateBillingCheckoutSession,
   mockCreateBillingCustomerPortalSession,
+  mockCreateBillingSubscriptionCancelPortalSession,
   mockGetBillingStatus,
   mockRedirectToBillingCheckout,
   mockRedirectToBillingPortal,
@@ -65,6 +69,7 @@ export const {
   mockBillingQueryResult,
   mockFeatureAccessQueryResult,
   mockCheckoutAccessQueryResult,
+  mockBillingCancellationQueryResult,
 } = mocks;
 
 vi.mock("@tanstack/react-query", () => ({
@@ -90,6 +95,8 @@ vi.mock("@/features/chat/api/ai-chat", () => ({
 vi.mock("@/features/chat/api/billing", () => ({
   billingStatusQueryOptions: mockBillingStatusQueryOptions,
   createBillingCustomerPortalSession: mockCreateBillingCustomerPortalSession,
+  createBillingSubscriptionCancelPortalSession:
+    mockCreateBillingSubscriptionCancelPortalSession,
   createBillingCheckoutSession: mockCreateBillingCheckoutSession,
   getBillingStatus: mockGetBillingStatus,
   redirectToBillingCheckout: mockRedirectToBillingCheckout,
@@ -129,6 +136,7 @@ export function ChatRouteComponent() {
       conversationId={parseConversationId(mockSearch.conversationId)}
       conversationIdSearch={mockSearch.conversationId}
       checkout={mockSearch.checkout}
+      billing={mockSearch.billing}
     />
   );
 }
@@ -169,6 +177,7 @@ export function resetChatRouteMocks() {
   window.localStorage.clear();
   mockSearch.conversationId = "41";
   mockSearch.checkout = undefined;
+  mockSearch.billing = undefined;
   mockNavigate.mockReset();
   mockCreateConversation.mockReset();
   mockGetConversation.mockReset();
@@ -184,6 +193,7 @@ export function resetChatRouteMocks() {
   mockFeatureAccessQueryOptions.mockReset();
   mockCreateBillingCheckoutSession.mockReset();
   mockCreateBillingCustomerPortalSession.mockReset();
+  mockCreateBillingSubscriptionCancelPortalSession.mockReset();
   mockGetBillingStatus.mockReset();
   mockRedirectToBillingCheckout.mockReset();
   mockRedirectToBillingPortal.mockReset();
@@ -231,12 +241,22 @@ export function resetChatRouteMocks() {
     isError: false,
     isSuccess: false,
   };
+  mockBillingCancellationQueryResult.value = {
+    data: undefined,
+    error: null,
+    isFetching: false,
+    isError: false,
+    isSuccess: false,
+  };
   mockUseQuery.mockImplementation((options: { queryKey?: unknown[] }) => {
     if (options.queryKey?.[0] === "feature-access") {
       return mockFeatureAccessQueryResult.value;
     }
     if (options.queryKey?.[2] === "checkout-access") {
       return mockCheckoutAccessQueryResult.value;
+    }
+    if (options.queryKey?.[2] === "billing-cancellation") {
+      return mockBillingCancellationQueryResult.value;
     }
     return mockBillingQueryResult.value;
   });
@@ -245,6 +265,9 @@ export function resetChatRouteMocks() {
   });
   mockCreateBillingCustomerPortalSession.mockResolvedValue({
     url: "https://billing.stripe.test/session",
+  });
+  mockCreateBillingSubscriptionCancelPortalSession.mockResolvedValue({
+    url: "https://billing.stripe.test/cancel-session",
   });
   mockRefetchBillingStatus.mockResolvedValue(mockBillingQueryResult.value);
   mockRefetchFeatureAccess.mockResolvedValue(

--- a/client/src/routes/_layout/chat.tsx
+++ b/client/src/routes/_layout/chat.tsx
@@ -4,12 +4,14 @@ import { ChatPage } from "@/features/chat/pages/chat-page";
 type ChatSearch = {
   conversationId?: string;
   checkout?: "success" | "cancelled";
+  billing?: "cancelled" | "portal-return";
 };
 
 export const Route = createFileRoute("/_layout/chat")({
   validateSearch: (search): ChatSearch => ({
     conversationId: normalizeConversationSearchValue(search.conversationId),
     checkout: normalizeCheckoutSearchValue(search.checkout),
+    billing: normalizeBillingSearchValue(search.billing),
   }),
   component: RouteComponent,
 });
@@ -24,6 +26,7 @@ function RouteComponent() {
       conversationId={parseConversationId(search.conversationId)}
       conversationIdSearch={search.conversationId}
       checkout={search.checkout}
+      billing={search.billing}
     />
   );
 }
@@ -62,4 +65,10 @@ function normalizeCheckoutSearchValue(
   value: unknown,
 ): ChatSearch["checkout"] | undefined {
   return value === "success" || value === "cancelled" ? value : undefined;
+}
+
+function normalizeBillingSearchValue(
+  value: unknown,
+): ChatSearch["billing"] | undefined {
+  return value === "cancelled" || value === "portal-return" ? value : undefined;
 }

--- a/docs/stripe-billing.md
+++ b/docs/stripe-billing.md
@@ -12,6 +12,7 @@ FitTrack uses Stripe subscriptions to grant premium access to the AI chat featur
 - Checkout redirects users back to `/chat?checkout=success` or `/chat?checkout=cancelled`.
 - The chat UI gates composer access on the same active `ai_chatbot` feature grant that the AI chat backend enforces.
 - After Checkout success, the chat UI polls access briefly because Stripe redirects can arrive before subscription webhooks finish.
+- Users with `trialing` or `active` subscriptions can manage the plan or start a Stripe-hosted cancellation flow from the chat billing card.
 - Users with `past_due` or `unpaid` subscriptions are sent to Stripe's billing portal to update payment details.
 
 ## Required Stripe Setup
@@ -32,11 +33,12 @@ AI_CHAT_TRIAL_PROMPT_CAP=30
 
 - `POST /api/billing/checkout-session`: authenticated endpoint that creates or reuses the current user's Stripe customer, then returns a hosted checkout URL.
 - `POST /api/billing/customer-portal-session`: authenticated endpoint that creates a Stripe billing portal session for the current customer, then returns a hosted billing management URL.
+- `POST /api/billing/subscription-cancel-portal-session`: authenticated endpoint that creates a Stripe billing portal deep link for canceling the current AI chat subscription, then redirects back to `/chat?billing=cancelled` after the Stripe flow completes.
 - `GET /api/billing/status`: authenticated endpoint that returns the current user's AI chat billing access, subscription details, and trial prompt usage when applicable.
 - `POST /stripe/webhook`: unauthenticated Stripe webhook endpoint. Signature verification uses `STRIPE_WEBHOOK_SECRET`.
 
 If checkout variables are missing, checkout returns `503 billing is not configured`. If only webhook configuration is missing, webhook processing returns the same configuration error.
-Stripe billing portal sessions require a Stripe Billing Portal configuration in the Stripe account.
+Stripe billing portal sessions require a Stripe Billing Portal configuration in the Stripe account. The subscription cancellation flow requires subscription cancellation to be enabled in that portal configuration.
 
 ## Webhook Events
 

--- a/server/cmd/api/routes.go
+++ b/server/cmd/api/routes.go
@@ -52,6 +52,7 @@ func (api *api) routes(wh *workout.WorkoutHandler, eh *exercise.ExerciseHandler,
 	if bh != nil {
 		mux.HandleFunc("POST /api/billing/checkout-session", bh.CreateCheckoutSession)
 		mux.HandleFunc("POST /api/billing/customer-portal-session", bh.CreateCustomerPortalSession)
+		mux.HandleFunc("POST /api/billing/subscription-cancel-portal-session", bh.CreateSubscriptionCancelPortalSession)
 		mux.HandleFunc("GET /api/billing/status", bh.CurrentStatus)
 	}
 	mux.HandleFunc("POST /api/exercises", eh.GetOrCreateExercise)

--- a/server/cmd/api/routes_test.go
+++ b/server/cmd/api/routes_test.go
@@ -28,6 +28,10 @@ func (routeBillingService) CreateCustomerPortalSession(context.Context) (*billin
 	return &billing.CustomerPortalSessionResponse{URL: "https://billing.stripe.test/session"}, nil
 }
 
+func (routeBillingService) CreateSubscriptionCancelPortalSession(context.Context) (*billing.CustomerPortalSessionResponse, error) {
+	return &billing.CustomerPortalSessionResponse{URL: "https://billing.stripe.test/cancel-session"}, nil
+}
+
 func (routeBillingService) CurrentStatus(context.Context) (*billing.StatusResponse, error) {
 	return &billing.StatusResponse{FeatureKey: billing.FeatureKeyAIChatbot}, nil
 }
@@ -151,5 +155,34 @@ func TestRoutes_RegistersBillingCustomerPortalSession(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), "https://billing.stripe.test/session") {
 		t.Fatalf("expected billing portal URL response, got %s", rr.Body.String())
+	}
+}
+
+func TestRoutes_RegistersBillingSubscriptionCancelPortalSession(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	api := &api{
+		logger: logger,
+		cfg:    &config.Config{},
+		pool:   nil,
+	}
+
+	wh := &workout.WorkoutHandler{}
+	eh := &exercise.ExerciseHandler{}
+	fh := &featureaccess.Handler{}
+	hh := health.NewHandler(logger, nil)
+	ah := aichat.NewHandler(logger, nil)
+	bh := billing.NewHandler(logger, routeBillingService{})
+
+	mux := api.routes(wh, eh, fh, hh, ah, bh, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/billing/subscription-cancel-portal-session", nil)
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "https://billing.stripe.test/cancel-session") {
+		t.Fatalf("expected billing cancel portal URL response, got %s", rr.Body.String())
 	}
 }

--- a/server/internal/billing/handler.go
+++ b/server/internal/billing/handler.go
@@ -16,6 +16,7 @@ const maxWebhookPayloadBytes = 1 << 20
 type billingService interface {
 	CreateCheckoutSession(ctx context.Context) (*CheckoutSessionResponse, error)
 	CreateCustomerPortalSession(ctx context.Context) (*CustomerPortalSessionResponse, error)
+	CreateSubscriptionCancelPortalSession(ctx context.Context) (*CustomerPortalSessionResponse, error)
 	CurrentStatus(ctx context.Context) (*StatusResponse, error)
 	HandleWebhook(ctx context.Context, payload []byte, signatureHeader string) error
 }
@@ -48,6 +49,18 @@ func (h *Handler) CreateCustomerPortalSession(w http.ResponseWriter, r *http.Req
 	resp, err := h.service.CreateCustomerPortalSession(r.Context())
 	if err != nil {
 		h.writeServiceError(w, r, err, http.StatusInternalServerError, "failed to create billing portal session")
+		return
+	}
+
+	if err := response.JSON(w, http.StatusOK, resp); err != nil {
+		response.ErrorJSON(w, r, h.logger, http.StatusInternalServerError, "failed to write response", err)
+	}
+}
+
+func (h *Handler) CreateSubscriptionCancelPortalSession(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.service.CreateSubscriptionCancelPortalSession(r.Context())
+	if err != nil {
+		h.writeServiceError(w, r, err, http.StatusInternalServerError, "failed to create subscription cancellation portal session")
 		return
 	}
 
@@ -93,6 +106,10 @@ func (h *Handler) writeServiceError(w http.ResponseWriter, r *http.Request, err 
 		response.ErrorJSON(w, r, h.logger, http.StatusServiceUnavailable, "billing is not configured", nil)
 	case errors.Is(err, ErrBillingCustomerMissing):
 		response.ErrorJSON(w, r, h.logger, http.StatusNotFound, "billing customer was not found", nil)
+	case errors.Is(err, ErrBillingSubscriptionMissing):
+		response.ErrorJSON(w, r, h.logger, http.StatusNotFound, "billing subscription was not found", nil)
+	case errors.Is(err, ErrBillingSubscriptionNotCancelable):
+		response.ErrorJSON(w, r, h.logger, http.StatusConflict, "billing subscription cannot be canceled", nil)
 	case errors.Is(err, ErrTrialPromptLimitExceeded):
 		response.ErrorJSON(w, r, h.logger, http.StatusForbidden, "ai chat trial prompt limit reached", nil)
 	default:

--- a/server/internal/billing/handler_test.go
+++ b/server/internal/billing/handler_test.go
@@ -13,10 +13,11 @@ import (
 )
 
 type stubBillingService struct {
-	createCheckoutSession       func(context.Context) (*CheckoutSessionResponse, error)
-	createCustomerPortalSession func(context.Context) (*CustomerPortalSessionResponse, error)
-	currentStatus               func(context.Context) (*StatusResponse, error)
-	handleWebhook               func(context.Context, []byte, string) error
+	createCheckoutSession                 func(context.Context) (*CheckoutSessionResponse, error)
+	createCustomerPortalSession           func(context.Context) (*CustomerPortalSessionResponse, error)
+	createSubscriptionCancelPortalSession func(context.Context) (*CustomerPortalSessionResponse, error)
+	currentStatus                         func(context.Context) (*StatusResponse, error)
+	handleWebhook                         func(context.Context, []byte, string) error
 }
 
 func (s stubBillingService) CreateCheckoutSession(ctx context.Context) (*CheckoutSessionResponse, error) {
@@ -31,6 +32,13 @@ func (s stubBillingService) CreateCustomerPortalSession(ctx context.Context) (*C
 		return s.createCustomerPortalSession(ctx)
 	}
 	return &CustomerPortalSessionResponse{URL: "https://billing.stripe.test/session"}, nil
+}
+
+func (s stubBillingService) CreateSubscriptionCancelPortalSession(ctx context.Context) (*CustomerPortalSessionResponse, error) {
+	if s.createSubscriptionCancelPortalSession != nil {
+		return s.createSubscriptionCancelPortalSession(ctx)
+	}
+	return &CustomerPortalSessionResponse{URL: "https://billing.stripe.test/cancel-session"}, nil
 }
 
 func (s stubBillingService) CurrentStatus(ctx context.Context) (*StatusResponse, error) {
@@ -86,4 +94,30 @@ func TestHandlerCreateCustomerPortalSession_MissingCustomerReturns404(t *testing
 
 	require.Equal(t, http.StatusNotFound, rr.Code)
 	assert.Contains(t, rr.Body.String(), "billing customer was not found")
+}
+
+func TestHandlerCreateSubscriptionCancelPortalSession_ReturnsPortalURL(t *testing.T) {
+	handler := NewHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), stubBillingService{})
+	req := httptest.NewRequest(http.MethodPost, "/api/billing/subscription-cancel-portal-session", nil)
+	rr := httptest.NewRecorder()
+
+	handler.CreateSubscriptionCancelPortalSession(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.JSONEq(t, `{"url":"https://billing.stripe.test/cancel-session"}`, rr.Body.String())
+}
+
+func TestHandlerCreateSubscriptionCancelPortalSession_NotCancelableReturns409(t *testing.T) {
+	handler := NewHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), stubBillingService{
+		createSubscriptionCancelPortalSession: func(context.Context) (*CustomerPortalSessionResponse, error) {
+			return nil, ErrBillingSubscriptionNotCancelable
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/billing/subscription-cancel-portal-session", nil)
+	rr := httptest.NewRecorder()
+
+	handler.CreateSubscriptionCancelPortalSession(rr, req)
+
+	require.Equal(t, http.StatusConflict, rr.Code)
+	assert.Contains(t, rr.Body.String(), "billing subscription cannot be canceled")
 }

--- a/server/internal/billing/models.go
+++ b/server/internal/billing/models.go
@@ -18,12 +18,14 @@ const (
 )
 
 var (
-	ErrBillingNotConfigured     = errors.New("billing is not configured")
-	ErrBillingCustomerMissing   = errors.New("billing customer is missing")
-	ErrTrialPromptLimitExceeded = errors.New("ai chat trial prompt limit exceeded")
-	ErrStripeUserMissing        = errors.New("stripe payload is missing fittrack user metadata")
-	ErrStripeCustomerMissing    = errors.New("stripe payload is missing customer")
-	ErrUnsupportedStripeEvent   = errors.New("unsupported stripe webhook event")
+	ErrBillingNotConfigured             = errors.New("billing is not configured")
+	ErrBillingCustomerMissing           = errors.New("billing customer is missing")
+	ErrBillingSubscriptionMissing       = errors.New("billing subscription is missing")
+	ErrBillingSubscriptionNotCancelable = errors.New("billing subscription cannot be canceled")
+	ErrTrialPromptLimitExceeded         = errors.New("ai chat trial prompt limit exceeded")
+	ErrStripeUserMissing                = errors.New("stripe payload is missing fittrack user metadata")
+	ErrStripeCustomerMissing            = errors.New("stripe payload is missing customer")
+	ErrUnsupportedStripeEvent           = errors.New("unsupported stripe webhook event")
 )
 
 type CheckoutSessionResponse struct {

--- a/server/internal/billing/service.go
+++ b/server/internal/billing/service.go
@@ -138,6 +138,53 @@ func (s *Service) CreateCustomerPortalSession(ctx context.Context) (*CustomerPor
 	return &CustomerPortalSessionResponse{URL: portalSession.URL}, nil
 }
 
+func (s *Service) CreateSubscriptionCancelPortalSession(ctx context.Context) (*CustomerPortalSessionResponse, error) {
+	if !s.configuredForPortal() {
+		return nil, ErrBillingNotConfigured
+	}
+
+	userID, err := currentUserID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	subscription, err := s.currentCancelableSubscription(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	stripe.Key = s.stripeSecretKey
+	customerID, err := s.existingStripeCustomer(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	portalSession, err := s.createPortalSession(&stripe.BillingPortalSessionParams{
+		Customer:  stripe.String(customerID),
+		ReturnURL: stripe.String(s.appBaseURL + "/chat?billing=portal-return"),
+		FlowData: &stripe.BillingPortalSessionFlowDataParams{
+			Type: stripe.String(string(stripe.BillingPortalSessionFlowTypeSubscriptionCancel)),
+			AfterCompletion: &stripe.BillingPortalSessionFlowDataAfterCompletionParams{
+				Type: stripe.String(string(stripe.BillingPortalSessionFlowAfterCompletionTypeRedirect)),
+				Redirect: &stripe.BillingPortalSessionFlowDataAfterCompletionRedirectParams{
+					ReturnURL: stripe.String(s.appBaseURL + "/chat?billing=cancelled"),
+				},
+			},
+			SubscriptionCancel: &stripe.BillingPortalSessionFlowDataSubscriptionCancelParams{
+				Subscription: stripe.String(subscription.StripeSubscriptionID),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create stripe subscription cancellation portal session: %w", err)
+	}
+	if strings.TrimSpace(portalSession.URL) == "" {
+		return nil, fmt.Errorf("stripe subscription cancellation portal session did not include a hosted url")
+	}
+
+	return &CustomerPortalSessionResponse{URL: portalSession.URL}, nil
+}
+
 func (s *Service) CurrentStatus(ctx context.Context) (*StatusResponse, error) {
 	userID, err := currentUserID(ctx)
 	if err != nil {
@@ -335,6 +382,24 @@ func (s *Service) existingStripeCustomer(ctx context.Context, userID string) (st
 	}
 
 	return customerID, nil
+}
+
+func (s *Service) currentCancelableSubscription(ctx context.Context, userID string) (db.StripeSubscriptions, error) {
+	subscription, err := s.repo.GetCurrentSubscriptionByUserID(ctx, userID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return db.StripeSubscriptions{}, ErrBillingSubscriptionMissing
+	case err != nil:
+		return db.StripeSubscriptions{}, fmt.Errorf("get current billing subscription: %w", err)
+	}
+
+	if !s.subscriptionRowGrantsAccess(subscription) ||
+		!subscriptionAccessPeriodOpen(subscription, time.Now().UTC()) ||
+		subscription.CancelAtPeriodEnd {
+		return db.StripeSubscriptions{}, ErrBillingSubscriptionNotCancelable
+	}
+
+	return subscription, nil
 }
 
 func (s *Service) configuredForCheckout() bool {

--- a/server/internal/billing/service_portal_test.go
+++ b/server/internal/billing/service_portal_test.go
@@ -77,3 +77,92 @@ func TestServiceCreateCustomerPortalSession_MissingCustomerDoesNotCreateStripeCu
 	repo.AssertExpectations(t)
 	repo.AssertNotCalled(t, "UpsertStripeCustomer", mock.Anything, mock.Anything, mock.Anything)
 }
+
+func TestServiceCreateSubscriptionCancelPortalSession(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	repo.On("GetCurrentSubscriptionByUserID", mock.Anything, "user-123").Return(db.StripeSubscriptions{
+		StripeSubscriptionID: "sub_123",
+		UserID:               "user-123",
+		StripeCustomerID:     "cus_123",
+		StripePriceID:        textToPg("price_premium"),
+		Status:               subscriptionStatusActive,
+	}, nil).Once()
+	repo.On("GetStripeCustomerByUserID", mock.Anything, "user-123").Return(db.StripeCustomers{
+		UserID:           "user-123",
+		StripeCustomerID: "cus_123",
+	}, nil).Once()
+	service.createPortalSession = func(params *stripe.BillingPortalSessionParams) (*stripe.BillingPortalSession, error) {
+		require.NotNil(t, params.Customer)
+		require.NotNil(t, params.ReturnURL)
+		require.NotNil(t, params.FlowData)
+		require.NotNil(t, params.FlowData.AfterCompletion)
+		require.NotNil(t, params.FlowData.AfterCompletion.Redirect)
+		require.NotNil(t, params.FlowData.SubscriptionCancel)
+		require.NotNil(t, params.FlowData.SubscriptionCancel.Subscription)
+		assert.Equal(t, "cus_123", *params.Customer)
+		assert.Equal(t, "http://localhost:5173/chat?billing=portal-return", *params.ReturnURL)
+		assert.Equal(t, string(stripe.BillingPortalSessionFlowTypeSubscriptionCancel), *params.FlowData.Type)
+		assert.Equal(t, string(stripe.BillingPortalSessionFlowAfterCompletionTypeRedirect), *params.FlowData.AfterCompletion.Type)
+		assert.Equal(t, "http://localhost:5173/chat?billing=cancelled", *params.FlowData.AfterCompletion.Redirect.ReturnURL)
+		assert.Equal(t, "sub_123", *params.FlowData.SubscriptionCancel.Subscription)
+		return &stripe.BillingPortalSession{URL: "https://billing.stripe.test/cancel-session"}, nil
+	}
+
+	resp, err := service.CreateSubscriptionCancelPortalSession(ctx)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "https://billing.stripe.test/cancel-session", resp.URL)
+	repo.AssertExpectations(t)
+}
+
+func TestServiceCreateSubscriptionCancelPortalSession_MissingSubscription(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	repo.On("GetCurrentSubscriptionByUserID", mock.Anything, "user-123").Return(db.StripeSubscriptions{}, pgx.ErrNoRows).Once()
+	service.createPortalSession = func(*stripe.BillingPortalSessionParams) (*stripe.BillingPortalSession, error) {
+		t.Fatal("portal session should not open without a cancelable subscription")
+		return nil, nil
+	}
+
+	resp, err := service.CreateSubscriptionCancelPortalSession(ctx)
+
+	require.ErrorIs(t, err, ErrBillingSubscriptionMissing)
+	assert.Nil(t, resp)
+	repo.AssertExpectations(t)
+	repo.AssertNotCalled(t, "GetStripeCustomerByUserID", mock.Anything, mock.Anything)
+}
+
+func TestServiceCreateSubscriptionCancelPortalSession_AlreadyCanceling(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	repo.On("GetCurrentSubscriptionByUserID", mock.Anything, "user-123").Return(db.StripeSubscriptions{
+		StripeSubscriptionID: "sub_123",
+		UserID:               "user-123",
+		StripeCustomerID:     "cus_123",
+		StripePriceID:        textToPg("price_premium"),
+		Status:               subscriptionStatusActive,
+		CancelAtPeriodEnd:    true,
+	}, nil).Once()
+	service.createPortalSession = func(*stripe.BillingPortalSessionParams) (*stripe.BillingPortalSession, error) {
+		t.Fatal("portal session should not open for a subscription already set to cancel")
+		return nil, nil
+	}
+
+	resp, err := service.CreateSubscriptionCancelPortalSession(ctx)
+
+	require.ErrorIs(t, err, ErrBillingSubscriptionNotCancelable)
+	assert.Nil(t, resp)
+	repo.AssertExpectations(t)
+	repo.AssertNotCalled(t, "GetStripeCustomerByUserID", mock.Anything, mock.Anything)
+}


### PR DESCRIPTION
## Summary
- add a Stripe Billing Portal cancellation deep link for active AI chat subscriptions
- add Manage plan and Cancel plan actions with shared pending state and cancellation return polling
- document the AI chat billing portal cancellation flow

## Tests
- `go test ./internal/billing ./cmd/api`
- `go test -short ./...` via pre-push hook
- `bun run tsc`
- `bun run lint`
- `bun run fmt:check`
- `bun run test src/features/chat/api/billing.test.ts src/features/chat/hooks/use-ai-chat-billing-access.hook.test.tsx src/features/chat/components/ai-chat-billing-card.test.tsx src/features/chat/pages/chat-billing-page.test.tsx`
- `bun run build`
- `python C:\Users\lenny\.codex\skills\autoreview\scripts\autoreview --mode local`

## Notes
- Full client `bun run test` had one unrelated workout dialog test fail once; rerunning that file passed.
