### PR TITLE
refactor: contain workout form orchestration

### DIFF
--- a/client/src/features/workouts/hooks/use-new-workout-form-workflow.test.tsx
+++ b/client/src/features/workouts/hooks/use-new-workout-form-workflow.test.tsx
@@ -1,0 +1,203 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkoutNewWorkoutContextResponse } from "@/client";
+import type { WorkoutDraftStorage } from "@/lib/local-storage";
+
+const {
+  mockApiMutateAsync,
+  mockDemoMutateAsync,
+  mockFetchQuery,
+  mockNavigate,
+  mockToastSuccess,
+} = vi.hoisted(() => ({
+  mockApiMutateAsync: vi.fn(),
+  mockDemoMutateAsync: vi.fn(),
+  mockFetchQuery: vi.fn(),
+  mockNavigate: vi.fn(),
+  mockToastSuccess: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({ mutateAsync: mockDemoMutateAsync }),
+}));
+
+vi.mock("@/features/workouts/api/workouts", () => ({
+  useSaveWorkoutMutation: () => ({ mutateAsync: mockApiMutateAsync }),
+}));
+
+vi.mock("@/lib/api/api", () => ({
+  queryClient: {
+    fetchQuery: mockFetchQuery,
+  },
+}));
+
+vi.mock("@/lib/api/unified-query-options", () => ({
+  getWorkoutByIdQueryOptions: (_user: unknown, workoutId: number) => ({
+    queryKey: ["workout", workoutId],
+  }),
+}));
+
+vi.mock("@/lib/demo-data/query-options", () => ({
+  postDemoWorkoutsMutation: () => ({}),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: mockToastSuccess,
+  },
+}));
+
+import { useNewWorkoutFormWorkflow } from "@/features/workouts/hooks/use-new-workout-form-workflow";
+
+function createDraftStorage(
+  loadValue: ReturnType<WorkoutDraftStorage["load"]> = null,
+): WorkoutDraftStorage {
+  return {
+    save: vi.fn(),
+    load: vi.fn(() => loadValue),
+    clear: vi.fn(),
+  };
+}
+
+const newWorkoutContext: WorkoutNewWorkoutContextResponse = {
+  latestWorkoutNote: undefined,
+  focusTemplates: [
+    {
+      date: "2026-06-12",
+      focus: "Push",
+      workoutId: 42,
+    },
+  ],
+};
+
+describe("useNewWorkoutFormWorkflow", () => {
+  beforeEach(() => {
+    mockApiMutateAsync.mockReset();
+    mockDemoMutateAsync.mockReset();
+    mockFetchQuery.mockReset();
+    mockNavigate.mockReset();
+    mockToastSuccess.mockReset();
+  });
+
+  it("uses the authenticated save mutation and clears the saved draft after submit", async () => {
+    const draftStorage = createDraftStorage();
+    mockApiMutateAsync.mockImplementation(async (_variables, options) => {
+      options.onSuccess();
+    });
+
+    const { result } = renderHook(() =>
+      useNewWorkoutFormWorkflow({
+        user: { id: "user-1" } as any,
+        exercises: [],
+        newWorkoutContext,
+        draftStorage,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.form.handleSubmit();
+    });
+
+    expect(mockApiMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          notes: undefined,
+          workoutFocus: undefined,
+        }),
+      }),
+      expect.any(Object),
+    );
+    expect(mockDemoMutateAsync).not.toHaveBeenCalled();
+    expect(draftStorage.clear).toHaveBeenCalledWith("user-1");
+    expect(mockNavigate).toHaveBeenCalledWith({ search: {} });
+    expect(mockToastSuccess).toHaveBeenCalledWith("Workout saved successfully");
+  });
+
+  it("asks before replacing an existing draft with a focus-area template", async () => {
+    const draftStorage = createDraftStorage({
+      date: "2026-06-13T10:00:00.000Z",
+      notes: "Keep this",
+      exercises: [],
+      workoutFocus: "",
+    });
+    mockFetchQuery.mockResolvedValue([
+      {
+        exercise_id: 1,
+        exercise_name: "Bench Press",
+        exercise_order: 0,
+        reps: 5,
+        set_id: 10,
+        set_order: 0,
+        set_type: "working",
+        volume: 500,
+        weight: 100,
+        workout_date: "2026-06-12",
+        workout_id: 42,
+        workout_notes: "",
+        workout_focus: "Push",
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useNewWorkoutFormWorkflow({
+        user: null,
+        exercises: [{ id: 1, name: "Bench Press" }],
+        newWorkoutContext,
+        draftStorage,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.repeatWorkout(42);
+    });
+
+    expect(result.current.pendingTemplateWorkoutId).toBe(42);
+    expect(mockFetchQuery).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.replaceDraftWithPendingTemplate();
+    });
+
+    expect(draftStorage.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workoutFocus: "Push",
+        exercises: [
+          {
+            name: "Bench Press",
+            sets: [{ reps: 5, setType: "working", weight: 100 }],
+          },
+        ],
+      }),
+      undefined,
+    );
+    expect(mockNavigate).toHaveBeenCalledWith({ search: {} });
+    expect(mockToastSuccess).toHaveBeenCalledWith("Loaded workout structure");
+  });
+
+  it("clears the current draft and closes the clear dialog", () => {
+    const draftStorage = createDraftStorage();
+    const { result } = renderHook(() =>
+      useNewWorkoutFormWorkflow({
+        user: null,
+        exercises: [],
+        newWorkoutContext,
+        draftStorage,
+      }),
+    );
+
+    act(() => {
+      result.current.setIsClearDialogOpen(true);
+    });
+    act(() => {
+      result.current.clearForm();
+    });
+
+    expect(draftStorage.clear).toHaveBeenCalledWith(undefined);
+    expect(mockNavigate).toHaveBeenCalledWith({ search: {} });
+    expect(result.current.isClearDialogOpen).toBe(false);
+  });
+});

