### PR TITLE
refactor: contain ai workout draft persistence

### DIFF
--- a/client/src/features/chat/api/ai-chat.test.ts
+++ b/client/src/features/chat/api/ai-chat.test.ts
@@ -536,16 +536,17 @@ describe("ai chat api wrapper", () => {
       ),
     );
 
-    const response = await saveAIChatLatestWorkoutDraft(41);
+    const conversation = await saveAIChatLatestWorkoutDraft(41);
 
     expect(fetch).toHaveBeenCalledWith(expect.any(Request));
     expect(latestRequest().url).toContain(
       "/api/ai/conversations/41/latest-workout-draft/save",
     );
     expect(latestRequest().method).toBe("POST");
-    expect(response.workout_id).toBe(901);
-    expect(response.conversation.latest_workout_draft_status?.is_saved).toBe(
-      true,
+    expect(conversation.id).toBe(41);
+    expect(conversation.latest_workout_draft_status?.is_saved).toBe(true);
+    expect(conversation.latest_workout_draft_status?.saved_workout_id).toBe(
+      901,
     );
   });
 

--- a/client/src/features/chat/api/ai-chat.ts
+++ b/client/src/features/chat/api/ai-chat.ts
@@ -236,14 +236,14 @@ export async function requestAIChatMessageRecovery(
 export async function saveAIChatLatestWorkoutDraft(
   conversationId: number,
   options: ConversationRequestOptions = {},
-): Promise<AISaveLatestWorkoutDraftResponse> {
+): Promise<AIChatConversation> {
   const response = await postAiConversationsByIdLatestWorkoutDraftSave({
     path: { id: conversationId },
     signal: options.signal,
     throwOnError: true,
   });
 
-  return response.data as AISaveLatestWorkoutDraftResponse;
+  return (response.data as AISaveLatestWorkoutDraftResponse).conversation;
 }
 
 export async function streamAIChatMessage(

--- a/client/src/features/chat/pages/chat-workout-draft-page.test.tsx
+++ b/client/src/features/chat/pages/chat-workout-draft-page.test.tsx
@@ -104,18 +104,15 @@ describe("ChatRouteComponent", () => {
       conversationDetail([], undefined, latestWorkoutDraft),
     );
     mockSaveLatestWorkoutDraft.mockResolvedValue({
-      conversation: {
-        id: 41,
-        created_at: "2026-03-26T17:00:00Z",
-        updated_at: "2026-03-26T17:05:00Z",
-        latest_workout_draft: latestWorkoutDraft,
-        latest_workout_draft_status: {
-          is_saved: true,
-          saved_workout_id: 88,
-          saved_at: "2026-04-21T12:05:00Z",
-        },
+      id: 41,
+      created_at: "2026-03-26T17:00:00Z",
+      updated_at: "2026-03-26T17:05:00Z",
+      latest_workout_draft: latestWorkoutDraft,
+      latest_workout_draft_status: {
+        is_saved: true,
+        saved_workout_id: 88,
+        saved_at: "2026-04-21T12:05:00Z",
       },
-      workout_id: 88,
     });
 
     render(<ChatRouteComponent />);

--- a/client/src/features/chat/utils/chat-session-workout-draft.ts
+++ b/client/src/features/chat/utils/chat-session-workout-draft.ts
@@ -19,8 +19,10 @@ export async function saveLatestWorkoutDraft({
 
   try {
     setters.setIsSavingWorkoutDraft(true);
-    const saved = await saveAIChatLatestWorkoutDraft(conversation.id);
-    setters.setConversation(saved.conversation);
+    const updatedConversation = await saveAIChatLatestWorkoutDraft(
+      conversation.id,
+    );
+    setters.setConversation(updatedConversation);
     toast.success("Workout saved successfully");
   } catch (error) {
     showErrorToast(error, "Failed to save workout");

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -170,9 +170,9 @@ func main() {
 		cfg.AIChatTrialPromptCap,
 	)
 	userService := user.NewService(logger, userRepo)
-	aiChatRepo := aichat.NewRepository(logger, queries, pool, workoutTxSaver, cfg.AIChatTrialPromptCap)
+	aiChatRepo := aichat.NewRepository(logger, queries, pool, cfg.AIChatTrialPromptCap)
 	aiChatRuntime := aichat.NewGenkitRuntime(ctx)
-	aiChatService := aichat.NewService(logger, featureAccessService, aiChatRuntime, aiChatRepo, workoutService)
+	aiChatService := aichat.NewService(logger, featureAccessService, aiChatRuntime, aiChatRepo, workoutTxSaver)
 	var inngestRecovery *aichat.InngestRecovery
 	switch {
 	case cfg.AIChatRecoveryConfigured():

--- a/server/internal/aichat/repository.go
+++ b/server/internal/aichat/repository.go
@@ -18,11 +18,24 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+type SaveWorkoutDraftTx func(ctx context.Context, qtx *db.Queries, draft workout.CreateWorkoutRequest, userID string) (int32, error)
+
+type SaveLatestWorkoutDraftRequest struct {
+	ConversationID int32
+	UserID         string
+	SavedAt        time.Time
+	SaveWorkout    SaveWorkoutDraftTx
+}
+
+type SavedLatestWorkoutDraft struct {
+	Conversation *Conversation
+	WorkoutID    int32
+}
+
 type Repository interface {
 	CreateConversation(ctx context.Context, userID string) (*Conversation, error)
 	GetConversation(ctx context.Context, conversationID int32, userID string) (*Conversation, error)
-	SaveLatestWorkoutDraft(ctx context.Context, conversationID int32, userID string, savedAt time.Time) (*SaveLatestWorkoutDraftResponse, error)
-	MarkLatestWorkoutDraftSaved(ctx context.Context, conversationID int32, userID string, sourceRunID *int32, workoutID int32, savedAt time.Time) (*Conversation, error)
+	SaveLatestWorkoutDraft(ctx context.Context, request SaveLatestWorkoutDraftRequest) (*SavedLatestWorkoutDraft, error)
 	ListMessages(ctx context.Context, conversationID int32, userID string) ([]ChatMessage, error)
 	GetActiveRunForConversation(ctx context.Context, conversationID int32, userID string) (*ChatRun, error)
 	GetLatestStreamSequence(ctx context.Context, runID int32, userID string) (int32, error)
@@ -42,13 +55,12 @@ type repository struct {
 	logger         *slog.Logger
 	queries        *db.Queries
 	pool           *pgxpool.Pool
-	workoutSaver   workout.TxSaver
 	trialPromptCap int32
 }
 
 const streamingRunStaleAfter = chatStreamTimeout + 15*time.Second
 
-func NewRepository(logger *slog.Logger, queries *db.Queries, pool *pgxpool.Pool, workoutSaver workout.TxSaver, trialPromptCap ...int) Repository {
+func NewRepository(logger *slog.Logger, queries *db.Queries, pool *pgxpool.Pool, trialPromptCap ...int) Repository {
 	var cap int32
 	if len(trialPromptCap) > 0 {
 		cap = int32(trialPromptCap[0])
@@ -57,7 +69,6 @@ func NewRepository(logger *slog.Logger, queries *db.Queries, pool *pgxpool.Pool,
 		logger:         logger,
 		queries:        queries,
 		pool:           pool,
-		workoutSaver:   workoutSaver,
 		trialPromptCap: cap,
 	}
 }
@@ -105,9 +116,12 @@ func (r *repository) GetConversation(ctx context.Context, conversationID int32, 
 	return conversation, nil
 }
 
-func (r *repository) SaveLatestWorkoutDraft(ctx context.Context, conversationID int32, userID string, savedAt time.Time) (*SaveLatestWorkoutDraftResponse, error) {
+func (r *repository) SaveLatestWorkoutDraft(ctx context.Context, request SaveLatestWorkoutDraftRequest) (*SavedLatestWorkoutDraft, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
+	if request.SaveWorkout == nil {
+		return nil, errors.New("save latest ai chat workout draft requires a workout saver")
+	}
 
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
@@ -117,8 +131,8 @@ func (r *repository) SaveLatestWorkoutDraft(ctx context.Context, conversationID 
 
 	qtx := r.queries.WithTx(tx)
 	row, err := qtx.GetAIChatConversationForUpdate(ctx, db.GetAIChatConversationForUpdateParams{
-		ID:     conversationID,
-		UserID: userID,
+		ID:     request.ConversationID,
+		UserID: request.UserID,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -139,13 +153,13 @@ func (r *repository) SaveLatestWorkoutDraft(ctx context.Context, conversationID 
 		if err := tx.Commit(ctx); err != nil {
 			return nil, fmt.Errorf("commit ai chat latest workout draft save transaction: %w", err)
 		}
-		return &SaveLatestWorkoutDraftResponse{
+		return &SavedLatestWorkoutDraft{
 			Conversation: conversation,
 			WorkoutID:    *status.SavedWorkoutID,
 		}, nil
 	}
 
-	workoutID, err := r.workoutSaver.SaveWorkoutTx(ctx, qtx, *conversation.LatestWorkoutDraft, userID)
+	workoutID, err := request.SaveWorkout(ctx, qtx, *conversation.LatestWorkoutDraft, request.UserID)
 	if err != nil {
 		return nil, fmt.Errorf("save ai chat latest workout draft workout: %w", err)
 	}
@@ -156,15 +170,15 @@ func (r *repository) SaveLatestWorkoutDraft(ctx context.Context, conversationID 
 	}
 
 	updatedRow, err := qtx.MarkAIChatConversationLatestWorkoutDraftSaved(ctx, db.MarkAIChatConversationLatestWorkoutDraftSavedParams{
-		ID:                            conversationID,
-		UserID:                        userID,
+		ID:                            request.ConversationID,
+		UserID:                        request.UserID,
 		LatestWorkoutDraftSourceRunID: int4PtrToPg(sourceRunID),
 		LatestWorkoutDraftSavedWorkoutID: pgtype.Int4{
 			Int32: workoutID,
 			Valid: true,
 		},
 		LatestWorkoutDraftSavedAt: pgtype.Timestamptz{
-			Time:  savedAt.UTC(),
+			Time:  request.SavedAt.UTC(),
 			Valid: true,
 		},
 	})
@@ -184,50 +198,10 @@ func (r *repository) SaveLatestWorkoutDraft(ctx context.Context, conversationID 
 		return nil, err
 	}
 
-	return &SaveLatestWorkoutDraftResponse{
+	return &SavedLatestWorkoutDraft{
 		Conversation: updatedConversation,
 		WorkoutID:    workoutID,
 	}, nil
-}
-
-func (r *repository) MarkLatestWorkoutDraftSaved(ctx context.Context, conversationID int32, userID string, sourceRunID *int32, workoutID int32, savedAt time.Time) (*Conversation, error) {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	sourceRun := pgtype.Int4{Valid: false}
-	if sourceRunID != nil {
-		sourceRun = pgtype.Int4{
-			Int32: *sourceRunID,
-			Valid: true,
-		}
-	}
-
-	row, err := r.queries.MarkAIChatConversationLatestWorkoutDraftSaved(ctx, db.MarkAIChatConversationLatestWorkoutDraftSavedParams{
-		ID:                            conversationID,
-		UserID:                        userID,
-		LatestWorkoutDraftSourceRunID: sourceRun,
-		LatestWorkoutDraftSavedWorkoutID: pgtype.Int4{
-			Int32: workoutID,
-			Valid: true,
-		},
-		LatestWorkoutDraftSavedAt: pgtype.Timestamptz{
-			Time:  savedAt.UTC(),
-			Valid: true,
-		},
-	})
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, err
-		}
-		return nil, fmt.Errorf("mark latest ai chat workout draft saved: %w", err)
-	}
-
-	conversation, err := mapConversation(row)
-	if err != nil {
-		return nil, err
-	}
-
-	return conversation, nil
 }
 
 func (r *repository) ListMessages(ctx context.Context, conversationID int32, userID string) ([]ChatMessage, error) {

--- a/server/internal/aichat/repository_integration_test.go
+++ b/server/internal/aichat/repository_integration_test.go
@@ -40,8 +40,7 @@ func TestRepositoryCompleteRun_PersistsWorkoutDraftJSONB(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	queries := db.New(pool)
-	exerciseRepo := exercise.NewRepository(logger, queries, pool)
-	repo := NewRepository(logger, queries, pool, workout.NewTxSaver(logger, exerciseRepo))
+	repo := NewRepository(logger, queries, pool)
 
 	conversation, err := repo.CreateConversation(ctx, userID)
 	require.NoError(t, err)
@@ -109,8 +108,7 @@ func TestRepositoryCompleteRun_AllowsNilWorkoutDraft(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	queries := db.New(pool)
-	exerciseRepo := exercise.NewRepository(logger, queries, pool)
-	repo := NewRepository(logger, queries, pool, workout.NewTxSaver(logger, exerciseRepo))
+	repo := NewRepository(logger, queries, pool)
 
 	conversation, err := repo.CreateConversation(ctx, userID)
 	require.NoError(t, err)
@@ -153,8 +151,7 @@ func TestRepositoryInterruptRun_RequiresLoadedGenerationSnapshot(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	queries := db.New(pool)
-	exerciseRepo := exercise.NewRepository(logger, queries, pool)
-	repo := NewRepository(logger, queries, pool, workout.NewTxSaver(logger, exerciseRepo))
+	repo := NewRepository(logger, queries, pool)
 
 	conversation, err := repo.CreateConversation(ctx, userID)
 	require.NoError(t, err)
@@ -224,8 +221,7 @@ func TestRepositoryCompleteRun_PersistsWorkoutDraftWithNullByteText(t *testing.T
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	queries := db.New(pool)
-	exerciseRepo := exercise.NewRepository(logger, queries, pool)
-	repo := NewRepository(logger, queries, pool, workout.NewTxSaver(logger, exerciseRepo))
+	repo := NewRepository(logger, queries, pool)
 
 	conversation, err := repo.CreateConversation(ctx, userID)
 	require.NoError(t, err)
@@ -274,7 +270,8 @@ func TestRepositorySaveLatestWorkoutDraft_ConcurrentCallsCreateOneWorkout(t *tes
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	queries := db.New(pool)
 	exerciseRepo := exercise.NewRepository(logger, queries, pool)
-	repo := NewRepository(logger, queries, pool, workout.NewTxSaver(logger, exerciseRepo))
+	workoutSaver := workout.NewTxSaver(logger, exerciseRepo)
+	repo := NewRepository(logger, queries, pool)
 
 	conversation, err := repo.CreateConversation(ctx, userID)
 	require.NoError(t, err)
@@ -307,7 +304,12 @@ func TestRepositorySaveLatestWorkoutDraft_ConcurrentCallsCreateOneWorkout(t *tes
 		go func() {
 			defer wg.Done()
 			<-start
-			resp, saveErr := repo.SaveLatestWorkoutDraft(context.Background(), conversation.ID, userID, time.Now().UTC())
+			resp, saveErr := repo.SaveLatestWorkoutDraft(context.Background(), SaveLatestWorkoutDraftRequest{
+				ConversationID: conversation.ID,
+				UserID:         userID,
+				SavedAt:        time.Now().UTC(),
+				SaveWorkout:    workoutSaver.SaveWorkoutTx,
+			})
 			if saveErr != nil {
 				errs <- saveErr
 				return
@@ -358,8 +360,7 @@ func TestRepositoryPrepareMessageStream_TrialCapAllowsTwoStartsAndBlocksThird(t 
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	queries := db.New(pool)
-	exerciseRepo := exercise.NewRepository(logger, queries, pool)
-	repo := NewRepository(logger, queries, pool, workout.NewTxSaver(logger, exerciseRepo), 2)
+	repo := NewRepository(logger, queries, pool, 2)
 
 	conversation, err := repo.CreateConversation(ctx, userID)
 	require.NoError(t, err)
@@ -402,8 +403,7 @@ func TestRepositoryPrepareMessageStream_DoesNotConsumeTrialPromptWhenStartFails(
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	queries := db.New(pool)
-	exerciseRepo := exercise.NewRepository(logger, queries, pool)
-	repo := NewRepository(logger, queries, pool, workout.NewTxSaver(logger, exerciseRepo), 2)
+	repo := NewRepository(logger, queries, pool, 2)
 
 	missing, err := repo.PrepareMessageStream(ctx, 999999, userID, "missing conversation", defaultModelName, "req-missing")
 	require.Error(t, err)

--- a/server/internal/aichat/service.go
+++ b/server/internal/aichat/service.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	db "github.com/Andrewy-gh/fittrack/server/internal/database"
 	apperrors "github.com/Andrewy-gh/fittrack/server/internal/errors"
 	"github.com/Andrewy-gh/fittrack/server/internal/user"
 	"github.com/Andrewy-gh/fittrack/server/internal/workout"
@@ -30,17 +31,13 @@ type recoveryDispatcher interface {
 	EnqueueRunRecovery(ctx context.Context, request RunRecoveryRequest) error
 }
 
-type workoutCreator interface {
-	CreateWorkoutWithID(ctx context.Context, requestBody workout.CreateWorkoutRequest) (int32, error)
-}
-
 type Service struct {
-	logger        *slog.Logger
-	featureAccess featureAccessService
-	runtime       runtime
-	repo          Repository
-	recovery      recoveryDispatcher
-	workouts      workoutCreator
+	logger            *slog.Logger
+	featureAccess     featureAccessService
+	runtime           runtime
+	repo              Repository
+	recovery          recoveryDispatcher
+	workoutDraftSaver workout.TxSaver
 }
 
 const (
@@ -50,13 +47,13 @@ const (
 	recoverReasonStreamReconnect = "stream_reconnect"
 )
 
-func NewService(logger *slog.Logger, featureAccess featureAccessService, runtime runtime, repo Repository, workouts workoutCreator) *Service {
+func NewService(logger *slog.Logger, featureAccess featureAccessService, runtime runtime, repo Repository, workoutDraftSaver workout.TxSaver) *Service {
 	return &Service{
-		logger:        logger,
-		featureAccess: featureAccess,
-		runtime:       runtime,
-		repo:          repo,
-		workouts:      workouts,
+		logger:            logger,
+		featureAccess:     featureAccess,
+		runtime:           runtime,
+		repo:              repo,
+		workoutDraftSaver: workoutDraftSaver,
 	}
 }
 
@@ -554,14 +551,30 @@ func (s *Service) SaveLatestWorkoutDraft(ctx context.Context, conversationID int
 		return nil, err
 	}
 
-	resp, err := s.repo.SaveLatestWorkoutDraft(ctx, conversationID, userID, time.Now().UTC())
+	saved, err := s.repo.SaveLatestWorkoutDraft(ctx, SaveLatestWorkoutDraftRequest{
+		ConversationID: conversationID,
+		UserID:         userID,
+		SavedAt:        time.Now().UTC(),
+		SaveWorkout:    s.saveWorkoutDraftTx,
+	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, newConversationNotFound(conversationID)
 		}
 		return nil, err
 	}
-	return resp, nil
+
+	return &SaveLatestWorkoutDraftResponse{
+		Conversation: saved.Conversation,
+		WorkoutID:    saved.WorkoutID,
+	}, nil
+}
+
+func (s *Service) saveWorkoutDraftTx(ctx context.Context, qtx *db.Queries, draft workout.CreateWorkoutRequest, userID string) (int32, error) {
+	if s.workoutDraftSaver == nil {
+		return 0, errors.New("ai chat workout draft saver is unavailable")
+	}
+	return s.workoutDraftSaver.SaveWorkoutTx(ctx, qtx, draft, userID)
 }
 
 func (s *Service) AbortPreparedMessageStream(ctx context.Context, prepared *PreparedMessageStream, failure error) error {

--- a/server/internal/aichat/service_test.go
+++ b/server/internal/aichat/service_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Andrewy-gh/fittrack/server/internal/billing"
+	db "github.com/Andrewy-gh/fittrack/server/internal/database"
 	apperrors "github.com/Andrewy-gh/fittrack/server/internal/errors"
 	"github.com/Andrewy-gh/fittrack/server/internal/user"
 	"github.com/Andrewy-gh/fittrack/server/internal/workout"
@@ -75,16 +76,10 @@ func (m *mockRepository) GetConversation(ctx context.Context, conversationID int
 	return conversation, args.Error(1)
 }
 
-func (m *mockRepository) SaveLatestWorkoutDraft(ctx context.Context, conversationID int32, userID string, savedAt time.Time) (*SaveLatestWorkoutDraftResponse, error) {
-	args := m.Called(ctx, conversationID, userID, savedAt)
-	resp, _ := args.Get(0).(*SaveLatestWorkoutDraftResponse)
+func (m *mockRepository) SaveLatestWorkoutDraft(ctx context.Context, request SaveLatestWorkoutDraftRequest) (*SavedLatestWorkoutDraft, error) {
+	args := m.Called(ctx, request)
+	resp, _ := args.Get(0).(*SavedLatestWorkoutDraft)
 	return resp, args.Error(1)
-}
-
-func (m *mockRepository) MarkLatestWorkoutDraftSaved(ctx context.Context, conversationID int32, userID string, sourceRunID *int32, workoutID int32, savedAt time.Time) (*Conversation, error) {
-	args := m.Called(ctx, conversationID, userID, sourceRunID, workoutID, savedAt)
-	conversation, _ := args.Get(0).(*Conversation)
-	return conversation, args.Error(1)
 }
 
 func (m *mockRepository) ListMessages(ctx context.Context, conversationID int32, userID string) ([]ChatMessage, error) {
@@ -178,12 +173,12 @@ func (m *mockPremiumAccessService) EnsureAIChatPromptAllowed(ctx context.Context
 	return args.Error(0)
 }
 
-type mockWorkoutCreator struct {
+type mockWorkoutDraftSaver struct {
 	mock.Mock
 }
 
-func (m *mockWorkoutCreator) CreateWorkoutWithID(ctx context.Context, requestBody workout.CreateWorkoutRequest) (int32, error) {
-	args := m.Called(ctx, requestBody)
+func (m *mockWorkoutDraftSaver) SaveWorkoutTx(ctx context.Context, qtx *db.Queries, requestBody workout.CreateWorkoutRequest, userID string) (int32, error) {
+	args := m.Called(ctx, qtx, requestBody, userID)
 	return args.Get(0).(int32), args.Error(1)
 }
 
@@ -458,32 +453,49 @@ func TestServiceGetConversation_IncludesLatestWorkoutDraft(t *testing.T) {
 func TestServiceSaveLatestWorkoutDraft(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	t.Run("delegates the draft save to the repository transaction", func(t *testing.T) {
+	t.Run("saves the latest draft through the repository transaction boundary", func(t *testing.T) {
 		featureAccess := new(mockFeatureAccessService)
 		repo := new(mockRepository)
-		service := NewService(logger, featureAccess, nil, repo, nil)
+		workoutSaver := new(mockWorkoutDraftSaver)
+		service := NewService(logger, featureAccess, nil, repo, workoutSaver)
 		ctx := user.WithContext(context.Background(), "user-123")
 		savedWorkoutID := int32(88)
-		savedAt := time.Date(2026, 4, 21, 17, 30, 0, 0, time.UTC)
+		expectedSavedAt := time.Date(2026, 4, 21, 17, 30, 0, 0, time.UTC)
+		draft := workout.CreateWorkoutRequest{
+			Date: "2026-04-21T12:00:00Z",
+			Exercises: []workout.ExerciseInput{
+				{
+					Name: "Chest Supported Row",
+					Sets: []workout.SetInput{
+						{Reps: 10, SetType: "working"},
+					},
+				},
+			},
+		}
 
 		featureAccess.On("HasCurrentUserFeatureAccess", mock.Anything, featureKeyAIChatbot).Return(true, nil).Once()
-		repo.On(
-			"SaveLatestWorkoutDraft",
-			mock.Anything,
-			int32(41),
-			"user-123",
-			mock.AnythingOfType("time.Time"),
-		).Run(func(args mock.Arguments) {
-			actualSavedAt := args.Get(3).(time.Time)
+		workoutSaver.On("SaveWorkoutTx", mock.Anything, (*db.Queries)(nil), draft, "user-123").Return(savedWorkoutID, nil).Once()
+		repo.On("SaveLatestWorkoutDraft", mock.Anything, mock.MatchedBy(func(request SaveLatestWorkoutDraftRequest) bool {
+			return request.ConversationID == 41 &&
+				request.UserID == "user-123" &&
+				!request.SavedAt.IsZero() &&
+				request.SaveWorkout != nil
+		})).Run(func(args mock.Arguments) {
+			request := args.Get(1).(SaveLatestWorkoutDraftRequest)
+			actualSavedAt := request.SavedAt
 			assert.WithinDuration(t, time.Now().UTC(), actualSavedAt, 5*time.Second)
-		}).Return(&SaveLatestWorkoutDraftResponse{
+
+			workoutID, err := request.SaveWorkout(context.Background(), nil, draft, "user-123")
+			require.NoError(t, err)
+			assert.Equal(t, savedWorkoutID, workoutID)
+		}).Return(&SavedLatestWorkoutDraft{
 			WorkoutID: savedWorkoutID,
 			Conversation: &Conversation{
 				ID: 41,
 				LatestWorkoutDraftStatus: &LatestWorkoutDraftStatus{
 					IsSaved:        true,
 					SavedWorkoutID: &savedWorkoutID,
-					SavedAt:        &savedAt,
+					SavedAt:        &expectedSavedAt,
 				},
 			},
 		}, nil).Once()
@@ -498,6 +510,7 @@ func TestServiceSaveLatestWorkoutDraft(t *testing.T) {
 		assert.True(t, resp.Conversation.LatestWorkoutDraftStatus.IsSaved)
 		assert.Equal(t, &savedWorkoutID, resp.Conversation.LatestWorkoutDraftStatus.SavedWorkoutID)
 		featureAccess.AssertExpectations(t)
+		workoutSaver.AssertExpectations(t)
 		repo.AssertExpectations(t)
 	})
 
@@ -509,7 +522,9 @@ func TestServiceSaveLatestWorkoutDraft(t *testing.T) {
 		savedWorkoutID := int32(88)
 
 		featureAccess.On("HasCurrentUserFeatureAccess", mock.Anything, featureKeyAIChatbot).Return(true, nil).Once()
-		repo.On("SaveLatestWorkoutDraft", mock.Anything, int32(41), "user-123", mock.AnythingOfType("time.Time")).Return(&SaveLatestWorkoutDraftResponse{
+		repo.On("SaveLatestWorkoutDraft", mock.Anything, mock.MatchedBy(func(request SaveLatestWorkoutDraftRequest) bool {
+			return request.ConversationID == 41 && request.UserID == "user-123" && request.SaveWorkout != nil
+		})).Return(&SavedLatestWorkoutDraft{
 			WorkoutID: savedWorkoutID,
 			Conversation: &Conversation{
 				ID: 41,
@@ -536,7 +551,9 @@ func TestServiceSaveLatestWorkoutDraft(t *testing.T) {
 		ctx := user.WithContext(context.Background(), "user-123")
 
 		featureAccess.On("HasCurrentUserFeatureAccess", mock.Anything, featureKeyAIChatbot).Return(true, nil).Once()
-		repo.On("SaveLatestWorkoutDraft", mock.Anything, int32(41), "user-123", mock.AnythingOfType("time.Time")).Return((*SaveLatestWorkoutDraftResponse)(nil), ErrLatestWorkoutDraftUnavailable).Once()
+		repo.On("SaveLatestWorkoutDraft", mock.Anything, mock.MatchedBy(func(request SaveLatestWorkoutDraftRequest) bool {
+			return request.ConversationID == 41 && request.UserID == "user-123" && request.SaveWorkout != nil
+		})).Return((*SavedLatestWorkoutDraft)(nil), ErrLatestWorkoutDraftUnavailable).Once()
 
 		resp, err := service.SaveLatestWorkoutDraft(ctx, 41)
 


### PR DESCRIPTION
## Summary
- move latest AI workout draft save orchestration into the AI chat service while keeping the locked database transaction in the repository
- inject the workout transaction saver at the service boundary so repository callers no longer need to own draft save-state behavior
- simplify the frontend chat save helper so callers receive the updated conversation instead of handling the full save response wrapper

## Behavior preserved
- saving the latest AI workout draft still creates a workout and marks the conversation draft saved with the saved workout ID
- already-saved drafts still return the existing saved workout state
- unavailable and superseded draft errors still flow through the existing API error handling
- concurrent saves remain covered so rapid duplicate saves create one workout

## Verification
- go test -count=1 ./internal/aichat ./cmd/api
- bun run test src/features/chat/api/ai-chat.test.ts src/features/chat/hooks/use-ai-chat-session.test.tsx src/features/chat/pages/chat-workout-draft-page.test.tsx
- bun run tsc
- autoreview clean: no accepted/actionable findings reported
