### PR TITLE
fix: expose product-shaped billing cancellation state

### DIFF
--- a/client/src/features/chat/api/billing.test.ts
+++ b/client/src/features/chat/api/billing.test.ts
@@ -61,7 +61,7 @@ describe("billing api wrapper", () => {
           subscription: {
             stripe_subscription_id: "sub_123",
             status: "trialing",
-            cancel_at_period_end: false,
+            cancellation_scheduled: false,
           },
           trial_usage: {
             used: 3,

--- a/client/src/features/chat/api/billing.ts
+++ b/client/src/features/chat/api/billing.ts
@@ -15,9 +15,8 @@ export type BillingSubscriptionStatus =
 export type BillingSubscription = {
   stripe_subscription_id: string;
   status: BillingSubscriptionStatus;
-  cancel_at_period_end: boolean;
-  cancel_at?: string;
-  current_period_end?: string;
+  cancellation_scheduled: boolean;
+  access_ends_at?: string;
   trial_end?: string;
 };
 

--- a/client/src/features/chat/components/ai-chat-billing-card.test.tsx
+++ b/client/src/features/chat/components/ai-chat-billing-card.test.tsx
@@ -138,7 +138,7 @@ describe("AIChatBillingCard", () => {
       subscription: {
         stripe_subscription_id: "sub_trial",
         status: "trialing",
-        cancel_at_period_end: false,
+        cancellation_scheduled: false,
       },
       trial_usage: {
         used: 12,
@@ -171,7 +171,7 @@ describe("AIChatBillingCard", () => {
       subscription: {
         stripe_subscription_id: "sub_active",
         status: "active",
-        cancel_at_period_end: false,
+        cancellation_scheduled: false,
       },
     });
 
@@ -198,7 +198,7 @@ describe("AIChatBillingCard", () => {
       subscription: {
         stripe_subscription_id: "sub_active",
         status: "active",
-        cancel_at_period_end: false,
+        cancellation_scheduled: false,
       },
     } satisfies BillingStatusResponse;
     const props = {
@@ -261,7 +261,7 @@ describe("AIChatBillingCard", () => {
         subscription: {
           stripe_subscription_id: "sub_past_due",
           status: "past_due",
-          cancel_at_period_end: false,
+          cancellation_scheduled: false,
         },
       },
       { accessState: "ready" },
@@ -294,7 +294,7 @@ describe("AIChatBillingCard", () => {
         subscription: {
           stripe_subscription_id: "sub_active",
           status: "active",
-          cancel_at_period_end: false,
+          cancellation_scheduled: false,
         },
       },
       { accessState: "activating" },
@@ -323,8 +323,8 @@ describe("AIChatBillingCard", () => {
       subscription: {
         stripe_subscription_id: "sub_cancel_later",
         status: "active",
-        cancel_at_period_end: true,
-        current_period_end: "2026-05-30T12:00:00Z",
+        cancellation_scheduled: true,
+        access_ends_at: "2026-05-30T12:00:00Z",
       },
     });
 
@@ -336,16 +336,15 @@ describe("AIChatBillingCard", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows scheduled cancellation access messaging from cancel_at", () => {
+  it("shows scheduled cancellation access messaging from access end", () => {
     renderCard({
       feature_key: "ai_chatbot",
       has_access: true,
       subscription: {
         stripe_subscription_id: "sub_cancel_at",
         status: "active",
-        cancel_at_period_end: false,
-        cancel_at: "2026-07-10T12:00:00Z",
-        current_period_end: "2026-07-10T12:00:00Z",
+        cancellation_scheduled: true,
+        access_ends_at: "2026-07-10T12:00:00Z",
       },
     });
 
@@ -364,9 +363,8 @@ describe("AIChatBillingCard", () => {
       subscription: {
         stripe_subscription_id: "sub_cancel_at_after_period",
         status: "active",
-        cancel_at_period_end: false,
-        cancel_at: "2026-07-10T03:39:36Z",
-        current_period_end: "2026-06-30T12:00:00Z",
+        cancellation_scheduled: true,
+        access_ends_at: "2026-06-30T12:00:00Z",
       },
     });
 
@@ -391,7 +389,7 @@ describe("AIChatBillingCard", () => {
         subscription: {
           stripe_subscription_id: `sub_${subscriptionStatus}`,
           status: subscriptionStatus,
-          cancel_at_period_end: false,
+          cancellation_scheduled: false,
         },
       });
 
@@ -418,7 +416,7 @@ describe("AIChatBillingCard", () => {
         subscription: {
           stripe_subscription_id: `sub_${subscriptionStatus}`,
           status: subscriptionStatus,
-          cancel_at_period_end: false,
+          cancellation_scheduled: false,
         },
       });
 

--- a/client/src/features/chat/components/ai-chat-billing-card.tsx
+++ b/client/src/features/chat/components/ai-chat-billing-card.tsx
@@ -520,53 +520,21 @@ function blockedStatusMessage(status?: BillingSubscriptionStatus): string {
 function getCancellationMessage(
   subscription?: BillingSubscription,
 ): string | null {
-  if (!subscription || !isSubscriptionCancellationScheduled(subscription)) {
+  if (!subscription || !subscription.cancellation_scheduled) {
     return null;
   }
 
-  const accessEnd = getScheduledCancellationAccessEnd(subscription);
-  if (!accessEnd) {
+  if (!subscription.access_ends_at) {
     return "Access continues until the end of the current billing period.";
   }
 
-  return `Access continues until ${formatBillingDate(accessEnd)}.`;
-}
-
-function getScheduledCancellationAccessEnd(
-  subscription: BillingSubscription,
-): string | undefined {
-  const candidates = [
-    subscription.cancel_at,
-    subscription.current_period_end,
-  ].filter((value): value is string => Boolean(value));
-
-  return candidates.reduce<string | undefined>((earliest, candidate) => {
-    if (!earliest) {
-      return candidate;
-    }
-
-    const earliestTime = parseBillingTime(earliest);
-    const candidateTime = parseBillingTime(candidate);
-    if (earliestTime === null) {
-      return candidateTime === null ? earliest : candidate;
-    }
-    if (candidateTime === null) {
-      return earliest;
-    }
-
-    return candidateTime < earliestTime ? candidate : earliest;
-  }, undefined);
-}
-
-function parseBillingTime(value: string): number | null {
-  const time = Date.parse(value);
-  return Number.isNaN(time) ? null : time;
+  return `Access continues until ${formatBillingDate(subscription.access_ends_at)}.`;
 }
 
 function isSubscriptionCancellationScheduled(
   subscription: BillingSubscription,
 ): boolean {
-  return subscription.cancel_at_period_end || Boolean(subscription.cancel_at);
+  return subscription.cancellation_scheduled;
 }
 
 function formatBillingDate(value: string): string {

--- a/client/src/features/chat/hooks/use-ai-chat-billing-access.hook.test.tsx
+++ b/client/src/features/chat/hooks/use-ai-chat-billing-access.hook.test.tsx
@@ -71,7 +71,7 @@ const activeBillingStatus: BillingStatusResponse = {
   subscription: {
     stripe_subscription_id: "sub_active",
     status: "active",
-    cancel_at_period_end: false,
+    cancellation_scheduled: false,
   },
 };
 
@@ -322,8 +322,8 @@ describe("useAIChatBillingAccess checkout polling", () => {
         ...activeBillingStatus,
         subscription: {
           ...activeBillingStatus.subscription!,
-          cancel_at_period_end: true,
-          current_period_end: "2026-06-10T12:00:00Z",
+          cancellation_scheduled: true,
+          access_ends_at: "2026-06-10T12:00:00Z",
         },
       });
     mocks.mockGetCheckoutFeatureAccess.mockResolvedValue([aiChatFeatureGrant]);
@@ -335,22 +335,21 @@ describe("useAIChatBillingAccess checkout polling", () => {
 
     await waitFor(() => {
       expect(
-        result.current.billingStatus?.subscription?.cancel_at_period_end,
+        result.current.billingStatus?.subscription?.cancellation_scheduled,
       ).toBe(true);
     });
     expect(mocks.mockGetCheckoutBillingStatus).toHaveBeenCalledTimes(2);
   });
 
-  it("treats cancel_at as reflected cancellation on portal return", async () => {
+  it("treats scheduled cancellation as reflected on portal return", async () => {
     mocks.mockGetBaseBillingStatus.mockResolvedValue(activeBillingStatus);
     mocks.mockGetBaseFeatureAccess.mockResolvedValue([aiChatFeatureGrant]);
     mocks.mockGetCheckoutBillingStatus.mockResolvedValue({
       ...activeBillingStatus,
       subscription: {
         ...activeBillingStatus.subscription!,
-        cancel_at_period_end: false,
-        cancel_at: "2026-07-10T12:00:00Z",
-        current_period_end: "2026-07-10T12:00:00Z",
+        cancellation_scheduled: true,
+        access_ends_at: "2026-07-10T12:00:00Z",
       },
     });
     mocks.mockGetCheckoutFeatureAccess.mockResolvedValue([aiChatFeatureGrant]);
@@ -361,7 +360,7 @@ describe("useAIChatBillingAccess checkout polling", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.billingStatus?.subscription?.cancel_at).toBe(
+      expect(result.current.billingStatus?.subscription?.access_ends_at).toBe(
         "2026-07-10T12:00:00Z",
       );
     });

--- a/client/src/features/chat/hooks/use-ai-chat-billing-access.test.ts
+++ b/client/src/features/chat/hooks/use-ai-chat-billing-access.test.ts
@@ -33,7 +33,7 @@ describe("resolveAIChatAccessView", () => {
         subscription: {
           stripe_subscription_id: "sub_active",
           status: "active",
-          cancel_at_period_end: false,
+          cancellation_scheduled: false,
         },
       },
       featureAccess: [],
@@ -65,7 +65,7 @@ describe("resolveAIChatAccessView", () => {
           subscription: {
             stripe_subscription_id: "sub_active",
             status: "active",
-            cancel_at_period_end: false,
+            cancellation_scheduled: false,
           },
         },
         featureAccess: [],

--- a/client/src/features/chat/hooks/use-ai-chat-billing-access.ts
+++ b/client/src/features/chat/hooks/use-ai-chat-billing-access.ts
@@ -621,8 +621,7 @@ function isBillingCancellationReflected(
   const subscription = billingStatus.subscription;
   return (
     !subscription ||
-    subscription.cancel_at_period_end ||
-    Boolean(subscription.cancel_at) ||
+    subscription.cancellation_scheduled ||
     subscription.status === "canceled"
   );
 }

--- a/client/src/features/chat/pages/chat-billing-page-usage.test.tsx
+++ b/client/src/features/chat/pages/chat-billing-page-usage.test.tsx
@@ -23,7 +23,7 @@ describe("ChatRouteComponent billing usage", () => {
         subscription: {
           stripe_subscription_id: "sub_trial",
           status: "trialing",
-          cancel_at_period_end: false,
+          cancellation_scheduled: false,
         },
         trial_usage: {
           used: 1,

--- a/client/src/features/chat/pages/chat-billing-page.test.tsx
+++ b/client/src/features/chat/pages/chat-billing-page.test.tsx
@@ -58,7 +58,7 @@ describe("ChatRouteComponent", () => {
           subscription: {
             stripe_subscription_id: "sub_123",
             status: "active",
-            cancel_at_period_end: false,
+            cancellation_scheduled: false,
           },
         },
         featureAccess: [{ feature_key: "ai_chatbot" }],
@@ -107,7 +107,7 @@ describe("ChatRouteComponent", () => {
           subscription: {
             stripe_subscription_id: "sub_active",
             status: "active",
-            cancel_at_period_end: false,
+            cancellation_scheduled: false,
           },
         },
         featureAccess: [],
@@ -252,7 +252,7 @@ describe("ChatRouteComponent", () => {
         subscription: {
           stripe_subscription_id: "sub_active",
           status: "active",
-          cancel_at_period_end: false,
+          cancellation_scheduled: false,
         },
       },
       isLoading: false,
@@ -289,7 +289,7 @@ describe("ChatRouteComponent", () => {
         subscription: {
           stripe_subscription_id: "sub_active",
           status: "active",
-          cancel_at_period_end: false,
+          cancellation_scheduled: false,
         },
       },
       isLoading: false,
@@ -370,8 +370,8 @@ describe("ChatRouteComponent", () => {
           subscription: {
             stripe_subscription_id: "sub_active",
             status: "active",
-            cancel_at_period_end: true,
-            current_period_end: "2026-06-10T12:00:00Z",
+            cancellation_scheduled: true,
+            access_ends_at: "2026-06-10T12:00:00Z",
           },
         },
         featureAccess: [{ feature_key: "ai_chatbot" }],
@@ -392,7 +392,7 @@ describe("ChatRouteComponent", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("uses cancel_at polling data after Stripe returns from scheduled cancellation", async () => {
+  it("uses access-end polling data after Stripe returns from scheduled cancellation", async () => {
     mockSearch.billing = "cancelled";
     mockBillingCancellationQueryResult.value = {
       data: {
@@ -402,9 +402,8 @@ describe("ChatRouteComponent", () => {
           subscription: {
             stripe_subscription_id: "sub_active",
             status: "active",
-            cancel_at_period_end: false,
-            cancel_at: "2026-07-10T12:00:00Z",
-            current_period_end: "2026-07-10T12:00:00Z",
+            cancellation_scheduled: true,
+            access_ends_at: "2026-07-10T12:00:00Z",
           },
         },
         featureAccess: [{ feature_key: "ai_chatbot" }],
@@ -541,7 +540,7 @@ describe("ChatRouteComponent", () => {
         subscription: {
           stripe_subscription_id: "sub_past_due",
           status: "past_due",
-          cancel_at_period_end: false,
+          cancellation_scheduled: false,
         },
       },
       isLoading: false,

--- a/client/src/features/chat/test/chat-page-test-utils.tsx
+++ b/client/src/features/chat/test/chat-page-test-utils.tsx
@@ -217,7 +217,7 @@ export function resetChatRouteMocks() {
       subscription: {
         stripe_subscription_id: "sub_123",
         status: "active",
-        cancel_at_period_end: false,
+        cancellation_scheduled: false,
       },
     },
     isLoading: false,

--- a/server/internal/billing/models.go
+++ b/server/internal/billing/models.go
@@ -44,12 +44,11 @@ type StatusResponse struct {
 }
 
 type SubscriptionView struct {
-	StripeSubscriptionID string     `json:"stripe_subscription_id"`
-	Status               string     `json:"status"`
-	CancelAtPeriodEnd    bool       `json:"cancel_at_period_end"`
-	CancelAt             *time.Time `json:"cancel_at,omitempty"`
-	CurrentPeriodEnd     *time.Time `json:"current_period_end,omitempty"`
-	TrialEnd             *time.Time `json:"trial_end,omitempty"`
+	StripeSubscriptionID  string     `json:"stripe_subscription_id"`
+	Status                string     `json:"status"`
+	CancellationScheduled bool       `json:"cancellation_scheduled"`
+	AccessEndsAt          *time.Time `json:"access_ends_at,omitempty"`
+	TrialEnd              *time.Time `json:"trial_end,omitempty"`
 }
 
 type TrialUsageView struct {

--- a/server/internal/billing/service.go
+++ b/server/internal/billing/service.go
@@ -513,12 +513,14 @@ func normalizedTimePtr(value *time.Time) *time.Time {
 
 func subscriptionView(row db.StripeSubscriptions) *SubscriptionView {
 	return &SubscriptionView{
-		StripeSubscriptionID: row.StripeSubscriptionID,
-		Status:               row.Status,
-		CancelAtPeriodEnd:    row.CancelAtPeriodEnd,
-		CancelAt:             timePtrFromPg(row.CancelAt),
-		CurrentPeriodEnd:     timePtrFromPg(row.CurrentPeriodEnd),
-		TrialEnd:             timePtrFromPg(row.TrialEnd),
+		StripeSubscriptionID:  row.StripeSubscriptionID,
+		Status:                row.Status,
+		CancellationScheduled: subscriptionCancelScheduled(row),
+		AccessEndsAt: subscriptionAccessEnd(
+			timePtrFromPg(row.CancelAt),
+			timePtrFromPg(row.CurrentPeriodEnd),
+		),
+		TrialEnd: timePtrFromPg(row.TrialEnd),
 	}
 }
 

--- a/server/internal/billing/service_test.go
+++ b/server/internal/billing/service_test.go
@@ -361,10 +361,13 @@ func TestServiceCurrentStatus_AccessRules(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantAccess, resp.HasAccess)
 			require.NotNil(t, resp.Subscription)
-			assert.Equal(t, tt.canceling, resp.Subscription.CancelAtPeriodEnd)
-			if tt.cancelAt != nil {
-				require.NotNil(t, resp.Subscription.CancelAt)
-				assert.Equal(t, tt.cancelAt.UTC(), resp.Subscription.CancelAt.UTC())
+			assert.Equal(t, tt.canceling || tt.cancelAt != nil, resp.Subscription.CancellationScheduled)
+			if tt.cancelAt != nil && tt.cancelAt.Before(tt.periodEnd) {
+				require.NotNil(t, resp.Subscription.AccessEndsAt)
+				assert.Equal(t, tt.cancelAt.UTC(), resp.Subscription.AccessEndsAt.UTC())
+			} else {
+				require.NotNil(t, resp.Subscription.AccessEndsAt)
+				assert.Equal(t, tt.periodEnd.UTC(), resp.Subscription.AccessEndsAt.UTC())
 			}
 			repo.AssertExpectations(t)
 		})


### PR DESCRIPTION
## Summary
- Replace client-facing Stripe cancellation fields with product-shaped `cancellation_scheduled` and `access_ends_at`
- Keep Stripe snapshot data server-side while deriving the API response from existing subscription access rules
- Update chat billing UI, polling behavior, and tests to use the product contract

## Verification
- `go test ./internal/billing`
- `bun run tsc`
- `bun run test src/features/chat/components/ai-chat-billing-card.test.tsx src/features/chat/hooks/use-ai-chat-billing-access.hook.test.tsx src/features/chat/hooks/use-ai-chat-billing-access.test.ts src/features/chat/api/billing.test.ts src/features/chat/pages/chat-billing-page.test.tsx src/features/chat/pages/chat-billing-page-usage.test.tsx`
- `bunx oxfmt --check src/features/chat/api/billing.ts src/features/chat/api/billing.test.ts src/features/chat/components/ai-chat-billing-card.tsx src/features/chat/components/ai-chat-billing-card.test.tsx src/features/chat/hooks/use-ai-chat-billing-access.ts src/features/chat/hooks/use-ai-chat-billing-access.hook.test.tsx src/features/chat/hooks/use-ai-chat-billing-access.test.ts src/features/chat/pages/chat-billing-page.test.tsx src/features/chat/pages/chat-billing-page-usage.test.tsx src/features/chat/test/chat-page-test-utils.tsx`
- `bun run lint`
- `bun run build`

## Notes
- `go test ./...` and the normal pre-push hook need local Docker/Postgres; Docker Desktop was unavailable on this machine, so DB-backed integration tests could not run locally.