### PR TITLE
refactor: contain ai chat stream lifecycle

### DIFF
--- a/client/src/features/chat/hooks/use-ai-chat-session.ts
+++ b/client/src/features/chat/hooks/use-ai-chat-session.ts
@@ -1,24 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  createAIChatConversation,
-  reportAIChatTelemetry,
-  type AIChatConversation,
-  type AIChatConversationDetail,
-  type AIChatMessage,
-  type AIChatTelemetryEvent,
+import type {
+  AIChatConversation,
+  AIChatMessage,
 } from "@/features/chat/api/ai-chat";
-import {
-  classifyLoadOutcome,
-  classifyRecoveryOutcome,
-} from "@/features/chat/utils/ai-chat-observability";
-import { showErrorToast } from "@/lib/errors";
-import {
-  loadConversation as loadConversationRequest,
-  recoverConversation as recoverConversationRequest,
-  recoverLoadedConversation,
-  resumeConversation as resumeConversationRequest,
-} from "../utils/chat-session-recovery";
-import { submitPrompt as submitPromptRequest } from "../utils/chat-session-submit";
+import { createAIChatSessionLifecycle } from "../utils/ai-chat-session-lifecycle";
 import type {
   ChatSessionRefs,
   ChatSessionSetters,
@@ -51,6 +36,7 @@ export function useAIChatSession({
   const recoveryAbortRef = useRef<AbortController | null>(null);
   const resumeAbortRef = useRef<AbortController | null>(null);
   const streamAbortRef = useRef<AbortController | null>(null);
+  const onConversationCreatedRef = useRef(onConversationCreated);
 
   const refs = useMemo<ChatSessionRefs>(
     () => ({
@@ -77,204 +63,57 @@ export function useAIChatSession({
     [],
   );
 
-  const recordTelemetry = useCallback((event: AIChatTelemetryEvent) => {
-    void Promise.resolve(reportAIChatTelemetry(event)).catch((error) => {
-      if (import.meta.env.DEV) {
-        console.warn("Failed to record AI chat telemetry", error, event);
-      }
-    });
-  }, []);
+  useEffect(() => {
+    onConversationCreatedRef.current = onConversationCreated;
+  }, [onConversationCreated]);
 
-  const loadConversation = useCallback(
-    (id: number, opts?: { silent?: boolean }) =>
-      loadConversationRequest(id, opts, { refs, setters }),
-    [refs, setters],
+  const handleConversationCreated = useCallback(
+    (createdConversationId: number) =>
+      onConversationCreatedRef.current(createdConversationId),
+    [],
   );
 
-  const recoverConversation = useCallback(
-    (id: number, opts?: { silent?: boolean }) =>
-      recoverConversationRequest(id, opts, { refs, setters }),
-    [refs, setters],
+  const lifecycle = useMemo(
+    () =>
+      createAIChatSessionLifecycle({
+        refs,
+        setters,
+        onConversationCreated: handleConversationCreated,
+      }),
+    [handleConversationCreated, refs, setters],
   );
-
-  const resumeConversation = useCallback(
-    (detail: Parameters<typeof resumeConversationRequest>[0]) =>
-      resumeConversationRequest(detail, loadConversation, { refs, setters }),
-    [loadConversation, refs, setters],
-  );
-
-  const resetConversation = useCallback(() => {
-    loadAbortRef.current?.abort();
-    recoveryAbortRef.current?.abort();
-    resumeAbortRef.current?.abort();
-    streamAbortRef.current?.abort();
-    setConversation(null);
-    setMessages([]);
-    setLatestWorkoutDraftMessageId(null);
-    setLoadError(null);
-    setIsLoadingConversation(false);
-  }, []);
 
   useEffect(() => {
     if (!conversationId) {
-      resetConversation();
+      lifecycle.resetConversation();
       return;
     }
 
-    const activeConversationId = conversationId;
-    void loadConversationForRoute();
+    void lifecycle.loadRouteConversation(conversationId);
 
     return () => {
-      loadAbortRef.current?.abort();
-      recoveryAbortRef.current?.abort();
-      resumeAbortRef.current?.abort();
-      streamAbortRef.current?.abort();
+      lifecycle.abortActiveRequests();
     };
-
-    async function loadConversationForRoute() {
-      const loadResult = await loadConversation(activeConversationId);
-      recordTelemetry({
-        category: "load",
-        outcome: loadResult.detail
-          ? "load_completed"
-          : classifyLoadOutcome(loadResult.aborted),
-      });
-
-      if (loadResult.detail?.active_run) {
-        await resumeOrRecoverActiveRun(loadResult.detail);
-        return;
-      }
-
-      if (
-        loadResult.detail?.messages.some(
-          (message) => message.status === "streaming",
-        )
-      ) {
-        await recoverOpenedConversation(activeConversationId);
-      }
-    }
-
-    async function resumeOrRecoverActiveRun(detail: AIChatConversationDetail) {
-      const resumeResult = await resumeConversation(detail);
-      if (!resumeResult.aborted && resumeResult.detail) {
-        const resumeOutcome = classifyRecoveryOutcome({
-          messages: resumeResult.detail.messages,
-          aborted: false,
-          error: resumeResult.error,
-        });
-        recordTelemetry({
-          category: "recovery",
-          outcome: resumeOutcome,
-        });
-        if (
-          resumeOutcome !== "recovered_completed" &&
-          resumeOutcome !== "recovery_aborted"
-        ) {
-          const resumeError =
-            resumeResult.error ??
-            new Error("Failed to resume AI chat conversation");
-          recordTelemetry({
-            category: "ux",
-            outcome: "failure_toast_shown",
-          });
-          showErrorToast(resumeError, "Failed to recover AI chat conversation");
-        }
-        return;
-      }
-
-      if (resumeResult.aborted) {
-        recordTelemetry({
-          category: "recovery",
-          outcome: "recovery_aborted",
-        });
-        return;
-      }
-
-      await recoverOpenedConversation(activeConversationId);
-    }
-
-    async function recoverOpenedConversation(id: number) {
-      await recoverLoadedConversation({
-        id,
-        recoverConversation,
-        recordTelemetry,
-        setLoadError,
-      });
-    }
-  }, [
-    conversationId,
-    loadConversation,
-    recoverConversation,
-    recordTelemetry,
-    resetConversation,
-    resumeConversation,
-  ]);
-
-  const createNewChat = useCallback(async () => {
-    try {
-      const created = await createAIChatConversation();
-      streamAbortRef.current?.abort();
-      recoveryAbortRef.current?.abort();
-      loadAbortRef.current?.abort();
-      setConversation(created);
-      setMessages([]);
-      setLatestWorkoutDraftMessageId(null);
-      setLoadError(null);
-      await onConversationCreated(created.id);
-    } catch (error) {
-      showErrorToast(error, "Failed to create chat conversation");
-    }
-  }, [onConversationCreated]);
+  }, [conversationId, lifecycle]);
 
   const submitPrompt = useCallback(
     () =>
-      submitPromptRequest({
+      lifecycle.submitPrompt({
         conversationId,
         prompt,
         isSubmitting,
-        onConversationCreated,
-        loadConversation,
-        recoverConversation,
-        recordTelemetry,
-        refs,
-        setters,
       }),
-    [
-      conversationId,
-      isSubmitting,
-      loadConversation,
-      onConversationCreated,
-      prompt,
-      recordTelemetry,
-      recoverConversation,
-      refs,
-      setters,
-    ],
+    [conversationId, isSubmitting, lifecycle, prompt],
   );
 
   const submitPromptValue = useCallback(
     (value: string) =>
-      submitPromptRequest({
+      lifecycle.submitPrompt({
         conversationId,
         prompt: value,
         isSubmitting,
-        onConversationCreated,
-        loadConversation,
-        recoverConversation,
-        recordTelemetry,
-        refs,
-        setters,
       }),
-    [
-      conversationId,
-      isSubmitting,
-      loadConversation,
-      onConversationCreated,
-      recordTelemetry,
-      recoverConversation,
-      refs,
-      setters,
-    ],
+    [conversationId, isSubmitting, lifecycle],
   );
 
   const saveLatestWorkoutDraft = useCallback(
@@ -296,7 +135,7 @@ export function useAIChatSession({
     loadError,
     isSavingWorkoutDraft,
     latestWorkoutDraftMessageId,
-    createNewChat,
+    createNewChat: lifecycle.createNewChat,
     submitPrompt,
     submitPromptValue,
     saveLatestWorkoutDraft,

--- a/client/src/features/chat/utils/ai-chat-session-lifecycle.ts
+++ b/client/src/features/chat/utils/ai-chat-session-lifecycle.ts
@@ -1,0 +1,189 @@
+import {
+  createAIChatConversation,
+  reportAIChatTelemetry,
+  type AIChatConversationDetail,
+  type AIChatTelemetryEvent,
+} from "@/features/chat/api/ai-chat";
+import {
+  classifyLoadOutcome,
+  classifyRecoveryOutcome,
+} from "@/features/chat/utils/ai-chat-observability";
+import { showErrorToast } from "@/lib/errors";
+import {
+  loadConversation as loadConversationRequest,
+  recoverConversation as recoverConversationRequest,
+  recoverLoadedConversation,
+  resumeConversation as resumeConversationRequest,
+} from "./chat-session-recovery";
+import { submitPrompt as submitPromptRequest } from "./chat-session-submit";
+import type { ChatSessionRefs, ChatSessionSetters } from "./chat-session-types";
+
+type AIChatSessionLifecycleOptions = {
+  refs: ChatSessionRefs;
+  setters: ChatSessionSetters;
+  onConversationCreated: (conversationId: number) => Promise<void>;
+};
+
+type SubmitPromptOptions = {
+  conversationId: number | null;
+  prompt: string;
+  isSubmitting: boolean;
+};
+
+export function createAIChatSessionLifecycle({
+  refs,
+  setters,
+  onConversationCreated,
+}: AIChatSessionLifecycleOptions) {
+  const recordTelemetry = (event: AIChatTelemetryEvent) => {
+    void Promise.resolve(reportAIChatTelemetry(event)).catch((error) => {
+      if (import.meta.env.DEV) {
+        console.warn("Failed to record AI chat telemetry", error, event);
+      }
+    });
+  };
+
+  const loadConversation = (
+    id: number,
+    opts?: Parameters<typeof loadConversationRequest>[1],
+  ) => loadConversationRequest(id, opts, { refs, setters });
+
+  const recoverConversation = (
+    id: number,
+    opts?: Parameters<typeof recoverConversationRequest>[1],
+  ) => recoverConversationRequest(id, opts, { refs, setters });
+
+  const resumeConversation = (detail: AIChatConversationDetail) =>
+    resumeConversationRequest(detail, loadConversation, { refs, setters });
+
+  const abortActiveRequests = () => {
+    refs.loadAbortRef.current?.abort();
+    refs.recoveryAbortRef.current?.abort();
+    refs.resumeAbortRef.current?.abort();
+    refs.streamAbortRef.current?.abort();
+  };
+
+  const resetConversation = () => {
+    abortActiveRequests();
+    setters.setConversation(null);
+    setters.setMessages([]);
+    setters.setLatestWorkoutDraftMessageId(null);
+    setters.setLoadError(null);
+    setters.setIsLoadingConversation(false);
+  };
+
+  const loadRouteConversation = async (conversationId: number) => {
+    const loadResult = await loadConversation(conversationId);
+    recordTelemetry({
+      category: "load",
+      outcome: loadResult.detail
+        ? "load_completed"
+        : classifyLoadOutcome(loadResult.aborted),
+    });
+
+    if (loadResult.detail?.active_run) {
+      await resumeOrRecoverActiveRun(conversationId, loadResult.detail);
+      return;
+    }
+
+    if (
+      loadResult.detail?.messages.some(
+        (message) => message.status === "streaming",
+      )
+    ) {
+      await recoverOpenedConversation(conversationId);
+    }
+  };
+
+  const createNewChat = async () => {
+    try {
+      const created = await createAIChatConversation();
+      refs.streamAbortRef.current?.abort();
+      refs.recoveryAbortRef.current?.abort();
+      refs.loadAbortRef.current?.abort();
+      setters.setConversation(created);
+      setters.setMessages([]);
+      setters.setLatestWorkoutDraftMessageId(null);
+      setters.setLoadError(null);
+      await onConversationCreated(created.id);
+    } catch (error) {
+      showErrorToast(error, "Failed to create chat conversation");
+    }
+  };
+
+  const submitPrompt = ({
+    conversationId,
+    prompt,
+    isSubmitting,
+  }: SubmitPromptOptions) =>
+    submitPromptRequest({
+      conversationId,
+      prompt,
+      isSubmitting,
+      onConversationCreated,
+      loadConversation,
+      recoverConversation,
+      recordTelemetry,
+      refs,
+      setters,
+    });
+
+  async function resumeOrRecoverActiveRun(
+    conversationId: number,
+    detail: AIChatConversationDetail,
+  ) {
+    const resumeResult = await resumeConversation(detail);
+    if (!resumeResult.aborted && resumeResult.detail) {
+      const resumeOutcome = classifyRecoveryOutcome({
+        messages: resumeResult.detail.messages,
+        aborted: false,
+        error: resumeResult.error,
+      });
+      recordTelemetry({
+        category: "recovery",
+        outcome: resumeOutcome,
+      });
+      if (
+        resumeOutcome !== "recovered_completed" &&
+        resumeOutcome !== "recovery_aborted"
+      ) {
+        const resumeError =
+          resumeResult.error ??
+          new Error("Failed to resume AI chat conversation");
+        recordTelemetry({
+          category: "ux",
+          outcome: "failure_toast_shown",
+        });
+        showErrorToast(resumeError, "Failed to recover AI chat conversation");
+      }
+      return;
+    }
+
+    if (resumeResult.aborted) {
+      recordTelemetry({
+        category: "recovery",
+        outcome: "recovery_aborted",
+      });
+      return;
+    }
+
+    await recoverOpenedConversation(conversationId);
+  }
+
+  async function recoverOpenedConversation(id: number) {
+    await recoverLoadedConversation({
+      id,
+      recoverConversation,
+      recordTelemetry,
+      setLoadError: setters.setLoadError,
+    });
+  }
+
+  return {
+    abortActiveRequests,
+    createNewChat,
+    loadRouteConversation,
+    resetConversation,
+    submitPrompt,
+  };
+}


### PR DESCRIPTION
## Summary
- move AI chat load, submit, resume, recovery, abort, and telemetry coordination behind a feature-local lifecycle module
- keep `useAIChatSession` focused on React state and page-facing actions
- preserve existing chat behavior while reducing the number of lifecycle details readers need to hold in the hook

## Behavior preserved
- optimistic user and assistant messages during submit
- SSE start, delta, done, and error handling
- resume cursor handling and active-run resume before recovery polling
- recovery telemetry, failure toast behavior, abort handling, and silent refresh after completed streams

## Verification
- `bun run test src/features/chat/hooks/use-ai-chat-session.test.tsx`
- `bun run test src/features/chat`
- `bun run lint`
- `bun run tsc`
- `python C:\Users\lenny\.codex\skills\autoreview\scripts\autoreview --mode local`
- `git diff --check`