### PR TITLE
fix: move demo guest button into header

### DIFF
--- a/client/src/components/demo-header.test.tsx
+++ b/client/src/components/demo-header.test.tsx
@@ -1,0 +1,36 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DemoHeader } from "@/components/demo-header";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, ...props }: ComponentPropsWithoutRef<"a">) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("@/components/guest-user-button", () => ({
+  GuestUserButton: () => (
+    <button
+      type="button"
+      aria-label="Guest user menu"
+    >
+      guest
+    </button>
+  ),
+}));
+
+vi.mock("@/components/mobile-bottom-nav", () => ({
+  MobileBottomNav: () => null,
+}));
+
+describe("DemoHeader", () => {
+  it("uses the guest user button instead of a separate theme button", () => {
+    render(<DemoHeader />);
+
+    expect(
+      screen.getByRole("button", { name: "Guest user menu" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+  });
+});

--- a/client/src/components/demo-header.tsx
+++ b/client/src/components/demo-header.tsx
@@ -1,16 +1,8 @@
 import { Link } from "@tanstack/react-router";
-import { Sun, Moon } from "lucide-react";
-import { useTheme } from "@/components/theme-provider";
-import { Button } from "@/components/ui/button";
+import { GuestUserButton } from "./guest-user-button";
 import { MobileBottomNav } from "./mobile-bottom-nav";
 
 export function DemoHeader() {
-  const { theme, setTheme } = useTheme();
-
-  const toggleTheme = () => {
-    setTheme(theme === "light" ? "dark" : "light");
-  };
-
   return (
     <>
       <header
@@ -32,16 +24,7 @@ export function DemoHeader() {
           </div>
         </nav>
 
-        <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={toggleTheme}
-            className="h-8 w-8"
-          >
-            {theme === "light" ? <Moon size={16} /> : <Sun size={16} />}
-          </Button>
-        </div>
+        <GuestUserButton />
       </header>
 
       <MobileBottomNav

--- a/client/src/components/guest-user-button.test.tsx
+++ b/client/src/components/guest-user-button.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { GuestUserButton } from "@/components/guest-user-button";
+import { ThemeProvider } from "@/components/theme-provider";
+
+describe("GuestUserButton", () => {
+  it("names the icon-only menu trigger", () => {
+    render(
+      <ThemeProvider>
+        <GuestUserButton />
+      </ThemeProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Guest user menu" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/components/guest-user-button.tsx
+++ b/client/src/components/guest-user-button.tsx
@@ -30,7 +30,10 @@ export function GuestUserButton() {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="outline-none">
+      <DropdownMenuTrigger
+        aria-label="Guest user menu"
+        className="outline-none"
+      >
         <Avatar className="h-8.5 w-8.5">
           <AvatarFallback>
             <User {...iconProps} />


### PR DESCRIPTION
## Summary
- Replace the standalone desktop demo theme toggle with the guest user menu
- Keep theme switching available inside the not-signed-in menu with sign in/sign up actions
- Add a regression test that demo desktop renders exactly one header button

## Verification
- bun run lint
- bun run tsc
- bun run test
- bun run build
- Visual review board: C:\Users\lenny\.codex\diagrams\verification-fittrack-demo-user-button\index.html