--- a/client/src/features/workouts/hooks/use-new-workout-form-workflow.ts
+++ b/client/src/features/workouts/hooks/use-new-workout-form-workflow.ts
@@ -1,0 +1,182 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useMutation } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import type { CurrentInternalUser, CurrentUser } from "@stackframe/react";
+import { toast } from "sonner";
+import type { WorkoutNewWorkoutContextResponse } from "@/client";
+import type { DbExercise } from "@/features/exercises/api/exercises";
+import {
+  formatExerciseGoalSummary,
+  getExerciseGoal,
+} from "@/features/exercises/utils/exercise-goals";
+import { useSaveWorkoutMutation } from "@/features/workouts/api/workouts";
+import {
+  getInitialValues,
+  MOCK_VALUES,
+} from "@/features/workouts/components/form/form-options";
+import { hasWorkoutDraftContent } from "@/features/workouts/components/form/workout-form-helpers";
+import { buildWorkoutDraftFromHistory } from "@/features/workouts/utils/workout-insights";
+import { useAppForm } from "@/hooks/form";
+import { queryClient } from "@/lib/api/api";
+import { getWorkoutByIdQueryOptions } from "@/lib/api/unified-query-options";
+import { postDemoWorkoutsMutation } from "@/lib/demo-data/query-options";
+import {
+  type WorkoutDraftStorage,
+  workoutDraftStorage,
+} from "@/lib/local-storage";
+
+export function useNewWorkoutFormWorkflow({
+  user,
+  exercises,
+  newWorkoutContext,
+  draftStorage = workoutDraftStorage,
+}: {
+  user: CurrentUser | CurrentInternalUser | null;
+  exercises: DbExercise[];
+  newWorkoutContext: WorkoutNewWorkoutContextResponse;
+  draftStorage?: WorkoutDraftStorage;
+}) {
+  const navigate = useNavigate({ from: "/workouts/new" });
+  const [isClearDialogOpen, setIsClearDialogOpen] = useState(false);
+  const [pendingTemplateWorkoutId, setPendingTemplateWorkoutId] = useState<
+    number | null
+  >(null);
+
+  const saveWorkoutApi = useSaveWorkoutMutation();
+  const saveWorkoutDemo = useMutation(postDemoWorkoutsMutation());
+  const saveWorkout = user ? saveWorkoutApi : saveWorkoutDemo;
+  const form = useAppForm({
+    defaultValues: getInitialValues(user?.id, draftStorage),
+    listeners: {
+      onChange: ({ formApi }) => {
+        draftStorage.save(formApi.state.values, user?.id);
+      },
+    },
+    onSubmit: async ({ value }) => {
+      const trimmedValue = {
+        ...value,
+        notes: value.notes?.trim() || undefined,
+        workoutFocus: value.workoutFocus?.trim() || undefined,
+      };
+
+      await saveWorkout.mutateAsync(
+        { body: trimmedValue },
+        {
+          onSuccess: () => {
+            toast.success("Workout saved successfully");
+            draftStorage.clear(user?.id);
+            form.reset(MOCK_VALUES);
+            clearSearch();
+          },
+        },
+      );
+    },
+  });
+
+  const exerciseIdsByName = useMemo(() => {
+    return new Map(exercises.map((exercise) => [exercise.name, exercise.id]));
+  }, [exercises]);
+  const latestWorkoutNote = newWorkoutContext.latestWorkoutNote;
+  const focusAreaTemplates = useMemo(
+    () => newWorkoutContext.focusTemplates ?? [],
+    [newWorkoutContext.focusTemplates],
+  );
+
+  function getExerciseId(exerciseName: string): number | null {
+    return exerciseIdsByName.get(exerciseName) ?? null;
+  }
+
+  function getExerciseGoalSummary(exerciseName: string): string | null {
+    return formatExerciseGoalSummary(
+      getExerciseGoal({
+        exerciseId: getExerciseId(exerciseName),
+        exerciseName,
+      }),
+    );
+  }
+
+  function clearSearch() {
+    navigate({ search: {} });
+  }
+
+  const openExercise = (index: number, isNewExercise?: boolean) => {
+    navigate({
+      search: { exerciseIndex: index, newExercise: isNewExercise },
+    });
+  };
+
+  const closeExercise = (exerciseIndex: number, newExercise?: boolean) => {
+    const currentExercise = form.state.values.exercises[exerciseIndex];
+    if (newExercise && currentExercise && currentExercise.sets.length === 0) {
+      form.removeFieldValue("exercises", exerciseIndex);
+    }
+    clearSearch();
+  };
+
+  const discardNewExercise = (exerciseIndex: number, newExercise?: boolean) => {
+    if (newExercise) {
+      form.removeFieldValue("exercises", exerciseIndex);
+    }
+    clearSearch();
+  };
+
+  const loadWorkoutTemplate = async (workoutId: number) => {
+    const workoutToRepeat = await queryClient.fetchQuery(
+      getWorkoutByIdQueryOptions(user, workoutId),
+    );
+    const nextDraft = buildWorkoutDraftFromHistory(workoutToRepeat);
+
+    form.reset(nextDraft);
+    draftStorage.save(nextDraft, user?.id);
+    clearSearch();
+    toast.success("Loaded workout structure");
+  };
+
+  const repeatWorkout = async (workoutId: number) => {
+    const hasDraft =
+      hasWorkoutDraftContent(form.state.values) ||
+      draftStorage.load(user?.id) !== null;
+    if (hasDraft) {
+      setPendingTemplateWorkoutId(workoutId);
+      return;
+    }
+
+    await loadWorkoutTemplate(workoutId);
+  };
+
+  const replaceDraftWithPendingTemplate = async () => {
+    if (pendingTemplateWorkoutId == null) {
+      return;
+    }
+
+    const workoutId = pendingTemplateWorkoutId;
+    setPendingTemplateWorkoutId(null);
+    await loadWorkoutTemplate(workoutId);
+  };
+
+  const clearForm = () => {
+    draftStorage.clear(user?.id);
+    form.reset(MOCK_VALUES);
+    clearSearch();
+    setIsClearDialogOpen(false);
+  };
+
+  return {
+    form,
+    latestWorkoutNote,
+    focusAreaTemplates,
+    isClearDialogOpen,
+    pendingTemplateWorkoutId,
+    setIsClearDialogOpen,
+    setPendingTemplateWorkoutId,
+    clearForm,
+    clearSearch,
+    openExercise,
+    closeExercise,
+    discardNewExercise,
+    repeatWorkout,
+    replaceDraftWithPendingTemplate,
+    getExerciseId,
+    getExerciseGoalSummary,
+  };
+}

