### PR TITLE
refactor: clean up schema boundary leakage

### DIFF
--- a/client/src/features/exercises/api/exercises.ts
+++ b/client/src/features/exercises/api/exercises.ts
@@ -12,6 +12,10 @@ import {
   getExercisesQueryKey,
   getExercisesByIdQueryKey,
 } from "@/client/@tanstack/react-query.gen";
+import {
+  deleteDemoExercisesByIdMutationWithMeta,
+  patchDemoExercisesByIdMutation,
+} from "@/lib/demo-data/query-options";
 
 export type DbExercise = Pick<ExerciseExerciseResponse, "id" | "name">;
 
@@ -44,6 +48,15 @@ export function exerciseMetricsHistoryQueryOptions(
   });
 }
 
+function invalidateExerciseDetail(id: number) {
+  queryClient.invalidateQueries({
+    queryKey: getExercisesQueryKey(),
+  });
+  queryClient.invalidateQueries({
+    queryKey: getExercisesByIdQueryKey({ path: { id } }),
+  });
+}
+
 export function useDeleteExerciseMutation() {
   return useMutation({
     ...deleteExercisesByIdMutation(),
@@ -59,18 +72,40 @@ export function useDeleteExerciseMutation() {
   });
 }
 
+export function useDeleteExerciseForModeMutation(isDemoMode: boolean) {
+  const apiMutation = useDeleteExerciseMutation();
+  const demoMutation = useMutation(deleteDemoExercisesByIdMutationWithMeta());
+
+  return isDemoMode ? demoMutation : apiMutation;
+}
+
 export function useUpdateExerciseMutation() {
   return useMutation({
     ...patchExercisesByIdMutation(),
     onSuccess: (_, { path: { id } }) => {
-      queryClient.invalidateQueries({
-        queryKey: getExercisesQueryKey(),
-      });
-      queryClient.invalidateQueries({
-        queryKey: getExercisesByIdQueryKey({ path: { id } }),
-      });
+      invalidateExerciseDetail(id);
     },
   });
+}
+
+export function useRenameExerciseMutation(isDemoMode: boolean) {
+  const apiMutation = useMutation({
+    ...patchExercisesByIdMutation(),
+    onSuccess: (_, { path: { id } }) => {
+      invalidateExerciseDetail(id);
+    },
+    onError: () => {
+      // The edit dialog renders duplicate-name errors inline and other errors as a toast.
+    },
+  });
+  const demoMutation = useMutation({
+    ...patchDemoExercisesByIdMutation(),
+    onError: () => {
+      // The edit dialog owns the user-facing error message.
+    },
+  });
+
+  return isDemoMode ? demoMutation : apiMutation;
 }
 
 export function useUpdateExerciseHistorical1RmMutation() {

--- a/client/src/features/exercises/components/exercise-delete-dialog.tsx
+++ b/client/src/features/exercises/components/exercise-delete-dialog.tsx
@@ -10,9 +10,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useState } from "react";
 import { useRouter } from "@tanstack/react-router";
-import { useMutation } from "@tanstack/react-query";
-import { useDeleteExerciseMutation } from "@/features/exercises/api/exercises";
-import { deleteDemoExercisesByIdMutationWithMeta } from "@/lib/demo-data/query-options";
+import { useDeleteExerciseForModeMutation } from "@/features/exercises/api/exercises";
 import { showErrorToast } from "@/lib/errors";
 import { toast } from "sonner";
 
@@ -32,11 +30,7 @@ export function ExerciseDeleteDialog({
   const [isDeleting, setIsDeleting] = useState(false);
   const router = useRouter();
 
-  const authDeleteMutation = useDeleteExerciseMutation();
-  const demoDeleteMutation = useMutation(
-    deleteDemoExercisesByIdMutationWithMeta(),
-  );
-  const deleteMutation = isDemoMode ? demoDeleteMutation : authDeleteMutation;
+  const deleteMutation = useDeleteExerciseForModeMutation(isDemoMode);
 
   const handleDelete = async () => {
     setIsDeleting(true);

--- a/client/src/features/exercises/components/exercise-edit-dialog.tsx
+++ b/client/src/features/exercises/components/exercise-edit-dialog.tsx
@@ -9,16 +9,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
-import {
-  patchExercisesByIdMutation,
-  getExercisesQueryKey,
-  getExercisesByIdQueryKey,
-} from "@/client/@tanstack/react-query.gen";
-import { patchDemoExercisesByIdMutation } from "@/lib/demo-data/query-options";
+import { useRenameExerciseMutation } from "@/features/exercises/api/exercises";
 import { isApiError, getErrorMessage } from "@/lib/errors";
 import { toast } from "sonner";
-import { queryClient } from "@/lib/api/api";
 
 interface ExerciseEditDialogProps {
   isOpen: boolean;
@@ -39,31 +32,7 @@ export function ExerciseEditDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Override global error handler to prevent double toasts
-  // We handle errors manually in the catch block below
-  const authUpdateMutation = useMutation({
-    ...patchExercisesByIdMutation(),
-    onSuccess: (_, { path: { id } }) => {
-      queryClient.invalidateQueries({
-        queryKey: getExercisesQueryKey(),
-      });
-      queryClient.invalidateQueries({
-        queryKey: getExercisesByIdQueryKey({ path: { id } }),
-      });
-    },
-    onError: () => {
-      // Don't show toast - we handle errors manually
-    },
-  });
-
-  const demoUpdateMutation = useMutation({
-    ...patchDemoExercisesByIdMutation(),
-    onError: () => {
-      // Don't show toast - we handle errors manually
-    },
-  });
-
-  const updateMutation = isDemoMode ? demoUpdateMutation : authUpdateMutation;
+  const updateMutation = useRenameExerciseMutation(isDemoMode);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/client/src/features/workouts/api/workouts.ts
+++ b/client/src/features/workouts/api/workouts.ts
@@ -1,4 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
+import type { CurrentInternalUser, CurrentUser } from "@stackframe/react";
 import { queryClient } from "@/lib/api/api";
 import {
   getExercisesQueryKey,
@@ -23,10 +24,17 @@ import type {
   WorkoutWorkoutWithSetsResponse,
 } from "@/client";
 import { sortByExerciseAndSetOrder } from "@/lib/utils";
+import {
+  deleteDemoWorkoutsByIdMutationWithMeta,
+  postDemoWorkoutsMutation,
+  putDemoWorkoutsByIdMutation,
+} from "@/lib/demo-data/query-options";
 
 export type WorkoutFocus = {
   name: string;
 };
+
+type WorkoutMutationUser = CurrentUser | CurrentInternalUser | null;
 
 // MARK: Get all
 export function workoutsQueryOptions() {
@@ -82,6 +90,13 @@ export function useSaveWorkoutMutation() {
   });
 }
 
+export function useSaveWorkoutForUserMutation(user: WorkoutMutationUser) {
+  const apiMutation = useSaveWorkoutMutation();
+  const demoMutation = useMutation(postDemoWorkoutsMutation());
+
+  return user ? apiMutation : demoMutation;
+}
+
 // MARK: Update
 export function useUpdateWorkoutMutation() {
   return useMutation({
@@ -96,6 +111,13 @@ export function useUpdateWorkoutMutation() {
       invalidateWorkoutAnalyticsQueries();
     },
   });
+}
+
+export function useUpdateWorkoutForUserMutation(user: WorkoutMutationUser) {
+  const apiMutation = useUpdateWorkoutMutation();
+  const demoMutation = useMutation(putDemoWorkoutsByIdMutation());
+
+  return user ? apiMutation : demoMutation;
 }
 
 // MARK: Delete
@@ -117,6 +139,13 @@ export function useDeleteWorkoutMutation() {
       invalidateWorkoutAnalyticsQueries();
     },
   });
+}
+
+export function useDeleteWorkoutForUserMutation(user: WorkoutMutationUser) {
+  const apiMutation = useDeleteWorkoutMutation();
+  const demoMutation = useMutation(deleteDemoWorkoutsByIdMutationWithMeta());
+
+  return user ? apiMutation : demoMutation;
 }
 
 // MARK: Utils

--- a/client/src/features/workouts/components/form/delete-dialog.tsx
+++ b/client/src/features/workouts/components/form/delete-dialog.tsx
@@ -10,9 +10,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useState } from "react";
 import { useRouter, useRouteContext } from "@tanstack/react-router";
-import { useMutation } from "@tanstack/react-query";
-import { useDeleteWorkoutMutation } from "@/features/workouts/api/workouts";
-import { deleteDemoWorkoutsByIdMutationWithMeta } from "@/lib/demo-data/query-options";
+import { useDeleteWorkoutForUserMutation } from "@/features/workouts/api/workouts";
 import { getErrorMessage } from "@/lib/errors";
 import { toast } from "sonner";
 
@@ -31,11 +29,7 @@ export function DeleteDialog({
   const router = useRouter();
   const { user } = useRouteContext({ from: "/_layout/workouts/$workoutId/" });
 
-  const authDeleteMutation = useDeleteWorkoutMutation();
-  const demoDeleteMutation = useMutation(
-    deleteDemoWorkoutsByIdMutationWithMeta(),
-  );
-  const deleteMutation = user ? authDeleteMutation : demoDeleteMutation;
+  const deleteMutation = useDeleteWorkoutForUserMutation(user);
 
   const handleDelete = async () => {
     setIsDeleting(true);

--- a/client/src/features/workouts/hooks/use-new-workout-form-workflow.test.tsx
+++ b/client/src/features/workouts/hooks/use-new-workout-form-workflow.test.tsx
@@ -21,12 +21,10 @@ vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => mockNavigate,
 }));
 
-vi.mock("@tanstack/react-query", () => ({
-  useMutation: () => ({ mutateAsync: mockDemoMutateAsync }),
-}));
-
 vi.mock("@/features/workouts/api/workouts", () => ({
-  useSaveWorkoutMutation: () => ({ mutateAsync: mockApiMutateAsync }),
+  useSaveWorkoutForUserMutation: (user: unknown) => ({
+    mutateAsync: user ? mockApiMutateAsync : mockDemoMutateAsync,
+  }),
 }));
 
 vi.mock("@/lib/api/api", () => ({
@@ -39,10 +37,6 @@ vi.mock("@/features/workouts/api/workout-query-options", () => ({
   getWorkoutByIdQueryOptions: (_user: unknown, workoutId: number) => ({
     queryKey: ["workout", workoutId],
   }),
-}));
-
-vi.mock("@/lib/demo-data/query-options", () => ({
-  postDemoWorkoutsMutation: () => ({}),
 }));
 
 vi.mock("sonner", () => ({

--- a/client/src/features/workouts/hooks/use-new-workout-form-workflow.ts
+++ b/client/src/features/workouts/hooks/use-new-workout-form-workflow.ts
@@ -1,5 +1,4 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useMutation } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import type { CurrentInternalUser, CurrentUser } from "@stackframe/react";
 import { toast } from "sonner";
@@ -9,7 +8,7 @@ import {
   formatExerciseGoalSummary,
   getExerciseGoal,
 } from "@/features/exercises/utils/exercise-goals";
-import { useSaveWorkoutMutation } from "@/features/workouts/api/workouts";
+import { useSaveWorkoutForUserMutation } from "@/features/workouts/api/workouts";
 import {
   getInitialValues,
   MOCK_VALUES,
@@ -19,7 +18,6 @@ import { buildWorkoutDraftFromHistory } from "@/features/workouts/utils/workout-
 import { useAppForm } from "@/hooks/form";
 import { queryClient } from "@/lib/api/api";
 import { getWorkoutByIdQueryOptions } from "@/features/workouts/api/workout-query-options";
-import { postDemoWorkoutsMutation } from "@/lib/demo-data/query-options";
 import {
   type WorkoutDraftStorage,
   workoutDraftStorage,
@@ -42,9 +40,7 @@ export function useNewWorkoutFormWorkflow({
     number | null
   >(null);
 
-  const saveWorkoutApi = useSaveWorkoutMutation();
-  const saveWorkoutDemo = useMutation(postDemoWorkoutsMutation());
-  const saveWorkout = user ? saveWorkoutApi : saveWorkoutDemo;
+  const saveWorkout = useSaveWorkoutForUserMutation(user);
   const form = useAppForm({
     defaultValues: getInitialValues(user?.id, draftStorage),
     listeners: {

--- a/client/src/features/workouts/pages/edit-workout-page.tsx
+++ b/client/src/features/workouts/pages/edit-workout-page.tsx
@@ -1,11 +1,9 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
-  useUpdateWorkoutMutation,
+  useUpdateWorkoutForUserMutation,
   type WorkoutFocus,
 } from "@/features/workouts/api/workouts";
-import { putDemoWorkoutsByIdMutation } from "@/lib/demo-data/query-options";
 import type { CurrentUser, CurrentInternalUser } from "@stackframe/react";
 import { Suspense } from "react";
 import { useAppForm } from "@/hooks/form";
@@ -96,9 +94,7 @@ export function EditWorkoutPage({
   const { addExercise, exerciseIndex, newExercise } = search;
   const navigate = useNavigate({ from: "/workouts/$workoutId/edit" });
 
-  const updateWorkoutApi = useUpdateWorkoutMutation();
-  const updateWorkoutDemo = useMutation(putDemoWorkoutsByIdMutation());
-  const updateWorkoutMutation = user ? updateWorkoutApi : updateWorkoutDemo;
+  const updateWorkoutMutation = useUpdateWorkoutForUserMutation(user);
 
   const form = useAppForm({
     defaultValues: workout,


### PR DESCRIPTION
## User impact
- No product behavior changes: authenticated workout/exercise writes still use the API, and demo users still use local demo data.
- Workout and exercise screens are easier to review because UI code no longer imports low-level demo mutation plumbing directly.

## Behavior preserved
- Workout create, update, and delete keep the same success handling, navigation, cache invalidation, and demo/API source selection.
- Exercise rename and delete keep the same inline/toast error handling and cache refresh behavior.

## Risk
- Low. This is a boundary cleanup that moves existing mutation selection into feature API modules without changing request payloads or generated client files.

## Tests run
- `bun run tsc`
- `bun run lint`
- `bun run test src/features/workouts/hooks/use-new-workout-form-workflow.test.tsx src/features/workouts/api/workouts.test.ts`
- `bun run test`
- `bun run build`

## Notes
- Build still reports the existing large chunk-size warning.
- Server/Go tests were not run because this PR does not touch server code.