### PR TITLE
fix: fence ai chat recovery owners

### DIFF
--- a/server/internal/aichat/repository_test.go
+++ b/server/internal/aichat/repository_test.go
@@ -55,6 +55,21 @@ func TestTextPtrToPg_PreservesNilAsNull(t *testing.T) {
 	}
 }
 
+func TestNewInngestRunOwner_UniquePerRecoveryClaim(t *testing.T) {
+	first := newInngestRunOwner(51).Value()
+	second := newInngestRunOwner(51).Value()
+
+	if first == second {
+		t.Fatalf("recovery owners should be unique per claim, got %q", first)
+	}
+	if !strings.HasPrefix(first, "inngest:run-51-") {
+		t.Fatalf("recovery owner should include run id for traceability, got %q", first)
+	}
+	if !strings.HasPrefix(second, "inngest:run-51-") {
+		t.Fatalf("recovery owner should include run id for traceability, got %q", second)
+	}
+}
+
 func TestIsStreamingRunStale(t *testing.T) {
 	now := time.Date(2026, 3, 26, 18, 30, 0, 0, time.UTC)
 

--- a/server/internal/aichat/run_owner.go
+++ b/server/internal/aichat/run_owner.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -36,7 +38,7 @@ func newAPIRunOwner() runOwner {
 }
 
 func newInngestRunOwner(runID int32) runOwner {
-	return newRunOwner(runOwnerKindInngest, fmt.Sprintf("run-%d", runID))
+	return newRunOwner(runOwnerKindInngest, fmt.Sprintf("run-%d-%s", runID, uuid.NewString()))
 }
 
 func newRunOwner(kind string, id string) runOwner {

--- a/server/internal/aichateval/scenarios.go
+++ b/server/internal/aichateval/scenarios.go
@@ -162,5 +162,13 @@ func DefaultScenarios() []Scenario {
 			ExpectedOutcome: ExpectedNarrowScopeBeforeGenerate,
 			FollowUpAnswer:  "Focus on the workout only: beginner, no injuries, 35 minutes, full gym.",
 		},
+		{
+			ID:              "prompt-19",
+			Title:           "Machine Chest Hypertrophy Follow-Up",
+			Prompt:          "Hello I would like a chest workout for today. I have about an hour and a half with warm up included. Only machines and cables. Focusing on hypertrophy.",
+			Expectation:     "Should ask about injuries first, then generate a structured machine-and-cable chest draft after a short no-injuries answer without failing workout contract validation.",
+			ExpectedOutcome: ExpectedAskOnceThenGenerate,
+			FollowUpAnswer:  "Nope.",
+		},
 	}
 }

--- a/server/internal/aichateval/scenarios_test.go
+++ b/server/internal/aichateval/scenarios_test.go
@@ -1,0 +1,29 @@
+package aichateval
+
+import "testing"
+
+func TestDefaultScenariosIncludesMachineChestHypertrophyFollowUp(t *testing.T) {
+	scenario, ok := findDefaultScenario("prompt-19")
+	if !ok {
+		t.Fatal("DefaultScenarios() missing prompt-19")
+	}
+
+	if scenario.ExpectedOutcome != ExpectedAskOnceThenGenerate {
+		t.Fatalf("prompt-19 expected outcome = %q, want %q", scenario.ExpectedOutcome, ExpectedAskOnceThenGenerate)
+	}
+	if scenario.FollowUpAnswer != "Nope." {
+		t.Fatalf("prompt-19 follow-up answer = %q, want observed short no-injuries answer", scenario.FollowUpAnswer)
+	}
+	if scenario.Prompt != "Hello I would like a chest workout for today. I have about an hour and a half with warm up included. Only machines and cables. Focusing on hypertrophy." {
+		t.Fatalf("prompt-19 prompt = %q, want observed machine chest prompt", scenario.Prompt)
+	}
+}
+
+func findDefaultScenario(id string) (Scenario, bool) {
+	for _, scenario := range DefaultScenarios() {
+		if scenario.ID == id {
+			return scenario, true
+		}
+	}
+	return Scenario{}, false
+}


### PR DESCRIPTION
## Summary
- make Inngest recovery owners unique per claim so stale recovery workers cannot keep writing after a newer claim
- add a regression test for recovery owner uniqueness
- add prompt-19 to the AI chat eval pack for the machine/cable chest workout follow-up that exposed workout draft validation failure

## Test plan
- go test ./internal/aichat ./internal/aichateval
- git diff --cached --check

Stacked on PR #161.