### PR TITLE
chore: bump go to 1.26.4

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
           cache-dependency-path: server/go.sum
       - name: Cache Go tools

--- a/.github/workflows/fly-preview.yml
+++ b/.github/workflows/fly-preview.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
           cache-dependency-path: server/go.sum
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
           cache-dependency-path: server/go.sum
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN bun install --frozen-lockfile --ignore-scripts
 COPY --link client .
 RUN bun run build
 
-FROM golang:1.26.3-alpine AS server-build
+FROM golang:1.26.4-alpine AS server-build
 WORKDIR /app
 COPY --link server .
 RUN CGO_ENABLED=0 go build -o api ./cmd/api

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/Andrewy-gh/fittrack/server
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/firebase/genkit/go v1.8.0


### PR DESCRIPTION
## Summary
- bump the Go toolchain pins from 1.26.3 to 1.26.4 across Docker, CI, and server/go.mod
- replace Dependabot PR #158, which only updated the Docker build image and left CI/server module pins on 1.26.3

## Why
`govulncheck` reported reachable Go standard-library vulnerabilities in 1.26.3:
- GO-2026-5039 in net/textproto
- GO-2026-5037 in crypto/x509

Both are fixed by Go 1.26.4.

## Verification
- `go version` -> `go version go1.26.4 windows/amd64`
- `go test -v ./internal/aichat`
- `go test -v ./cmd/api`
- `go test -v ./cmd/ai-chat-scenario-sweep`
- `go mod verify`
- `govulncheck ./...` -> `Your code is affected by 0 vulnerabilities.`

Also tried `go test ./...`; local run failed only on packages requiring the Postgres test database because this Windows environment does not have the expected local test DB credentials/service. CI provisions Postgres for those tests.