--- a/client/src/features/workouts/pages/new-workout-page.tsx
+++ b/client/src/features/workouts/pages/new-workout-page.tsx
@@ -1,11 +1,5 @@
-import { useNavigate } from "@tanstack/react-router";
-import { Suspense, useMemo, useState, type ReactNode } from "react";
-import { useAppForm } from "@/hooks/form";
-import {
-  useSaveWorkoutMutation,
-  type WorkoutFocus,
-} from "@/features/workouts/api/workouts";
-import { useMutation } from "@tanstack/react-query";
+import { Suspense, type ReactNode } from "react";
+import { type WorkoutFocus } from "@/features/workouts/api/workouts";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { MiniChart } from "@/features/workouts/components/form/mini-chart";
@@ -17,26 +11,14 @@ import {
   workoutDraftStorage,
 } from "@/lib/local-storage";
 import { type DbExercise } from "@/features/exercises/api/exercises";
-import {
-  getInitialValues,
-  MOCK_VALUES,
-} from "@/features/workouts/components/form/form-options";
-import { postDemoWorkoutsMutation } from "@/lib/demo-data/query-options";
 import { toast } from "sonner";
-import { getWorkoutByIdQueryOptions } from "@/lib/api/unified-query-options";
 import { formatWeight } from "@/lib/utils";
 import {
   ErrorBoundary,
   FullScreenErrorFallback,
 } from "@/components/error-boundary";
