### PR TITLE
fix: cast ai chat stream chunk owner query

### DIFF
--- a/server/internal/aichat/repository.go
+++ b/server/internal/aichat/repository.go
@@ -710,11 +710,11 @@ func (r *repository) AppendStreamChunk(ctx context.Context, prepared *PreparedMe
 	qtx := r.queries.WithTx(tx)
 	nextSequence := prepared.LastSequence + 1
 	if _, err := qtx.CreateAIChatStreamChunk(ctx, db.CreateAIChatStreamChunkParams{
-		RunID:     prepared.Run.ID,
-		UserID:    prepared.Run.UserID,
-		Sequence:  nextSequence,
-		DeltaText: delta,
-		Column5:   textValue(prepared.Run.GenerationOwner),
+		RunID:           prepared.Run.ID,
+		UserID:          prepared.Run.UserID,
+		Sequence:        nextSequence,
+		DeltaText:       delta,
+		GenerationOwner: textValue(prepared.Run.GenerationOwner),
 	}); err != nil {
 		return 0, fmt.Errorf("create ai chat stream chunk: %w", err)
 	}

--- a/server/internal/database/query.sql.go
+++ b/server/internal/database/query.sql.go
@@ -379,17 +379,21 @@ INSERT INTO ai_chat_stream_chunk (
     sequence,
     delta_text
 )
-SELECT $1, $2, $3, $4
+SELECT
+    $1,
+    $2::varchar,
+    $3,
+    $4
 WHERE (
     NULLIF($5::text, '') IS NULL
     OR EXISTS (
         SELECT 1
         FROM ai_chat_run
         WHERE id = $1
-          AND user_id = $2
+          AND user_id = $2::varchar
           AND status = 'streaming'
           AND generation_status = 'generating'
-          AND generation_owner = $5
+          AND generation_owner = $5::varchar
     )
 )
 RETURNING
@@ -401,11 +405,11 @@ RETURNING
 `
 
 type CreateAIChatStreamChunkParams struct {
-	RunID     int32  `json:"run_id"`
-	UserID    string `json:"user_id"`
-	Sequence  int32  `json:"sequence"`
-	DeltaText string `json:"delta_text"`
-	Column5   string `json:"column_5"`
+	RunID           int32  `json:"run_id"`
+	UserID          string `json:"user_id"`
+	Sequence        int32  `json:"sequence"`
+	DeltaText       string `json:"delta_text"`
+	GenerationOwner string `json:"generation_owner"`
 }
 
 func (q *Queries) CreateAIChatStreamChunk(ctx context.Context, arg CreateAIChatStreamChunkParams) (AiChatStreamChunk, error) {
@@ -414,7 +418,7 @@ func (q *Queries) CreateAIChatStreamChunk(ctx context.Context, arg CreateAIChatS
 		arg.UserID,
 		arg.Sequence,
 		arg.DeltaText,
-		arg.Column5,
+		arg.GenerationOwner,
 	)
 	var i AiChatStreamChunk
 	err := row.Scan(

--- a/server/query.sql
+++ b/server/query.sql
@@ -935,17 +935,21 @@ INSERT INTO ai_chat_stream_chunk (
     sequence,
     delta_text
 )
-SELECT $1, $2, $3, $4
+SELECT
+    sqlc.arg(run_id),
+    sqlc.arg(user_id)::varchar,
+    sqlc.arg(sequence),
+    sqlc.arg(delta_text)
 WHERE (
-    NULLIF($5::text, '') IS NULL
+    NULLIF(sqlc.arg(generation_owner)::text, '') IS NULL
     OR EXISTS (
         SELECT 1
         FROM ai_chat_run
-        WHERE id = $1
-          AND user_id = $2
+        WHERE id = sqlc.arg(run_id)
+          AND user_id = sqlc.arg(user_id)::varchar
           AND status = 'streaming'
           AND generation_status = 'generating'
-          AND generation_owner = $5
+          AND generation_owner = sqlc.arg(generation_owner)::varchar
     )
 )
 RETURNING


### PR DESCRIPTION
## Summary
- Fixes the red backend integration test after PR 165 by making the AI chat stream chunk owner query use explicit varchar casts.
- Regenerates the sqlc wrapper so the owner parameter is named and the repository call stays type-safe.

## Verification
- go mod verify
- govulncheck ./...
- DATABASE_URL=postgresql://test_user:test_password@127.0.0.1:55432/fittrack_test?sslmode=disable go test -short ./...
- DATABASE_URL=postgresql://test_user:test_password@127.0.0.1:55432/fittrack_test?sslmode=disable go test -v ./...
- go vet -v ./...
- go build ./cmd/api