### PR TITLE
fix: auto-refresh ai chat access

### DIFF
--- a/client/src/features/chat/components/ai-chat-billing-card.test.tsx
+++ b/client/src/features/chat/components/ai-chat-billing-card.test.tsx
@@ -113,7 +113,7 @@ describe("AIChatBillingCard", () => {
     expect(screen.getByText("Confirming")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Payment complete. We are confirming your AI chat access. Refresh access if this takes more than a moment.",
+        "Payment complete. We are confirming your AI chat access and will keep checking automatically.",
       ),
     ).toBeInTheDocument();
     expect(
@@ -234,7 +234,7 @@ describe("AIChatBillingCard", () => {
     expect(screen.getByText("Activating")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Premium is active. We are finishing AI chat activation. Refresh access if this takes more than a moment.",
+        "Premium is active. We are finishing AI chat activation and will keep checking automatically.",
       ),
     ).toBeInTheDocument();
     expect(

--- a/client/src/features/chat/components/ai-chat-billing-card.tsx
+++ b/client/src/features/chat/components/ai-chat-billing-card.tsx
@@ -283,8 +283,8 @@ function BillingMessage({
   if (accessState === "payment-confirming") {
     return (
       <p className="text-sm text-muted-foreground">
-        Payment complete. We are confirming your AI chat access. Refresh access
-        if this takes more than a moment.
+        Payment complete. We are confirming your AI chat access and will keep
+        checking automatically.
       </p>
     );
   }
@@ -292,8 +292,8 @@ function BillingMessage({
   if (accessState === "activating") {
     return (
       <p className="text-sm text-muted-foreground">
-        Premium is active. We are finishing AI chat activation. Refresh access
-        if this takes more than a moment.
+        Premium is active. We are finishing AI chat activation and will keep
+        checking automatically.
       </p>
     );
   }

--- a/client/src/features/chat/hooks/use-ai-chat-billing-access.hook.test.tsx
+++ b/client/src/features/chat/hooks/use-ai-chat-billing-access.hook.test.tsx
@@ -124,6 +124,63 @@ describe("useAIChatBillingAccess checkout polling", () => {
     expect(result.current.isBillingError).toBe(false);
   });
 
+  it("keeps refreshing checkout access automatically while payment is confirming", async () => {
+    mocks.mockGetBaseBillingStatus.mockResolvedValue(blockedBillingStatus);
+    mocks.mockGetBaseFeatureAccess.mockResolvedValue([]);
+    mocks.mockGetCheckoutBillingStatus.mockResolvedValue(blockedBillingStatus);
+    mocks.mockGetCheckoutFeatureAccess.mockResolvedValue([]);
+
+    const { result } = renderBillingAccessHook();
+
+    await waitFor(
+      () => {
+        expect(result.current.accessState).toBe("payment-confirming");
+      },
+      { interval: 1 },
+    );
+    const checkoutAttemptsBeforeRefresh =
+      mocks.mockGetCheckoutFeatureAccess.mock.calls.length;
+
+    mocks.mockGetCheckoutBillingStatus.mockResolvedValue(activeBillingStatus);
+    mocks.mockGetCheckoutFeatureAccess.mockResolvedValue([aiChatFeatureGrant]);
+
+    await waitFor(() => {
+      expect(result.current.accessState).toBe("ready");
+      expect(
+        mocks.mockGetCheckoutFeatureAccess.mock.calls.length,
+      ).toBeGreaterThan(checkoutAttemptsBeforeRefresh);
+    });
+    expect(result.current.hasChatAccess).toBe(true);
+  });
+
+  it("keeps refreshing access automatically when premium billing is active but the feature grant is stale", async () => {
+    mocks.mockGetBaseBillingStatus.mockResolvedValue(activeBillingStatus);
+    mocks.mockGetBaseFeatureAccess.mockResolvedValue([]);
+    mocks.mockGetCheckoutBillingStatus.mockResolvedValue(activeBillingStatus);
+    mocks.mockGetCheckoutFeatureAccess.mockResolvedValue([]);
+
+    const { result } = renderBillingAccessHook({ checkout: undefined });
+
+    await waitFor(
+      () => {
+        expect(result.current.accessState).toBe("activating");
+      },
+      { interval: 1 },
+    );
+    const accessAttemptsBeforeRefresh =
+      mocks.mockGetCheckoutFeatureAccess.mock.calls.length;
+
+    mocks.mockGetCheckoutFeatureAccess.mockResolvedValue([aiChatFeatureGrant]);
+
+    await waitFor(() => {
+      expect(result.current.accessState).toBe("ready");
+      expect(
+        mocks.mockGetCheckoutFeatureAccess.mock.calls.length,
+      ).toBeGreaterThan(accessAttemptsBeforeRefresh);
+    });
+    expect(result.current.hasChatAccess).toBe(true);
+  });
+
   it("restarts checkout polling when payment confirmation is refreshed", async () => {
     mocks.mockGetBaseBillingStatus.mockResolvedValue(blockedBillingStatus);
     mocks.mockGetBaseFeatureAccess.mockResolvedValue([]);

--- a/client/src/features/chat/hooks/use-ai-chat-billing-access.ts
+++ b/client/src/features/chat/hooks/use-ai-chat-billing-access.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import type { NavigateFn } from "@tanstack/react-router";
 import {
@@ -58,6 +58,8 @@ export type AIChatBillingAccess = {
 
 const checkoutAccessRetryDelaysMs =
   import.meta.env.MODE === "test" ? [1, 1, 1, 1] : [1000, 2000, 4000, 8000];
+const checkoutAccessAutoRefreshDelayMs =
+  import.meta.env.MODE === "test" ? 25 : 5000;
 
 export type AIChatAccessState =
   | "checking"
@@ -134,6 +136,12 @@ export function useAIChatBillingAccess({
     onSuccess: (session) => redirectToBillingPortal(session.url),
     onError: (error) => showErrorToast(error, "Could not open billing"),
   });
+  const restartCheckoutAccessPolling = useCallback(() => {
+    setSettledCheckoutPollingView({ status: "idle" });
+    setShouldPollCheckoutAccess(true);
+    void billingQuery.refetch();
+    void featureAccessQuery.refetch();
+  }, [billingQuery.refetch, featureAccessQuery.refetch]);
 
   useEffect(() => {
     if (!checkout) {
@@ -223,6 +231,35 @@ export function useAIChatBillingAccess({
     Boolean(billingQuery.isFetching) ||
     Boolean(featureAccessQuery.isFetching);
 
+  useEffect(() => {
+    if (checkoutNotice !== "success" && accessView.state !== "activating") {
+      return;
+    }
+
+    if (
+      accessView.state !== "payment-confirming" &&
+      accessView.state !== "activating"
+    ) {
+      return;
+    }
+
+    if (isRefreshingAccess) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(
+      restartCheckoutAccessPolling,
+      checkoutAccessAutoRefreshDelayMs,
+    );
+
+    return () => window.clearTimeout(timeoutId);
+  }, [
+    accessView.state,
+    checkoutNotice,
+    isRefreshingAccess,
+    restartCheckoutAccessPolling,
+  ]);
+
   return {
     billingStatus: accessView.billingStatus,
     checkoutNotice,
@@ -242,8 +279,8 @@ export function useAIChatBillingAccess({
         accessView.state === "payment-confirming" ||
         accessView.state === "checkout-activation-error"
       ) {
-        setSettledCheckoutPollingView({ status: "idle" });
-        setShouldPollCheckoutAccess(true);
+        restartCheckoutAccessPolling();
+        return;
       }
       void billingQuery.refetch();
       void featureAccessQuery.refetch();

--- a/client/src/features/chat/pages/chat-billing-page.test.tsx
+++ b/client/src/features/chat/pages/chat-billing-page.test.tsx
@@ -128,10 +128,19 @@ describe("ChatRouteComponent", () => {
       screen.queryByRole("button", { name: "Start 7-day trial" }),
     ).not.toBeInTheDocument();
 
+    const billingRefreshesBeforeClick =
+      mockRefetchBillingStatus.mock.calls.length;
+    const featureAccessRefreshesBeforeClick =
+      mockRefetchFeatureAccess.mock.calls.length;
+
     await user.click(screen.getByRole("button", { name: "Refresh access" }));
 
-    expect(mockRefetchBillingStatus).toHaveBeenCalledTimes(1);
-    expect(mockRefetchFeatureAccess).toHaveBeenCalledTimes(1);
+    expect(mockRefetchBillingStatus.mock.calls.length).toBeGreaterThanOrEqual(
+      billingRefreshesBeforeClick + 1,
+    );
+    expect(mockRefetchFeatureAccess.mock.calls.length).toBeGreaterThanOrEqual(
+      featureAccessRefreshesBeforeClick + 1,
+    );
   });
 
   it("confirms payment without offering Checkout when the checkout poll has not received billing access yet", async () => {
@@ -178,10 +187,19 @@ describe("ChatRouteComponent", () => {
       screen.queryByRole("button", { name: "Start 7-day trial" }),
     ).not.toBeInTheDocument();
 
+    const billingRefreshesBeforeClick =
+      mockRefetchBillingStatus.mock.calls.length;
+    const featureAccessRefreshesBeforeClick =
+      mockRefetchFeatureAccess.mock.calls.length;
+
     await user.click(screen.getByRole("button", { name: "Refresh access" }));
 
-    expect(mockRefetchBillingStatus).toHaveBeenCalledTimes(1);
-    expect(mockRefetchFeatureAccess).toHaveBeenCalledTimes(1);
+    expect(mockRefetchBillingStatus.mock.calls.length).toBeGreaterThanOrEqual(
+      billingRefreshesBeforeClick + 1,
+    );
+    expect(mockRefetchFeatureAccess.mock.calls.length).toBeGreaterThanOrEqual(
+      featureAccessRefreshesBeforeClick + 1,
+    );
     expect(mockCreateBillingCheckoutSession).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- keep AI chat access polling alive while checkout/payment activation catches up
- auto-refresh stale premium activation states without requiring F5 or manual refresh
- update billing card copy and regression tests for automatic access checking

## Verification
- bun run test src/features/chat/hooks/use-ai-chat-billing-access.hook.test.tsx src/features/chat/pages/chat-billing-page.test.tsx src/features/chat/components/ai-chat-billing-card.test.tsx
- bun run fmt:check -- src/features/chat/hooks/use-ai-chat-billing-access.ts src/features/chat/hooks/use-ai-chat-billing-access.hook.test.tsx src/features/chat/pages/chat-billing-page.test.tsx src/features/chat/components/ai-chat-billing-card.tsx src/features/chat/components/ai-chat-billing-card.test.tsx
- bun run lint
- bun run tsc
- autoreview clean: no accepted/actionable findings reported