-import { queryClient } from "@/lib/api/api";
 import { ExerciseContextPanel } from "@/features/workouts/components/form/exercise-context-panel";
 import { LastWorkoutNoteSection } from "@/features/workouts/components/last-workout-note-section";
-import { buildWorkoutDraftFromHistory } from "@/features/workouts/utils/workout-insights";
-import {
-  formatExerciseGoalSummary,
-  getExerciseGoal,
-} from "@/features/exercises/utils/exercise-goals";
 import type { WorkoutNewWorkoutContextResponse } from "@/client";
 import {
   AlertDialog,
@@ -63,10 +45,7 @@ import {
   ExerciseSets,
 } from "@/features/workouts/components/form/exercise-screen";
 import { RecentSets } from "@/features/workouts/components/form/recent-sets-display";
-import {
-  hasWorkoutDraftContent,
-  shouldShowRecentFocusAreaCard,
-} from "@/features/workouts/components/form/workout-form-helpers";
+import { shouldShowRecentFocusAreaCard } from "@/features/workouts/components/form/workout-form-helpers";
 import {
   WorkoutExerciseCards,
   type WorkoutExerciseCard,
@@ -74,6 +53,7 @@ import {
   WorkoutMetadataFields,
 } from "@/features/workouts/components/form/workout-form-sections";
 import { useExerciseReorder } from "@/features/workouts/components/form/use-exercise-reorder";
+import { useNewWorkoutFormWorkflow } from "@/features/workouts/hooks/use-new-workout-form-workflow";
 
 function WorkoutExerciseSection({
   field,
@@ -146,92 +126,17 @@ export function NewWorkoutPage({
   draftStorage?: WorkoutDraftStorage;
 }) {
   const { addExercise, exerciseIndex, newExercise } = search;
-  const navigate = useNavigate({ from: "/workouts/new" });
-  const [isClearDialogOpen, setIsClearDialogOpen] = useState(false);
-  const [pendingTemplateWorkoutId, setPendingTemplateWorkoutId] = useState<
-    number | null
-  >(null);
-
-  const saveWorkoutApi = useSaveWorkoutMutation();
-  const saveWorkoutDemo = useMutation(postDemoWorkoutsMutation());
-  const saveWorkout = user ? saveWorkoutApi : saveWorkoutDemo;
-  const form = useAppForm({
-    defaultValues: getInitialValues(user?.id, draftStorage),
-    listeners: {
-      onChange: ({ formApi }) => {
-        draftStorage.save(formApi.state.values, user?.id);
-      },
-    },
-    onSubmit: async ({ value }) => {
-      const trimmedValue = {
-        ...value,
-        notes: value.notes?.trim() || undefined,
-        workoutFocus: value.workoutFocus?.trim() || undefined,
-      };
-
-      await saveWorkout.mutateAsync(
-        { body: trimmedValue },
-        {
-          onSuccess: () => {
-            toast.success("Workout saved successfully");
-            draftStorage.clear(user?.id);
-            form.reset(MOCK_VALUES);
-            navigate({ search: {} });
-          },
-        },
-      );
-    },
+  const workoutForm = useNewWorkoutFormWorkflow({
+    user,
+    exercises,
+    newWorkoutContext,
+    draftStorage,
   });
-
-  // Helper to get exercise ID from exercises list
-  const getExerciseId = (exerciseName: string): number | null => {
-    const exercise = exercises.find((ex) => ex.name === exerciseName);
-    return exercise?.id || null;
-  };
-
-  const latestWorkoutNote = newWorkoutContext.latestWorkoutNote;
-  const focusAreaTemplates = useMemo(
-    () => newWorkoutContext.focusTemplates ?? [],
-    [newWorkoutContext.focusTemplates],
-  );
-
-  const loadWorkoutTemplate = async (workoutId: number) => {
-    const workoutToRepeat = await queryClient.fetchQuery(
-      getWorkoutByIdQueryOptions(user, workoutId),
-    );
-    const nextDraft = buildWorkoutDraftFromHistory(workoutToRepeat);
-
-    form.reset(nextDraft);
-    draftStorage.save(nextDraft, user?.id);
-    navigate({ search: {} });
-    toast.success("Loaded workout structure");
-  };
-
-  const handleRepeatWorkout = async (workoutId: number) => {
-    const hasDraft =
-      hasWorkoutDraftContent(form.state.values) ||
-      draftStorage.load(user?.id) !== null;
-    if (hasDraft) {
-      setPendingTemplateWorkoutId(workoutId);
-      return;
-    }
-
-    await loadWorkoutTemplate(workoutId);
-  };
-
-  const handleClearForm = () => {
-    draftStorage.clear(user?.id);
-    form.reset(MOCK_VALUES);
-    navigate({ search: {} });
-    setIsClearDialogOpen(false);
-  };
+  const { form, focusAreaTemplates, latestWorkoutNote } = workoutForm;
 
   const renderExerciseGoalSummary = (exercise: { name: string }) => {
-    const exerciseGoalSummary = formatExerciseGoalSummary(
-      getExerciseGoal({
-        exerciseId: getExerciseId(exercise.name),
-        exerciseName: exercise.name,
-      }),
+    const exerciseGoalSummary = workoutForm.getExerciseGoalSummary(
+      exercise.name,
     );
 
     if (!exerciseGoalSummary) {
@@ -252,7 +157,7 @@ export function NewWorkoutPage({
         fallback={
           <FullScreenErrorFallback
             message="Failed to load exercise selection"
-            onAction={() => navigate({ search: {} })}
+            onAction={workoutForm.clearSearch}
             actionLabel="Go Back"
           />
         }
@@ -267,12 +172,8 @@ export function NewWorkoutPage({
           <AddExerciseScreen
             form={form}
             exercises={exercises}
-            onAddExercise={(index, isNewExercise) =>
-              navigate({
-                search: { exerciseIndex: index, newExercise: isNewExercise },
-              })
-            }
-            onBack={() => navigate({ search: {} })}
+            onAddExercise={workoutForm.openExercise}
+            onBack={workoutForm.clearSearch}
           />
         </Suspense>
       </ErrorBoundary>
@@ -285,34 +186,19 @@ export function NewWorkoutPage({
     // Validate exercise index
     if (exerciseIndex < 0 || exerciseIndex >= exercises.length) {
       // Silently redirect to main
-      navigate({ search: {} });
+      workoutForm.clearSearch();
       return null;
     }
 
     const exerciseName = exercises[exerciseIndex]?.name;
-    const exerciseId = getExerciseId(exerciseName);
-
-    const handleExerciseBack = () => {
-      const currentExercise = form.state.values.exercises[exerciseIndex];
-      if (newExercise && currentExercise && currentExercise.sets.length === 0) {
-        form.removeFieldValue("exercises", exerciseIndex);
-      }
-      navigate({ search: {} });
-    };
-
-    const handleDiscardNewExercise = () => {
-      if (newExercise) {
-        form.removeFieldValue("exercises", exerciseIndex);
-      }
-      navigate({ search: {} });
-    };
+    const exerciseId = workoutForm.getExerciseId(exerciseName);
 
     return (
       <ErrorBoundary
         fallback={
           <FullScreenErrorFallback
             message="Failed to load exercise details"
-            onAction={() => navigate({ search: {} })}
+            onAction={workoutForm.clearSearch}
             actionLabel="Go Back"
           />
         }
@@ -329,7 +215,9 @@ export function NewWorkoutPage({
               <ExerciseHeader
                 form={form}
                 exerciseIndex={exerciseIndex}
-                onBack={handleExerciseBack}
+                onBack={() =>
+                  workoutForm.closeExercise(exerciseIndex, newExercise)
+                }
               />
             }
             contextPanel={
@@ -349,7 +237,9 @@ export function NewWorkoutPage({
                 form={form}
                 exerciseIndex={exerciseIndex}
                 isNewExercise={newExercise}
-                onDiscardNewExercise={handleDiscardNewExercise}
+                onDiscardNewExercise={() =>
+                  workoutForm.discardNewExercise(exerciseIndex, newExercise)
+                }
               />
             }
           />
@@ -383,7 +273,7 @@ export function NewWorkoutPage({
               <Button
                 type="button"
                 variant="ghost"
-                onClick={() => setIsClearDialogOpen(true)}
+                onClick={() => workoutForm.setIsClearDialogOpen(true)}
                 size="sm"
               >
                 <X className="w-3.5 h-3.5 mr-1.5" />
@@ -422,7 +312,7 @@ export function NewWorkoutPage({
                       </div>
                       <Select
                         onValueChange={(value) =>
-                          handleRepeatWorkout(Number(value))
+                          workoutForm.repeatWorkout(Number(value))
                         }
                       >
                         <SelectTrigger>
@@ -480,8 +370,8 @@ export function NewWorkoutPage({
           </form>
         </div>
         <AlertDialog
-          open={isClearDialogOpen}
-          onOpenChange={setIsClearDialogOpen}
+          open={workoutForm.isClearDialogOpen}
+          onOpenChange={workoutForm.setIsClearDialogOpen}
         >
           <AlertDialogContent>
             <AlertDialogHeader>
@@ -493,17 +383,17 @@ export function NewWorkoutPage({
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction onClick={handleClearForm}>
+              <AlertDialogAction onClick={workoutForm.clearForm}>
                 Clear draft
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
         <AlertDialog
-          open={pendingTemplateWorkoutId !== null}
+          open={workoutForm.pendingTemplateWorkoutId !== null}
           onOpenChange={(open) => {
             if (!open) {
-              setPendingTemplateWorkoutId(null);
+              workoutForm.setPendingTemplateWorkoutId(null);
             }
           }}
         >
@@ -518,15 +408,7 @@ export function NewWorkoutPage({
             <AlertDialogFooter>
               <AlertDialogCancel>Keep current draft</AlertDialogCancel>
               <AlertDialogAction
-                onClick={async () => {
-                  if (pendingTemplateWorkoutId == null) {
-                    return;
-                  }
-
-                  const workoutId = pendingTemplateWorkoutId;
-                  setPendingTemplateWorkoutId(null);
-                  await loadWorkoutTemplate(workoutId);
-                }}
+                onClick={workoutForm.replaceDraftWithPendingTemplate}
               >
                 Replace draft
               </AlertDialogAction>


### PR DESCRIPTION
## User impact
- Keeps the new workout flow behavior the same while making the page easier to review and reason about.
- Moves draft persistence, save mutation choice, repeat-template loading, clear/reset behavior, and route search cleanup behind one feature-local workflow hook.

## Behavior preserved
- Creating workouts still uses authenticated or demo save mutations based on the current user.
- Local workout drafts still save on change and clear after submit or explicit clear.
- Recent focus-area templates still load into the form, with confirmation before replacing an existing draft.
- Add-exercise and exercise-detail routes still clean up empty new exercises and reset search state.
- Goal summaries and last workout notes still render from the same data.

## Risk
- Low to moderate: orchestration moved, but UI components and request shapes were left in place.
- Main risk is workflow wiring, covered by a focused hook regression test plus the workout feature test slice.

## Tests run
- `bun run test src/features/workouts/hooks/use-new-workout-form-workflow.test.tsx`
- `bun run test src/features/workouts`
- `bun run tsc`
- `bun run lint`