### PR TITLE
refactor: consolidate workout request transformation

### DIFF
--- a/server/internal/workout/historical_1rm_pr_integration_test.go
+++ b/server/internal/workout/historical_1rm_pr_integration_test.go
@@ -71,10 +71,10 @@ func TestWorkout_Historical1RM_PR_Lifecycle_Integration(t *testing.T) {
 	updateReq := UpdateWorkoutRequest{
 		Date:  "2026-02-10T10:00:00Z",
 		Notes: stringPtr("PR reduced"),
-		Exercises: []UpdateExercise{
+		Exercises: []ExerciseInput{
 			{
 				Name: "Bench Press",
-				Sets: []UpdateSet{
+				Sets: []SetInput{
 					{Weight: float64Ptr(100), Reps: 1, SetType: "working"}, // e1rm ~= 103.33
 				},
 			},

--- a/server/internal/workout/models.go
+++ b/server/internal/workout/models.go
@@ -25,6 +25,13 @@ type SetInput struct {
 	SetType string   `json:"setType" validate:"required,oneof=warmup working"`
 }
 
+type workoutRequestDraft struct {
+	Date         string
+	Notes        *string
+	WorkoutFocus *string
+	Exercises    []ExerciseInput
+}
+
 // PostgreSQL-specific types
 
 type PGWorkoutData struct {
@@ -76,147 +83,14 @@ type ReformattedRequest struct {
 	Sets      []SetData
 }
 
-// Interfaces for generic transformation
-type WorkoutRequestTransformable interface {
-	GetDate() *string
-	GetNotes() *string
-	GetWorkoutFocus() *string
-	GetExercises() []ExerciseTransformable
-}
-
-type ExerciseTransformable interface {
-	GetName() string
-	GetSets() []SetTransformable
-}
-
-type SetTransformable interface {
-	GetWeight() *float64
-	GetReps() int
-	GetSetType() string
-}
-
 // UPDATE endpoint types for PUT /api/workouts/{id}
 // Returns 204 No Content on success
 type UpdateWorkoutRequest struct {
-	Date         string           `json:"date" validate:"required,datetime=2006-01-02T15:04:05Z07:00"`
-	Notes        *string          `json:"notes,omitempty" validate:"omitempty,max=256"`
-	WorkoutFocus *string          `json:"workoutFocus,omitempty" validate:"omitempty,max=256"`
-	Exercises    []UpdateExercise `json:"exercises" validate:"required,min=1,dive"`
+	Date         string          `json:"date" validate:"required,datetime=2006-01-02T15:04:05Z07:00"`
+	Notes        *string         `json:"notes,omitempty" validate:"omitempty,max=256"`
+	WorkoutFocus *string         `json:"workoutFocus,omitempty" validate:"omitempty,max=256"`
+	Exercises    []ExerciseInput `json:"exercises" validate:"required,min=1,dive"`
 }
-
-type UpdateExercise struct {
-	Name string      `json:"name" validate:"required,min=1,max=256"`
-	Sets []UpdateSet `json:"sets" validate:"required,min=1,dive"`
-}
-
-type UpdateSet struct {
-	Weight  *float64 `json:"weight,omitempty" validate:"omitempty,gte=0,lte=999999999.9"`
-	Reps    int      `json:"reps" validate:"required,gte=1"`
-	SetType string   `json:"setType" validate:"required,oneof=warmup working"`
-}
-
-// Interface implementations for CreateWorkoutRequest
-func (c CreateWorkoutRequest) GetDate() *string {
-	return &c.Date
-}
-
-func (c CreateWorkoutRequest) GetNotes() *string {
-	return c.Notes
-}
-
-func (c CreateWorkoutRequest) GetWorkoutFocus() *string {
-	return c.WorkoutFocus
-}
-
-func (c CreateWorkoutRequest) GetExercises() []ExerciseTransformable {
-	result := make([]ExerciseTransformable, len(c.Exercises))
-	for i, exercise := range c.Exercises {
-		result[i] = exercise
-	}
-	return result
-}
-
-// Interface implementations for UpdateWorkoutRequest
-func (u UpdateWorkoutRequest) GetDate() *string {
-	return &u.Date
-}
-
-func (u UpdateWorkoutRequest) GetNotes() *string {
-	return u.Notes
-}
-
-func (u UpdateWorkoutRequest) GetWorkoutFocus() *string {
-	return u.WorkoutFocus
-}
-
-func (u UpdateWorkoutRequest) GetExercises() []ExerciseTransformable {
-	result := make([]ExerciseTransformable, len(u.Exercises))
-	for i, exercise := range u.Exercises {
-		result[i] = exercise
-	}
-	return result
-}
-
-// Interface implementations for ExerciseInput
-func (e ExerciseInput) GetName() string {
-	return e.Name
-}
-
-func (e ExerciseInput) GetSets() []SetTransformable {
-	result := make([]SetTransformable, len(e.Sets))
-	for i, set := range e.Sets {
-		result[i] = set
-	}
-	return result
-}
-
-// Interface implementations for UpdateExercise
-func (u UpdateExercise) GetName() string {
-	return u.Name
-}
-
-func (u UpdateExercise) GetSets() []SetTransformable {
-	result := make([]SetTransformable, len(u.Sets))
-	for i, set := range u.Sets {
-		result[i] = set
-	}
-	return result
-}
-
-// Interface implementations for SetInput
-func (s SetInput) GetWeight() *float64 {
-	return s.Weight
-}
-
-func (s SetInput) GetReps() int {
-	return s.Reps
-}
-
-func (s SetInput) GetSetType() string {
-	return s.SetType
-}
-
-// Interface implementations for UpdateSet
-func (u UpdateSet) GetWeight() *float64 {
-	return u.Weight
-}
-
-func (u UpdateSet) GetReps() int {
-	return u.Reps
-}
-
-func (u UpdateSet) GetSetType() string {
-	return u.SetType
-}
-
-var (
-	_ WorkoutRequestTransformable = CreateWorkoutRequest{}
-	_ WorkoutRequestTransformable = UpdateWorkoutRequest{}
-	_ ExerciseTransformable       = ExerciseInput{}
-	_ ExerciseTransformable       = UpdateExercise{}
-	_ SetTransformable            = SetInput{}
-	_ SetTransformable            = UpdateSet{}
-)
 
 // Contribution Graph types for GET /api/workouts/contribution-data
 type WorkoutSummary struct {

--- a/server/internal/workout/service.go
+++ b/server/internal/workout/service.go
@@ -333,29 +333,37 @@ func (ws *WorkoutService) parseWorkouts(workoutsJSON []byte) []WorkoutSummary {
 	return workouts
 }
 
-// Generic transform function that works with both request types
-func transformWorkoutRequest[T WorkoutRequestTransformable](logger *slog.Logger, request T, requireDate bool) (*ReformattedRequest, error) {
-	// Parse date
-	datePtr := request.GetDate()
-	if requireDate && datePtr == nil {
-		return nil, fmt.Errorf("date is required")
+func newCreateWorkoutDraft(request CreateWorkoutRequest) workoutRequestDraft {
+	return workoutRequestDraft{
+		Date:         request.Date,
+		Notes:        request.Notes,
+		WorkoutFocus: request.WorkoutFocus,
+		Exercises:    request.Exercises,
 	}
+}
 
-	var parsedDate time.Time
-	var err error
-	if datePtr != nil {
-		parsedDate, err = time.Parse("2006-01-02T15:04:05Z07:00", *datePtr)
-		if err != nil {
-			logger.Error("failed to parse date", "error", err)
-			return nil, fmt.Errorf("invalid date format: %w", err)
-		}
+func newUpdateWorkoutDraft(request UpdateWorkoutRequest) workoutRequestDraft {
+	return workoutRequestDraft{
+		Date:         request.Date,
+		Notes:        request.Notes,
+		WorkoutFocus: request.WorkoutFocus,
+		Exercises:    request.Exercises,
+	}
+}
+
+func transformWorkoutRequest(logger *slog.Logger, request workoutRequestDraft) (*ReformattedRequest, error) {
+	// Parse date
+	parsedDate, err := time.Parse("2006-01-02T15:04:05Z07:00", request.Date)
+	if err != nil {
+		logger.Error("failed to parse date", "error", err)
+		return nil, fmt.Errorf("invalid date format: %w", err)
 	}
 
 	// Create workout data
 	workout := WorkoutData{
 		Date:         parsedDate,
-		Notes:        request.GetNotes(),
-		WorkoutFocus: request.GetWorkoutFocus(),
+		Notes:        request.Notes,
+		WorkoutFocus: request.WorkoutFocus,
 	}
 
 	// Process exercises and sets
@@ -363,20 +371,20 @@ func transformWorkoutRequest[T WorkoutRequestTransformable](logger *slog.Logger,
 	var exercises []ExerciseData
 	var sets []SetData
 
-	for _, exercise := range request.GetExercises() {
-		if !exerciseMap[exercise.GetName()] {
-			exerciseMap[exercise.GetName()] = true
+	for _, exercise := range request.Exercises {
+		if !exerciseMap[exercise.Name] {
+			exerciseMap[exercise.Name] = true
 			exercises = append(exercises, ExerciseData{
-				Name: exercise.GetName(),
+				Name: exercise.Name,
 			})
 		}
 
-		for _, set := range exercise.GetSets() {
+		for _, set := range exercise.Sets {
 			sets = append(sets, SetData{
-				ExerciseName: exercise.GetName(),
-				Weight:       set.GetWeight(),
-				Reps:         set.GetReps(),
-				SetType:      set.GetSetType(),
+				ExerciseName: exercise.Name,
+				Weight:       set.Weight,
+				Reps:         set.Reps,
+				SetType:      set.SetType,
 			})
 		}
 	}
@@ -388,13 +396,12 @@ func transformWorkoutRequest[T WorkoutRequestTransformable](logger *slog.Logger,
 	}, nil
 }
 
-// Convenience wrappers
 func (ws *WorkoutService) transformRequest(request CreateWorkoutRequest) (*ReformattedRequest, error) {
-	return transformWorkoutRequest(ws.logger, request, false) // Date is required in struct, not optional
+	return transformWorkoutRequest(ws.logger, newCreateWorkoutDraft(request))
 }
 
 func (ws *WorkoutService) transformUpdateRequest(request UpdateWorkoutRequest) (*ReformattedRequest, error) {
-	return transformWorkoutRequest(ws.logger, request, false) // Date is optional for updates (partial updates allowed)
+	return transformWorkoutRequest(ws.logger, newUpdateWorkoutDraft(request))
 }
 
 // convertWorkoutWithSetsRows converts database rows to response type, handling pgtype.Numeric to float64 conversion

--- a/server/internal/workout/tx_saver.go
+++ b/server/internal/workout/tx_saver.go
@@ -26,7 +26,7 @@ func NewTxSaver(logger *slog.Logger, exerciseRepo exercise.ExerciseRepository) T
 }
 
 func (s *txSaver) SaveWorkoutTx(ctx context.Context, qtx *db.Queries, requestBody CreateWorkoutRequest, userID string) (int32, error) {
-	reformatted, err := transformWorkoutRequest(s.logger, requestBody, false)
+	reformatted, err := transformWorkoutRequest(s.logger, newCreateWorkoutDraft(requestBody))
 	if err != nil {
 		return 0, fmt.Errorf("failed to transform request: %w", err)
 	}

--- a/server/internal/workout/update_workout_test.go
+++ b/server/internal/workout/update_workout_test.go
@@ -44,10 +44,10 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			requestBody: UpdateWorkoutRequest{
 				Date:  "2023-01-15T10:00:00Z",
 				Notes: stringPtr("Updated workout notes"),
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "Updated Exercise",
-						Sets: []UpdateSet{
+						Sets: []SetInput{
 							{Weight: float64Ptr(225), Reps: 8, SetType: "working"},
 						},
 					},
@@ -68,10 +68,10 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			requestBody: UpdateWorkoutRequest{
 				Date:  "2023-01-15T10:00:00Z",
 				Notes: stringPtr("Just updating notes"),
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
@@ -88,10 +88,10 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			workoutID: "1",
 			requestBody: UpdateWorkoutRequest{
 				Date: "2023-01-15T15:30:00Z",
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
@@ -104,14 +104,14 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			expectedCode: http.StatusNoContent,
 		},
 		{
-			name:          "invalid workout ID - non-numeric",
-			workoutID:     "invalid",
-			requestBody:   UpdateWorkoutRequest{
+			name:      "invalid workout ID - non-numeric",
+			workoutID: "invalid",
+			requestBody: UpdateWorkoutRequest{
 				Date: "2023-01-15T10:00:00Z",
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
@@ -121,14 +121,14 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			expectedError: "Invalid workout ID",
 		},
 		{
-			name:          "missing workout ID",
-			workoutID:     "",
-			requestBody:   UpdateWorkoutRequest{
+			name:      "missing workout ID",
+			workoutID: "",
+			requestBody: UpdateWorkoutRequest{
 				Date: "2023-01-15T10:00:00Z",
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
@@ -151,10 +151,10 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			workoutID: "1",
 			requestBody: UpdateWorkoutRequest{
 				Date: "invalid-date-format",
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
@@ -169,10 +169,10 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			requestBody: UpdateWorkoutRequest{
 				Date:  "2023-01-15T10:00:00Z",
 				Notes: stringPtr(string(make([]byte, 500))), // Exceeds 256 char limit
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
@@ -185,11 +185,11 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			name:      "validation error - exercise missing name",
 			workoutID: "1",
 			requestBody: UpdateWorkoutRequest{
-				Date:      "2023-01-15T10:00:00Z",
-				Exercises: []UpdateExercise{
+				Date: "2023-01-15T10:00:00Z",
+				Exercises: []ExerciseInput{
 					{
 						// Missing Name field
-						Sets: []UpdateSet{
+						Sets: []SetInput{
 							{Reps: 10, SetType: "working"},
 						},
 					},
@@ -204,11 +204,11 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			name:      "validation error - set missing required fields",
 			workoutID: "1",
 			requestBody: UpdateWorkoutRequest{
-				Date:      "2023-01-15T10:00:00Z",
-				Exercises: []UpdateExercise{
+				Date: "2023-01-15T10:00:00Z",
+				Exercises: []ExerciseInput{
 					{
 						Name: "Valid Exercise",
-						Sets: []UpdateSet{
+						Sets: []SetInput{
 							{
 								// Missing Reps and SetType
 							},
@@ -227,10 +227,10 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			requestBody: UpdateWorkoutRequest{
 				Date:  "2023-01-15T10:00:00Z",
 				Notes: stringPtr("Updating non-existent workout"),
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
@@ -249,10 +249,10 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			requestBody: UpdateWorkoutRequest{
 				Date:  "2023-01-15T10:00:00Z",
 				Notes: stringPtr("Valid update"),
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
@@ -266,15 +266,15 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			expectedError: "failed to update workout",
 		},
 		{
-			name:          "unauthenticated user",
-			workoutID:     "1",
-			requestBody:   UpdateWorkoutRequest{
+			name:      "unauthenticated user",
+			workoutID: "1",
+			requestBody: UpdateWorkoutRequest{
 				Date:  "2023-01-15T10:00:00Z",
 				Notes: stringPtr("Unauthorized update"),
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
@@ -351,15 +351,15 @@ func TestWorkoutHandler_UpdateWorkout_Integration(t *testing.T) {
 	// Setup test data
 	userAID := "test-user-a"
 	userBID := "test-user-b"
-	
+
 	// Create test workout for User A
 	workoutID := setupTestWorkout(t, pool, userAID, "Original workout")
-	
+
 	// Initialize components with real database
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	validator := validator.New()
 	queries := db.New(pool)
-	
+
 	// Initialize repositories
 	exerciseRepo := exercise.NewRepository(logger, queries, pool)
 	workoutRepo := NewRepository(logger, queries, pool, exerciseRepo)
@@ -373,10 +373,10 @@ func TestWorkoutHandler_UpdateWorkout_Integration(t *testing.T) {
 		updateReq := UpdateWorkoutRequest{
 			Date:  "2023-01-15T10:00:00Z",
 			Notes: stringPtr("Updated notes via integration test"),
-			Exercises: []UpdateExercise{
+			Exercises: []ExerciseInput{
 				{
 					Name: "placeholder",
-					Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+					Sets: []SetInput{{Reps: 1, SetType: "working"}},
 				},
 			},
 		}
@@ -391,7 +391,7 @@ func TestWorkoutHandler_UpdateWorkout_Integration(t *testing.T) {
 		handler.UpdateWorkout(w, req)
 
 		assert.Equal(t, http.StatusNoContent, w.Code)
-		
+
 		// Verify the update by checking the workout directly from database
 		// Since our test workout has no sets, GetWorkoutWithSets would return empty
 		// Let's create a workout with sets in this test, or verify via database directly
@@ -409,10 +409,10 @@ func TestWorkoutHandler_UpdateWorkout_Integration(t *testing.T) {
 		updateReq := UpdateWorkoutRequest{
 			Date:  "2023-01-15T10:00:00Z",
 			Notes: stringPtr("Malicious update attempt from User B"),
-			Exercises: []UpdateExercise{
+			Exercises: []ExerciseInput{
 				{
 					Name: "placeholder",
-					Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+					Sets: []SetInput{{Reps: 1, SetType: "working"}},
 				},
 			},
 		}
@@ -428,11 +428,11 @@ func TestWorkoutHandler_UpdateWorkout_Integration(t *testing.T) {
 
 		// Should fail due to RLS - workout not found for userB
 		assert.Equal(t, http.StatusNotFound, w.Code)
-		
+
 		// Double-check userA's workout was not modified
 		ctxA := setTestUserContext(context.Background(), t, pool, userAID)
 		ctxA = user.WithContext(ctxA, userAID)
-		
+
 		// Verify via direct database query that the workout was not modified
 		var actualNotes string
 		err := pool.QueryRow(ctxA, "SELECT notes FROM workout WHERE id = $1 AND user_id = $2",
@@ -449,10 +449,10 @@ func TestWorkoutHandler_UpdateWorkout_Integration(t *testing.T) {
 		updateReq := UpdateWorkoutRequest{
 			Date:  "2023-01-15T10:00:00Z",
 			Notes: stringPtr("Updated with new exercises"),
-			Exercises: []UpdateExercise{
+			Exercises: []ExerciseInput{
 				{
 					Name: "Bench Press",
-					Sets: []UpdateSet{
+					Sets: []SetInput{
 						{Weight: float64Ptr(135), Reps: 10, SetType: "warmup"},
 						{Weight: float64Ptr(185), Reps: 8, SetType: "working"},
 						{Weight: float64Ptr(225), Reps: 5, SetType: "working"},
@@ -460,7 +460,7 @@ func TestWorkoutHandler_UpdateWorkout_Integration(t *testing.T) {
 				},
 				{
 					Name: "Squats",
-					Sets: []UpdateSet{
+					Sets: []SetInput{
 						{Weight: float64Ptr(95), Reps: 10, SetType: "warmup"},
 						{Weight: float64Ptr(135), Reps: 8, SetType: "working"},
 					},
@@ -478,36 +478,36 @@ func TestWorkoutHandler_UpdateWorkout_Integration(t *testing.T) {
 		handler.UpdateWorkout(w, req)
 
 		assert.Equal(t, http.StatusNoContent, w.Code)
-		
+
 		// Order columns are now automatically populated by the UpdateWorkout method
 		// No manual backfill needed since our implementation handles ordering
-		
+
 		// Verify the update by getting the workout and checking exercises and sets
 		getReq := httptest.NewRequest("GET", fmt.Sprintf("/api/workouts/%d", workoutID), nil)
 		getReq = getReq.WithContext(ctx)
 		getReq.SetPathValue("id", strconv.Itoa(int(workoutID)))
-		
+
 		getW := httptest.NewRecorder()
 		handler.GetWorkoutWithSets(getW, getReq)
-		
+
 		var workout []db.GetWorkoutWithSetsRow
 		err := json.Unmarshal(getW.Body.Bytes(), &workout)
 		assert.NoError(t, err)
-		
+
 		// Group sets by exercise
 		exerciseSets := make(map[string][]db.GetWorkoutWithSetsRow)
 		for _, row := range workout {
-		if row.ExerciseName != "" {
-			exerciseSets[row.ExerciseName] = append(
-				exerciseSets[row.ExerciseName], row)
+			if row.ExerciseName != "" {
+				exerciseSets[row.ExerciseName] = append(
+					exerciseSets[row.ExerciseName], row)
 			}
 		}
-		
+
 		// Check for Bench Press and its 3 sets
 		benchSets, hasBench := exerciseSets["Bench Press"]
 		assert.True(t, hasBench, "Bench Press exercise should exist")
 		assert.Len(t, benchSets, 3, "Bench Press should have 3 sets")
-		
+
 		// Check for Squats and its 2 sets
 		squatSets, hasSquats := exerciseSets["Squats"]
 		assert.True(t, hasSquats, "Squats exercise should exist")

--- a/server/internal/workout/workout_focus_test.go
+++ b/server/internal/workout/workout_focus_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestWorkoutFocus_CreateWorkout(t *testing.T) {
 	userID := "test-user-id"
-	
+
 	// Helper function for string pointers
 	stringPtr := func(s string) *string { return &s }
 
@@ -125,10 +125,10 @@ func TestWorkoutFocus_CreateWorkout(t *testing.T) {
 					},
 				},
 			},
-			setupMock:    func(m *MockWorkoutRepository) {},
-			ctx:          context.WithValue(context.Background(), user.UserIDKey, userID),
-			expectedCode: http.StatusBadRequest,
-			expectJSON:   true,
+			setupMock:     func(m *MockWorkoutRepository) {},
+			ctx:           context.WithValue(context.Background(), user.UserIDKey, userID),
+			expectedCode:  http.StatusBadRequest,
+			expectJSON:    true,
 			expectedError: "validation error occurred",
 		},
 	}
@@ -205,10 +205,10 @@ func TestWorkoutFocus_UpdateWorkout(t *testing.T) {
 			requestBody: UpdateWorkoutRequest{
 				Date:         "2023-01-15T10:00:00Z",
 				WorkoutFocus: stringPtrHelper("Push Day"),
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
@@ -227,10 +227,10 @@ func TestWorkoutFocus_UpdateWorkout(t *testing.T) {
 			requestBody: UpdateWorkoutRequest{
 				Date:         "2023-01-15T10:00:00Z",
 				WorkoutFocus: stringPtrHelper(""),
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
@@ -248,10 +248,10 @@ func TestWorkoutFocus_UpdateWorkout(t *testing.T) {
 			requestBody: UpdateWorkoutRequest{
 				Date:         "2023-01-15T10:00:00Z", // Date is required for validation
 				WorkoutFocus: stringPtrHelper("Leg Day"),
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
@@ -269,16 +269,16 @@ func TestWorkoutFocus_UpdateWorkout(t *testing.T) {
 			requestBody: UpdateWorkoutRequest{
 				Date:         "2023-01-15T10:00:00Z",
 				WorkoutFocus: stringPtr(string(make([]byte, 300))), // Exceeds 256 char limit
-				Exercises: []UpdateExercise{
+				Exercises: []ExerciseInput{
 					{
 						Name: "placeholder",
-						Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+						Sets: []SetInput{{Reps: 1, SetType: "working"}},
 					},
 				},
 			},
-			setupMock:    func(m *MockWorkoutRepository) {},
-			ctx:          context.WithValue(context.Background(), user.UserIDKey, userID),
-			expectedCode: http.StatusBadRequest,
+			setupMock:     func(m *MockWorkoutRepository) {},
+			ctx:           context.WithValue(context.Background(), user.UserIDKey, userID),
+			expectedCode:  http.StatusBadRequest,
 			expectedError: "validation error occurred",
 		},
 	}
@@ -382,13 +382,13 @@ func TestWorkoutFocus_Integration(t *testing.T) {
 		handler.CreateWorkout(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		
+
 		// Verify that the workout was created successfully by checking the response
 		var result map[string]bool
 		err := json.Unmarshal(w.Body.Bytes(), &result)
 		assert.NoError(t, err)
 		assert.True(t, result["success"])
-		
+
 		// Verify the workout was created with the focus by querying the database directly
 		var actualFocus string
 		var actualFocusValid bool
@@ -436,10 +436,10 @@ func TestWorkoutFocus_Integration(t *testing.T) {
 		updateReq := UpdateWorkoutRequest{
 			Date:         "2023-01-15T10:00:00Z", // Date is required
 			WorkoutFocus: stringPtrHelper("Leg Day Focus"),
-			Exercises: []UpdateExercise{
+			Exercises: []ExerciseInput{
 				{
 					Name: "placeholder",
-					Sets: []UpdateSet{{Reps: 1, SetType: "working"}},
+					Sets: []SetInput{{Reps: 1, SetType: "working"}},
 				},
 			},
 		}
@@ -529,13 +529,13 @@ func stringPtrHelper(s string) *string {
 
 func setupTestDatabaseForWorkoutFocus(t *testing.T) (*pgxpool.Pool, func()) {
 	t.Helper()
-	
+
 	// Use the same setup as other integration tests
 	pool, cleanup := setupTestDatabase(t)
-	
+
 	// Setup specific test users if needed
 	setupSpecificTestUsersForFocus(t, pool)
-	
+
 	return pool, func() {
 		cleanupSpecificTestUsersForFocus(t, pool)
 		cleanup()


### PR DESCRIPTION
## User impact

Workout create and update keep the same request behavior, but the backend code now has less repeated request schema and less indirection to understand before changing workout save/update behavior.

## Behavior preserved

- Create and update still accept the same JSON fields and validation rules.
- Workout transformation still parses the request date, preserves notes/focus, deduplicates exercises by name, and flattens sets for repository persistence.
- Transactional workout saves now use the same explicit create draft path as the service.

## Risk

Low. This is a backend refactor with no intended API behavior change. Main risk is accidentally changing create/update transformation, covered by focused handler/service tests.

## Tests run

- `go test ./internal/workout -count=1 -run "TestWorkoutHandler_(CreateWorkout|UpdateWorkout|ListWorkouts|GetWorkoutWithSets|GetContributionData|ListWorkoutFocusValues|GetNewWorkoutContext|DeleteWorkout)$|TestWorkoutFocus_(CreateWorkout|UpdateWorkout)$|TestWorkoutService_|TestFormatValidationErrors"`
- `go test ./internal/workout` attempted, blocked by missing local Postgres at `localhost:5432` for `fittrack_test` integration tests.
- `go test ./...` attempted from `server`, blocked by the same missing local Postgres dependency in database/exercise/workout integration tests; non-database packages completed before the DB-backed failures.