### PR TITLE
feat(chat): redesign AI chat page around a centered composer

### DIFF
--- a/client/src/features/chat/components/chat-composer.tsx
+++ b/client/src/features/chat/components/chat-composer.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef } from "react";
+import type { FormEvent, KeyboardEvent } from "react";
+import { ArrowUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type ChatComposerProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  disabled?: boolean;
+  isSubmitting?: boolean;
+  placeholder?: string;
+  autoFocus?: boolean;
+  className?: string;
+};
+
+export function ChatComposer({
+  value,
+  onChange,
+  onSubmit,
+  disabled = false,
+  isSubmitting = false,
+  placeholder,
+  autoFocus = false,
+  className,
+}: ChatComposerProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const canSend = Boolean(value.trim()) && !disabled && !isSubmitting;
+
+  useEffect(() => {
+    const element = textareaRef.current;
+    if (!element) {
+      return;
+    }
+    element.style.height = "auto";
+    element.style.height = `${Math.min(element.scrollHeight, 160)}px`;
+  }, [value]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (canSend) {
+      onSubmit();
+    }
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      !event.nativeEvent.isComposing
+    ) {
+      event.preventDefault();
+      if (canSend) {
+        onSubmit();
+      }
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={cn("w-full", className)}
+    >
+      <div
+        className={cn(
+          "flex items-end gap-2 rounded-[1.75rem] border bg-muted/40 px-4 py-3 shadow-sm",
+          "transition-colors focus-within:border-ring focus-within:bg-background",
+          disabled && "opacity-70",
+        )}
+      >
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus={autoFocus}
+          rows={1}
+          className={cn(
+            "max-h-40 min-h-[1.5rem] flex-1 resize-none bg-transparent py-1 text-sm leading-6",
+            "outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed",
+          )}
+        />
+        <Button
+          type="submit"
+          size="icon"
+          aria-label="Send"
+          disabled={!canSend}
+          className="size-9 shrink-0 rounded-full"
+        >
+          <ArrowUp className="size-4" />
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/client/src/features/chat/components/chat-empty-state.tsx
+++ b/client/src/features/chat/components/chat-empty-state.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type ChatEmptyStateProps = {
+  heading: string;
+  examples: string[];
+  onSelectExample: (text: string) => void;
+  composer: ReactNode;
+  disabled?: boolean;
+};
+
+export function ChatEmptyState({
+  heading,
+  examples,
+  onSelectExample,
+  composer,
+  disabled = false,
+}: ChatEmptyStateProps) {
+  return (
+    <div className="flex min-h-[70vh] w-full flex-col items-center justify-center gap-6 px-1">
+      <h1 className="text-center text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+        {heading}
+      </h1>
+      <div className="w-full">{composer}</div>
+      {examples.length > 0 ? (
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          {examples.map((example, index) => (
+            <button
+              key={example}
+              type="button"
+              disabled={disabled}
+              onClick={() => onSelectExample(example)}
+              className={cn(
+                "rounded-full border bg-background px-4 py-2 text-sm text-muted-foreground transition-colors",
+                "hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50",
+                // One example on small screens, a second on larger screens.
+                index >= 1 && "hidden sm:inline-flex",
+              )}
+            >
+              {example}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/features/chat/components/chat-message-actions.tsx
+++ b/client/src/features/chat/components/chat-message-actions.tsx
@@ -1,0 +1,83 @@
+import { Check, Copy, RotateCcw } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+type ChatMessageActionsProps = {
+  content: string;
+  canRetry?: boolean;
+  onRetry?: () => void;
+  className?: string;
+};
+
+export function ChatMessageActions({
+  content,
+  canRetry = false,
+  onRetry,
+  className,
+}: ChatMessageActionsProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+    const timer = window.setTimeout(() => setCopied(false), 1500);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard?.writeText(content);
+      setCopied(true);
+    } catch {
+      toast.error("Could not copy message");
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-0.5 text-muted-foreground",
+        className,
+      )}
+    >
+      <ActionButton
+        label={copied ? "Copied" : "Copy"}
+        onClick={handleCopy}
+      >
+        {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+      </ActionButton>
+      {canRetry && onRetry ? (
+        <ActionButton
+          label="Retry"
+          onClick={onRetry}
+        >
+          <RotateCcw className="size-4" />
+        </ActionButton>
+      ) : null}
+    </div>
+  );
+}
+
+function ActionButton({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      className="inline-flex size-7 items-center justify-center rounded-md transition-colors hover:bg-accent hover:text-accent-foreground"
+    >
+      {children}
+    </button>
+  );
+}

--- a/client/src/features/chat/components/chat-typing-indicator.tsx
+++ b/client/src/features/chat/components/chat-typing-indicator.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+
+type ChatTypingIndicatorProps = {
+  className?: string;
+};
+
+export function ChatTypingIndicator({ className }: ChatTypingIndicatorProps) {
+  return (
+    <span
+      role="status"
+      aria-label="Assistant is typing"
+      data-testid="chat-typing-indicator"
+      className={cn("inline-flex items-center gap-1 align-middle", className)}
+    >
+      {[0, 1, 2].map((dot) => (
+        <span
+          key={dot}
+          className="size-1.5 animate-bounce rounded-full bg-muted-foreground/60"
+          style={{ animationDelay: `${dot * 0.16}s`, animationDuration: "1s" }}
+        />
+      ))}
+    </span>
+  );
+}

--- a/client/src/features/chat/hooks/use-ai-chat-session.ts
+++ b/client/src/features/chat/hooks/use-ai-chat-session.ts
@@ -252,6 +252,31 @@ export function useAIChatSession({
     ],
   );
 
+  const submitPromptValue = useCallback(
+    (value: string) =>
+      submitPromptRequest({
+        conversationId,
+        prompt: value,
+        isSubmitting,
+        onConversationCreated,
+        loadConversation,
+        recoverConversation,
+        recordTelemetry,
+        refs,
+        setters,
+      }),
+    [
+      conversationId,
+      isSubmitting,
+      loadConversation,
+      onConversationCreated,
+      recordTelemetry,
+      recoverConversation,
+      refs,
+      setters,
+    ],
+  );
+
   const saveLatestWorkoutDraft = useCallback(
     () =>
       saveLatestWorkoutDraftRequest({
@@ -273,6 +298,7 @@ export function useAIChatSession({
     latestWorkoutDraftMessageId,
     createNewChat,
     submitPrompt,
+    submitPromptValue,
     saveLatestWorkoutDraft,
   };
 }

--- a/client/src/features/chat/pages/chat-billing-page.test.tsx
+++ b/client/src/features/chat/pages/chat-billing-page.test.tsx
@@ -117,10 +117,7 @@ describe("ChatRouteComponent", () => {
 
     render(<ChatRouteComponent />);
 
-    expect(
-      await screen.findByText("AI chat activation is still finishing."),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Activating")).toBeInTheDocument();
+    expect(await screen.findByText("Activating")).toBeInTheDocument();
     expect(
       screen.queryByText("Checking your AI chat access..."),
     ).not.toBeInTheDocument();
@@ -177,12 +174,7 @@ describe("ChatRouteComponent", () => {
 
     render(<ChatRouteComponent />);
 
-    expect(
-      await screen.findByText(
-        "Payment complete. We are confirming your AI chat access.",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Confirming")).toBeInTheDocument();
+    expect(await screen.findByText("Confirming")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Start 7-day trial" }),
     ).not.toBeInTheDocument();
@@ -241,9 +233,6 @@ describe("ChatRouteComponent", () => {
     expect(
       screen.queryByRole("button", { name: "Start 7-day trial" }),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByText("AI chat activation needs another access refresh."),
-    ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Refresh access" }));
 
@@ -286,7 +275,6 @@ describe("ChatRouteComponent", () => {
         "Ask about training, recovery, exercise choices, or FitTrack usage...",
       ),
     ).toBeDisabled();
-    expect(screen.getByText("AI chat activation is still finishing."));
   });
 
   it("starts Checkout from the no-access trial CTA", async () => {

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -125,12 +125,12 @@ describe("ChatRouteComponent", () => {
       category: "ux",
       outcome: "failure_toast_shown",
     });
+    expect(screen.getByText("What should we train today?")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "No messages yet. Start a new chat or send the first prompt.",
+      screen.getByPlaceholderText(
+        "Ask about training, recovery, exercise choices, or FitTrack usage...",
       ),
-    ).toBeInTheDocument();
-    expect(promptBox).toHaveValue("hello");
+    ).toHaveValue("hello");
   });
 
   it("keeps the prompt visible and shows the recovery failure when submit recovery fails before stream start", async () => {
@@ -185,9 +185,7 @@ describe("ChatRouteComponent", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(
-          "No messages yet. Start a new chat or send the first prompt.",
-        ),
+        screen.getByText("What should we train today?"),
       ).toBeInTheDocument();
     });
 
@@ -239,9 +237,7 @@ describe("ChatRouteComponent", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(
-          "No messages yet. Start a new chat or send the first prompt.",
-        ),
+        screen.getByText("What should we train today?"),
       ).toBeInTheDocument();
     });
 
@@ -306,11 +302,7 @@ describe("ChatRouteComponent", () => {
         ),
       ).toBeEnabled();
     });
-    expect(
-      screen.getByText(
-        "No messages yet. Start a new chat or send the first prompt.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText("What should we train today?")).toBeInTheDocument();
     expect(mockShowErrorToast).not.toHaveBeenCalled();
     expect(mockReportTelemetry).toHaveBeenCalledWith({
       category: "recovery",
@@ -520,7 +512,7 @@ describe("ChatRouteComponent", () => {
     });
     expect(streamSignal?.aborted).toBe(false);
     expect(screen.getByText("hello")).toBeInTheDocument();
-    expect(screen.getByText("...")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-typing-indicator")).toBeInTheDocument();
 
     view.unmount();
   });

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -1,16 +1,20 @@
-import type { FormEvent } from "react";
+import { Plus } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Textarea } from "@/components/ui/textarea";
 import type {
   AIChatMessage,
   AIWorkoutDraft,
 } from "@/features/chat/api/ai-chat";
 import { saveAIWorkoutDraftToWorkoutForm } from "@/features/chat/utils/ai-workout-draft";
 import { workoutDraftStorage } from "@/lib/local-storage";
+import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { AIChatBillingCard } from "../components/ai-chat-billing-card";
+import { ChatComposer } from "../components/chat-composer";
+import { ChatEmptyState } from "../components/chat-empty-state";
+import { ChatMessageActions } from "../components/chat-message-actions";
+import { ChatTypingIndicator } from "../components/chat-typing-indicator";
 import { ChatWorkoutDraftCard } from "../components/chat-workout-draft-card";
 import { useAIChatBillingAccess } from "../hooks/use-ai-chat-billing-access";
 import { useAIChatSession } from "../hooks/use-ai-chat-session";
@@ -23,6 +27,11 @@ type ChatPageProps = {
   conversationIdSearch?: string;
   checkout?: ChatCheckoutSearch;
 };
+
+const COMPOSER_PLACEHOLDER =
+  "Ask about training, recovery, exercise choices, or FitTrack usage...";
+
+const EXAMPLE_PROMPTS = ["Build me a 45-min push day", "Plan leg day"];
 
 export function ChatPage({
   userId,
@@ -43,6 +52,7 @@ export function ChatPage({
     latestWorkoutDraftMessageId,
     createNewChat,
     submitPrompt,
+    submitPromptValue,
     saveLatestWorkoutDraft,
   } = useAIChatSession({
     conversationId,
@@ -76,21 +86,54 @@ export function ChatPage({
   }
   const currentUserId = userId;
 
+  const hasChatAccess = billingAccess.hasChatAccess;
+  const isComposerDisabled =
+    isSubmitting || billingAccess.isCheckingAccess || !hasChatAccess;
+
   async function handleNewChat() {
-    if (!billingAccess.hasChatAccess || billingAccess.isCheckingAccess) {
+    if (!hasChatAccess || billingAccess.isCheckingAccess) {
       return;
     }
 
     await createNewChat();
   }
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!billingAccess.hasChatAccess || billingAccess.isCheckingAccess) {
+  async function handleSubmit() {
+    if (isComposerDisabled) {
       return;
     }
 
     await submitPrompt();
+    billingAccess.refreshAccess();
+  }
+
+  async function handleSelectExample(text: string) {
+    if (isComposerDisabled) {
+      return;
+    }
+
+    setPrompt(text);
+    await submitPromptValue(text);
+    billingAccess.refreshAccess();
+  }
+
+  async function handleRetry() {
+    if (isComposerDisabled) {
+      return;
+    }
+
+    let lastUserPrompt: string | undefined;
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      if (messages[index].role === "user") {
+        lastUserPrompt = messages[index].content;
+        break;
+      }
+    }
+    if (!lastUserPrompt) {
+      return;
+    }
+
+    await submitPromptValue(lastUserPrompt);
     billingAccess.refreshAccess();
   }
 
@@ -125,166 +168,157 @@ export function ChatPage({
     conversation?.latest_workout_draft_status?.is_saved ?? false;
   const savedWorkoutId =
     conversation?.latest_workout_draft_status?.saved_workout_id;
-  const chatAccessMessage =
-    billingAccess.accessState === "payment-confirming"
-      ? "Payment complete. We are confirming your AI chat access."
-      : billingAccess.accessState === "activating"
-        ? "AI chat activation is still finishing."
-        : billingAccess.accessState === "checkout-activation-error"
-          ? "AI chat activation needs another access refresh."
-          : "Start or restore premium access to use AI chat.";
+
+  let lastAssistantMessageId: number | null = null;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index].role === "assistant") {
+      lastAssistantMessageId = messages[index].id;
+      break;
+    }
+  }
+
+  const composer = (
+    <ChatComposer
+      value={prompt}
+      onChange={setPrompt}
+      onSubmit={handleSubmit}
+      disabled={isComposerDisabled}
+      isSubmitting={isSubmitting}
+      placeholder={COMPOSER_PLACEHOLDER}
+      autoFocus={messages.length === 0}
+    />
+  );
+
+  const showEmptyState =
+    !isLoadingConversation &&
+    !loadError &&
+    messages.length === 0 &&
+    !conversation?.latest_workout_draft;
 
   return (
-    <div className="mx-auto flex max-w-5xl flex-col gap-6 p-6">
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between gap-4">
-          <div>
-            <CardTitle>AI Chat</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              Persisted chat with reopenable workout drafts and a direct handoff
-              into the workout form.
-            </p>
+    <div className="flex flex-col gap-4 pb-10">
+      <div className="mx-auto w-full max-w-3xl px-4 pt-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="sm:flex-1">
+            <AIChatBillingCard
+              status={billingAccess.billingStatus}
+              accessState={billingAccess.accessState}
+              isLoading={billingAccess.isBillingCardLoading}
+              isError={billingAccess.isBillingError}
+              isRefreshingAccess={billingAccess.isRefreshingAccess}
+              isCheckoutLoading={billingAccess.isCheckoutLoading}
+              isBillingPortalLoading={billingAccess.isBillingPortalLoading}
+              onStartCheckout={billingAccess.startCheckout}
+              onManageBilling={billingAccess.manageBilling}
+              onRefreshAccess={billingAccess.refreshAccess}
+            />
           </div>
           <Button
             type="button"
             variant="outline"
+            aria-label="New Chat"
             onClick={handleNewChat}
-            disabled={
-              billingAccess.isCheckingAccess || !billingAccess.hasChatAccess
-            }
+            disabled={billingAccess.isCheckingAccess || !hasChatAccess}
+            className="self-end sm:self-start"
           >
+            <Plus className="size-4" />
             New Chat
           </Button>
-        </CardHeader>
-      </Card>
+        </div>
+      </div>
 
       {billingAccess.checkoutNotice ? (
-        <CheckoutNotice checkout={billingAccess.checkoutNotice} />
+        <div className="mx-auto w-full max-w-3xl px-4">
+          <CheckoutNotice checkout={billingAccess.checkoutNotice} />
+        </div>
       ) : null}
 
-      <AIChatBillingCard
-        status={billingAccess.billingStatus}
-        accessState={billingAccess.accessState}
-        isLoading={billingAccess.isBillingCardLoading}
-        isError={billingAccess.isBillingError}
-        isRefreshingAccess={billingAccess.isRefreshingAccess}
-        isCheckoutLoading={billingAccess.isCheckoutLoading}
-        isBillingPortalLoading={billingAccess.isBillingPortalLoading}
-        onStartCheckout={billingAccess.startCheckout}
-        onManageBilling={billingAccess.manageBilling}
-        onRefreshAccess={billingAccess.refreshAccess}
-      />
-
-      <Card className="min-h-[32rem]">
-        <CardContent className="flex h-full flex-col gap-4 p-4">
-          {isLoadingConversation ? (
-            <div className="text-sm text-muted-foreground">
-              Loading conversation...
-            </div>
-          ) : loadError ? (
-            <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-              {loadError}
-            </div>
-          ) : messages.length === 0 ? (
-            <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
-              No messages yet. Start a new chat or send the first prompt.
-            </div>
-          ) : (
-            <div className="flex flex-1 flex-col gap-3 overflow-y-auto">
-              {messages.map((message) => (
-                <MessageBubble
-                  key={`${message.id}-${message.updated_at}`}
-                  message={message}
-                  workoutDraft={
-                    message.id === latestWorkoutDraftMessageId
-                      ? conversation?.latest_workout_draft
-                      : undefined
-                  }
-                  onEditWorkoutDraft={() => {
-                    if (conversation?.latest_workout_draft) {
-                      handleEditInWorkoutForm(
-                        conversation.latest_workout_draft,
-                      );
+      <div className="mx-auto w-full max-w-3xl px-4">
+        {showEmptyState ? (
+          <ChatEmptyState
+            heading={
+              hasChatAccess
+                ? "What should we train today?"
+                : "Unlock your AI training partner"
+            }
+            examples={hasChatAccess ? EXAMPLE_PROMPTS : []}
+            onSelectExample={handleSelectExample}
+            composer={composer}
+            disabled={isComposerDisabled}
+          />
+        ) : (
+          <div className="flex flex-col gap-6">
+            {loadError ? (
+              <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+                {loadError}
+              </div>
+            ) : isLoadingConversation && messages.length === 0 ? (
+              <div className="text-sm text-muted-foreground">
+                Loading conversation...
+              </div>
+            ) : (
+              <div className="flex flex-col gap-6">
+                {messages.map((message) => (
+                  <MessageBubble
+                    key={`${message.id}-${message.updated_at}`}
+                    message={message}
+                    isLastAssistant={message.id === lastAssistantMessageId}
+                    onRetry={handleRetry}
+                    workoutDraft={
+                      message.id === latestWorkoutDraftMessageId
+                        ? conversation?.latest_workout_draft
+                        : undefined
                     }
-                  }}
-                  onSaveWorkoutDraft={() => {
-                    if (conversation?.latest_workout_draft) {
-                      void handleSaveWorkoutDraft();
+                    onEditWorkoutDraft={() => {
+                      if (conversation?.latest_workout_draft) {
+                        handleEditInWorkoutForm(
+                          conversation.latest_workout_draft,
+                        );
+                      }
+                    }}
+                    onSaveWorkoutDraft={() => {
+                      if (conversation?.latest_workout_draft) {
+                        void handleSaveWorkoutDraft();
+                      }
+                    }}
+                    onOpenSavedWorkout={
+                      savedWorkoutId
+                        ? () => handleOpenSavedWorkout(savedWorkoutId)
+                        : undefined
                     }
-                  }}
-                  onOpenSavedWorkout={
-                    savedWorkoutId
-                      ? () => handleOpenSavedWorkout(savedWorkoutId)
-                      : undefined
-                  }
-                  isSavingWorkoutDraft={isSavingWorkoutDraft}
-                  isSavedWorkoutDraft={isLatestWorkoutDraftSaved}
-                  savedWorkoutId={savedWorkoutId}
-                />
-              ))}
-            </div>
-          )}
+                    isSavingWorkoutDraft={isSavingWorkoutDraft}
+                    isSavedWorkoutDraft={isLatestWorkoutDraftSaved}
+                    savedWorkoutId={savedWorkoutId}
+                  />
+                ))}
+              </div>
+            )}
 
-          {conversation?.latest_workout_draft &&
-          latestWorkoutDraftMessageId === null ? (
-            <ChatWorkoutDraftCard
-              className="max-w-[85%]"
-              draft={conversation.latest_workout_draft}
-              isSaving={isSavingWorkoutDraft}
-              isSaved={isLatestWorkoutDraftSaved}
-              savedWorkoutId={savedWorkoutId}
-              onSave={() => void handleSaveWorkoutDraft()}
-              onEdit={() =>
-                handleEditInWorkoutForm(conversation.latest_workout_draft!)
-              }
-              onOpenSavedWorkout={
-                savedWorkoutId
-                  ? () => handleOpenSavedWorkout(savedWorkoutId)
-                  : undefined
-              }
-            />
-          ) : null}
-
-          <form
-            className="mt-auto flex flex-col gap-3"
-            onSubmit={handleSubmit}
-          >
-            <Textarea
-              value={prompt}
-              onChange={(event) => setPrompt(event.target.value)}
-              placeholder="Ask about training, recovery, exercise choices, or FitTrack usage..."
-              rows={4}
-              disabled={
-                isSubmitting ||
-                billingAccess.isCheckingAccess ||
-                !billingAccess.hasChatAccess
-              }
-            />
-            <div className="flex items-center justify-between gap-3">
-              <p className="text-xs text-muted-foreground">
-                {billingAccess.isCheckingAccess
-                  ? "Checking AI chat access..."
-                  : billingAccess.hasChatAccess
-                    ? `Conversation ID: ${
-                        conversation?.id ?? conversationId ?? "not created yet"
-                      }`
-                    : chatAccessMessage}
-              </p>
-              <Button
-                type="submit"
-                disabled={
-                  isSubmitting ||
-                  !prompt.trim() ||
-                  billingAccess.isCheckingAccess ||
-                  !billingAccess.hasChatAccess
+            {conversation?.latest_workout_draft &&
+            latestWorkoutDraftMessageId === null ? (
+              <ChatWorkoutDraftCard
+                draft={conversation.latest_workout_draft}
+                isSaving={isSavingWorkoutDraft}
+                isSaved={isLatestWorkoutDraftSaved}
+                savedWorkoutId={savedWorkoutId}
+                onSave={() => void handleSaveWorkoutDraft()}
+                onEdit={() =>
+                  handleEditInWorkoutForm(conversation.latest_workout_draft!)
                 }
-              >
-                {isSubmitting ? "Streaming..." : "Send"}
-              </Button>
+                onOpenSavedWorkout={
+                  savedWorkoutId
+                    ? () => handleOpenSavedWorkout(savedWorkoutId)
+                    : undefined
+                }
+              />
+            ) : null}
+
+            <div className="bg-background pt-2 md:sticky md:bottom-4">
+              {composer}
             </div>
-          </form>
-        </CardContent>
-      </Card>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -309,6 +343,8 @@ function CheckoutNotice({ checkout }: { checkout: ChatCheckoutSearch }) {
 
 function MessageBubble({
   message,
+  isLastAssistant,
+  onRetry,
   workoutDraft,
   isSavingWorkoutDraft,
   isSavedWorkoutDraft,
@@ -318,6 +354,8 @@ function MessageBubble({
   onOpenSavedWorkout,
 }: {
   message: AIChatMessage;
+  isLastAssistant?: boolean;
+  onRetry?: () => void;
   workoutDraft?: AIWorkoutDraft;
   isSavingWorkoutDraft?: boolean;
   isSavedWorkoutDraft?: boolean;
@@ -327,44 +365,54 @@ function MessageBubble({
   onOpenSavedWorkout?: () => void;
 }) {
   const isUser = message.role === "user";
-  const statusLabel =
-    message.status === "failed"
-      ? "failed"
-      : message.status === "streaming"
-        ? "streaming"
-        : null;
+
+  if (isUser) {
+    return (
+      <div
+        data-testid={`chat-message-${message.id}`}
+        className="flex justify-end"
+      >
+        <div className="max-w-[80%] whitespace-pre-wrap rounded-2xl bg-muted px-4 py-2.5 text-sm leading-relaxed">
+          {message.content}
+        </div>
+      </div>
+    );
+  }
+
+  const isStreaming = message.status === "streaming";
+  const isFailed = message.status === "failed";
+  const showActions =
+    !isStreaming && (message.content.trim().length > 0 || isFailed);
 
   return (
     <div
       data-testid={`chat-message-${message.id}`}
-      className={`flex max-w-[85%] flex-col gap-3 ${
-        isUser ? "ml-auto items-end" : "mr-auto items-start"
-      }`}
+      className="flex flex-col gap-2"
     >
-      <div
-        className={`w-full rounded-lg border px-4 py-3 text-sm ${
-          isUser
-            ? "border-primary/30 bg-primary/10"
-            : "border-border bg-background"
-        }`}
-      >
-        <div className="mb-2 flex items-center justify-between gap-3 text-xs uppercase tracking-wide text-muted-foreground">
-          <span>{isUser ? "You" : "Assistant"}</span>
-          {statusLabel ? <span>{statusLabel}</span> : null}
-        </div>
-        <div className="whitespace-pre-wrap leading-relaxed">
-          {message.content || (message.status === "streaming" ? "..." : "")}
-        </div>
-        {message.error_message ? (
-          <div className="mt-2 text-xs text-destructive">
-            {message.error_message}
-          </div>
+      <div className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+        {message.content}
+        {isStreaming ? (
+          <ChatTypingIndicator
+            className={message.content ? "ml-1" : undefined}
+          />
         ) : null}
       </div>
 
-      {!isUser && workoutDraft && onSaveWorkoutDraft && onEditWorkoutDraft ? (
+      {message.error_message ? (
+        <div className="text-xs text-destructive">{message.error_message}</div>
+      ) : null}
+
+      {showActions ? (
+        <ChatMessageActions
+          content={message.content}
+          canRetry={Boolean(isLastAssistant && onRetry)}
+          onRetry={onRetry}
+        />
+      ) : null}
+
+      {workoutDraft && onSaveWorkoutDraft && onEditWorkoutDraft ? (
         <ChatWorkoutDraftCard
-          className="w-full"
+          className={cn("mt-1 w-full")}
           draft={workoutDraft}
           isSaving={isSavingWorkoutDraft}
           isSaved={isSavedWorkoutDraft}


### PR DESCRIPTION
## Summary

Redesigns the AI chat page from a stacked-card layout into a centered, conversational experience.

### Empty state (Direction C — conversational)
- Centered heading **"What should we train today?"** with a single rounded composer and two happy-path example pills.
- Pills are pill/badge shaped: **one on mobile, two on larger screens**. Selecting one pre-fills and submits straight to the workout-draft happy path.

### Composer
- New `ChatComposer`: a rounded input with a **send-arrow only** (no model picker, mic, or plus).
- Enter submits, Shift+Enter newlines, auto-grows to a max height, send disabled until there is text.

### Messages
- **User** messages render as compact right-aligned bubbles; **assistant** replies are plain text with no card wrapper and no "Assistant" label.
- The "Assistant …streaming" label is replaced with a **typing-dots** indicator while a reply streams.
- Each finished assistant reply gets a **Copy** action, plus **Retry** on the latest reply (resubmits the previous user prompt via the existing stream endpoint).
- Workout-draft cards are unchanged and still render inline / on reopen.

### Chrome
- **New Chat** moved to the **top-right**.
- The billing card now sits **opposite New Chat** instead of in the middle of the chat (interim placement).

## Notes / deferred
- **Chat-history sidebar:** there is currently no backend `list-conversations` endpoint, so a history sidebar is deferred. No rework is needed to add it later.
- **Full sign-up/paywall screen:** deferred — the billing card is relocated rather than replaced for now.

## Testing
- `vitest run src/features/chat` — 90/90 chat tests pass.
- Typecheck, `oxlint`, and `oxfmt` all clean.
- Full pre-commit suite (272 tests) runs via the hook.

Test updates are limited to the intentional UI changes: the empty-state heading replaces "No messages yet", the typing indicator replaces the `"..."` placeholder, and four billing tests assert the billing card's badges instead of the removed per-composer status line.
