### PR TITLE
feat: add backend account deletion

### DIFF
--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -31,6 +31,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Andrewy-gh/fittrack/server/internal/account"
 	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
 	"github.com/Andrewy-gh/fittrack/server/internal/auth"
 	"github.com/Andrewy-gh/fittrack/server/internal/billing"
@@ -151,6 +152,7 @@ func main() {
 	// Initialize repositories
 	exerciseRepo := exercise.NewRepository(logger, queries, pool)
 	featureAccessRepo := featureaccess.NewRepository(logger, queries)
+	accountRepo := account.NewRepository(logger, queries)
 	billingRepo := billing.NewRepository(logger, queries, pool)
 	workoutRepo := workout.NewRepository(logger, queries, pool, exerciseRepo)
 	userRepo := user.NewRepository(logger, queries, pool)
@@ -169,6 +171,7 @@ func main() {
 		cfg.AppBaseURL,
 		cfg.AIChatTrialPromptCap,
 	)
+	accountService := account.NewService(logger, accountRepo, billingService)
 	userService := user.NewService(logger, userRepo)
 	aiChatRepo := aichat.NewRepository(logger, queries, pool, cfg.AIChatTrialPromptCap)
 	aiChatRuntime := aichat.NewGenkitRuntime(ctx)
@@ -192,6 +195,7 @@ func main() {
 	workoutHandler := workout.NewHandler(logger, validator, workoutService)
 	exerciseHandler := exercise.NewHandler(logger, validator, exerciseService)
 	featureAccessHandler := featureaccess.NewHandler(logger, featureAccessService)
+	accountHandler := account.NewHandler(logger, accountService)
 	billingHandler := billing.NewHandler(logger, billingService)
 	healthHandler := health.NewHandler(logger, pool)
 	aiChatHandler := aichat.NewHandler(logger, aiChatService)
@@ -232,7 +236,7 @@ func main() {
 			UserID:  cfg.LocalE2EAuthUserID,
 		})
 	}
-	router := api.routes(workoutHandler, exerciseHandler, featureAccessHandler, healthHandler, aiChatHandler, billingHandler, e2eAuthHandler)
+	router := api.routes(workoutHandler, exerciseHandler, featureAccessHandler, healthHandler, aiChatHandler, billingHandler, accountHandler, e2eAuthHandler)
 
 	// Apply middleware in order: SecurityHeaders → CORS → RequestID → RequestLog → Metrics → Authentication → RateLimit
 	var handler http.Handler = router

--- a/server/cmd/api/routes.go
+++ b/server/cmd/api/routes.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/Andrewy-gh/fittrack/server/internal/account"
 	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
 	"github.com/Andrewy-gh/fittrack/server/internal/billing"
 	"github.com/Andrewy-gh/fittrack/server/internal/e2eauth"
@@ -17,7 +18,7 @@ import (
 	httpSwagger "github.com/swaggo/http-swagger"
 )
 
-func (api *api) routes(wh *workout.WorkoutHandler, eh *exercise.ExerciseHandler, fh *featureaccess.Handler, hh *health.Handler, ah *aichat.Handler, bh *billing.Handler, e2eh *e2eauth.Handler) *http.ServeMux {
+func (api *api) routes(wh *workout.WorkoutHandler, eh *exercise.ExerciseHandler, fh *featureaccess.Handler, hh *health.Handler, ah *aichat.Handler, bh *billing.Handler, accountHandler *account.Handler, e2eh *e2eauth.Handler) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// Health endpoints (no authentication required)
@@ -49,6 +50,9 @@ func (api *api) routes(wh *workout.WorkoutHandler, eh *exercise.ExerciseHandler,
 	mux.HandleFunc("GET /api/workouts/contribution-data", wh.GetContributionData)
 	mux.HandleFunc("GET /api/exercises", eh.ListExercises)
 	mux.HandleFunc("GET /api/features/access", fh.ListActiveFeatureAccess)
+	if accountHandler != nil {
+		mux.HandleFunc("DELETE /api/account", accountHandler.DeleteAccount)
+	}
 	if bh != nil {
 		mux.HandleFunc("POST /api/billing/checkout-session", bh.CreateCheckoutSession)
 		mux.HandleFunc("POST /api/billing/customer-portal-session", bh.CreateCustomerPortalSession)

--- a/server/cmd/api/routes_test.go
+++ b/server/cmd/api/routes_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Andrewy-gh/fittrack/server/internal/account"
 	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
 	"github.com/Andrewy-gh/fittrack/server/internal/billing"
 	"github.com/Andrewy-gh/fittrack/server/internal/config"
@@ -19,6 +20,8 @@ import (
 )
 
 type routeBillingService struct{}
+
+type routeAccountService struct{}
 
 func (routeBillingService) CreateCheckoutSession(context.Context) (*billing.CheckoutSessionResponse, error) {
 	return &billing.CheckoutSessionResponse{URL: "https://checkout.stripe.test/session"}, nil
@@ -37,6 +40,10 @@ func (routeBillingService) CurrentStatus(context.Context) (*billing.StatusRespon
 }
 
 func (routeBillingService) HandleWebhook(context.Context, []byte, string) error {
+	return nil
+}
+
+func (routeAccountService) DeleteCurrentUser(context.Context) error {
 	return nil
 }
 
@@ -62,7 +69,7 @@ func TestRoutes_AllowsInngestHandlerAlongsideStaticFallback(t *testing.T) {
 		}
 	}()
 
-	_ = api.routes(wh, eh, fh, hh, ah, nil, nil)
+	_ = api.routes(wh, eh, fh, hh, ah, nil, nil, nil)
 }
 
 func TestRoutes_RegistersPutForInngestHandler(t *testing.T) {
@@ -87,7 +94,7 @@ func TestRoutes_RegistersPutForInngestHandler(t *testing.T) {
 	hh := health.NewHandler(logger, nil)
 	ah := aichat.NewHandler(logger, nil)
 
-	mux := api.routes(wh, eh, fh, hh, ah, nil, nil)
+	mux := api.routes(wh, eh, fh, hh, ah, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPut, "/inngest", nil)
 	rr := httptest.NewRecorder()
 
@@ -115,7 +122,7 @@ func TestRoutes_DoesNotExposeAIChatValidationEndpoints(t *testing.T) {
 	hh := health.NewHandler(logger, nil)
 	ah := aichat.NewHandler(logger, nil)
 
-	mux := api.routes(wh, eh, fh, hh, ah, nil, nil)
+	mux := api.routes(wh, eh, fh, hh, ah, nil, nil, nil)
 
 	for _, path := range []string{"/api/ai/chat/validate", "/api/ai/chat/validate/stream"} {
 		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"prompt":"prove the slice"}`))
@@ -144,7 +151,7 @@ func TestRoutes_RegistersBillingCustomerPortalSession(t *testing.T) {
 	ah := aichat.NewHandler(logger, nil)
 	bh := billing.NewHandler(logger, routeBillingService{})
 
-	mux := api.routes(wh, eh, fh, hh, ah, bh, nil)
+	mux := api.routes(wh, eh, fh, hh, ah, bh, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/billing/customer-portal-session", nil)
 	rr := httptest.NewRecorder()
 
@@ -173,7 +180,7 @@ func TestRoutes_RegistersBillingSubscriptionCancelPortalSession(t *testing.T) {
 	ah := aichat.NewHandler(logger, nil)
 	bh := billing.NewHandler(logger, routeBillingService{})
 
-	mux := api.routes(wh, eh, fh, hh, ah, bh, nil)
+	mux := api.routes(wh, eh, fh, hh, ah, bh, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/billing/subscription-cancel-portal-session", nil)
 	rr := httptest.NewRecorder()
 
@@ -184,5 +191,31 @@ func TestRoutes_RegistersBillingSubscriptionCancelPortalSession(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), "https://billing.stripe.test/cancel-session") {
 		t.Fatalf("expected billing cancel portal URL response, got %s", rr.Body.String())
+	}
+}
+
+func TestRoutes_RegistersAccountDeletion(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	api := &api{
+		logger: logger,
+		cfg:    &config.Config{},
+		pool:   nil,
+	}
+
+	wh := &workout.WorkoutHandler{}
+	eh := &exercise.ExerciseHandler{}
+	fh := &featureaccess.Handler{}
+	hh := health.NewHandler(logger, nil)
+	ah := aichat.NewHandler(logger, nil)
+	accountHandler := account.NewHandler(logger, routeAccountService{})
+
+	mux := api.routes(wh, eh, fh, hh, ah, nil, accountHandler, nil)
+	req := httptest.NewRequest(http.MethodDelete, "/api/account", nil)
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusNoContent, rr.Code, rr.Body.String())
 	}
 }

--- a/server/internal/account/handler.go
+++ b/server/internal/account/handler.go
@@ -1,0 +1,48 @@
+package account
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	apperrors "github.com/Andrewy-gh/fittrack/server/internal/errors"
+	"github.com/Andrewy-gh/fittrack/server/internal/response"
+)
+
+type accountService interface {
+	DeleteCurrentUser(ctx context.Context) error
+}
+
+type Handler struct {
+	logger  *slog.Logger
+	service accountService
+}
+
+func NewHandler(logger *slog.Logger, service accountService) *Handler {
+	return &Handler{
+		logger:  logger,
+		service: service,
+	}
+}
+
+func (h *Handler) DeleteAccount(w http.ResponseWriter, r *http.Request) {
+	err := h.service.DeleteCurrentUser(r.Context())
+	if err != nil {
+		h.writeServiceError(w, r, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) writeServiceError(w http.ResponseWriter, r *http.Request, err error) {
+	var errUnauthorized *apperrors.Unauthorized
+
+	switch {
+	case errors.As(err, &errUnauthorized):
+		response.ErrorJSON(w, r, h.logger, http.StatusUnauthorized, errUnauthorized.Error(), nil)
+	default:
+		response.ErrorJSON(w, r, h.logger, http.StatusInternalServerError, "failed to delete account", err)
+	}
+}

--- a/server/internal/account/handler_test.go
+++ b/server/internal/account/handler_test.go
@@ -1,0 +1,43 @@
+package account
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubService struct {
+	err error
+}
+
+func (s stubService) DeleteCurrentUser(ctx context.Context) error {
+	return s.err
+}
+
+func TestHandlerDeleteAccount_ReturnsNoContent(t *testing.T) {
+	handler := NewHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), stubService{})
+	req := httptest.NewRequest(http.MethodDelete, "/api/account", nil)
+	rr := httptest.NewRecorder()
+
+	handler.DeleteAccount(rr, req)
+
+	require.Equal(t, http.StatusNoContent, rr.Code)
+	assert.Empty(t, rr.Body.String())
+}
+
+func TestHandlerDeleteAccount_ServiceFailureReturnsInternalServerError(t *testing.T) {
+	handler := NewHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), stubService{err: assert.AnError})
+	req := httptest.NewRequest(http.MethodDelete, "/api/account", nil)
+	rr := httptest.NewRecorder()
+
+	handler.DeleteAccount(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "failed to delete account")
+}

--- a/server/internal/account/repository.go
+++ b/server/internal/account/repository.go
@@ -2,6 +2,7 @@ package account
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -12,6 +13,8 @@ import (
 type Repository interface {
 	DeleteUser(ctx context.Context, userID string) error
 }
+
+var ErrUserNotDeleted = errors.New("user account was not deleted")
 
 type repository struct {
 	logger  *slog.Logger
@@ -29,9 +32,14 @@ func (r *repository) DeleteUser(ctx context.Context, userID string) error {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	if err := r.queries.DeleteUser(ctx, userID); err != nil {
+	rowsAffected, err := r.queries.DeleteUser(ctx, userID)
+	if err != nil {
 		r.logger.Error("database error deleting user", "error", err, "user_id", userID)
 		return fmt.Errorf("delete user: %w", err)
+	}
+	if rowsAffected == 0 {
+		r.logger.Error("database delete affected zero users", "user_id", userID)
+		return ErrUserNotDeleted
 	}
 	return nil
 }

--- a/server/internal/account/repository.go
+++ b/server/internal/account/repository.go
@@ -1,0 +1,39 @@
+package account
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	db "github.com/Andrewy-gh/fittrack/server/internal/database"
+)
+
+type Repository interface {
+	DeleteUser(ctx context.Context, userID string) error
+}
+
+type repository struct {
+	logger  *slog.Logger
+	queries *db.Queries
+}
+
+func NewRepository(logger *slog.Logger, queries *db.Queries) Repository {
+	return &repository{
+		logger:  logger,
+		queries: queries,
+	}
+}
+
+func (r *repository) DeleteUser(ctx context.Context, userID string) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if err := r.queries.DeleteUser(ctx, userID); err != nil {
+		r.logger.Error("database error deleting user", "error", err, "user_id", userID)
+		return fmt.Errorf("delete user: %w", err)
+	}
+	return nil
+}
+
+var _ Repository = (*repository)(nil)

--- a/server/internal/account/repository_test.go
+++ b/server/internal/account/repository_test.go
@@ -1,0 +1,52 @@
+package account
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	db "github.com/Andrewy-gh/fittrack/server/internal/database"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDeleteDB struct {
+	commandTag pgconn.CommandTag
+	err        error
+}
+
+func (f fakeDeleteDB) Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error) {
+	return f.commandTag, f.err
+}
+
+func (f fakeDeleteDB) Query(context.Context, string, ...interface{}) (pgx.Rows, error) {
+	panic("query is not used by DeleteUser")
+}
+
+func (f fakeDeleteDB) QueryRow(context.Context, string, ...interface{}) pgx.Row {
+	panic("query row is not used by DeleteUser")
+}
+
+func TestRepositoryDeleteUser_ReturnsErrorWhenNoRowsDeleted(t *testing.T) {
+	repo := NewRepository(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		db.New(fakeDeleteDB{commandTag: pgconn.NewCommandTag("DELETE 0")}),
+	)
+
+	err := repo.DeleteUser(context.Background(), "user-123")
+
+	require.ErrorIs(t, err, ErrUserNotDeleted)
+}
+
+func TestRepositoryDeleteUser_SucceedsWhenUserDeleted(t *testing.T) {
+	repo := NewRepository(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		db.New(fakeDeleteDB{commandTag: pgconn.NewCommandTag("DELETE 1")}),
+	)
+
+	err := repo.DeleteUser(context.Background(), "user-123")
+
+	require.NoError(t, err)
+}

--- a/server/internal/account/service.go
+++ b/server/internal/account/service.go
@@ -1,0 +1,48 @@
+package account
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	apperrors "github.com/Andrewy-gh/fittrack/server/internal/errors"
+	"github.com/Andrewy-gh/fittrack/server/internal/user"
+)
+
+type Service struct {
+	logger  *slog.Logger
+	repo    Repository
+	billing BillingCanceler
+}
+
+type BillingCanceler interface {
+	CancelCurrentSubscriptionRenewal(ctx context.Context) error
+}
+
+func NewService(logger *slog.Logger, repo Repository, billing BillingCanceler) *Service {
+	return &Service{
+		logger:  logger,
+		repo:    repo,
+		billing: billing,
+	}
+}
+
+func (s *Service) DeleteCurrentUser(ctx context.Context) error {
+	userID, ok := user.Current(ctx)
+	if !ok || userID == "" {
+		return apperrors.NewUnauthorized("account", "")
+	}
+
+	if s.billing != nil {
+		if err := s.billing.CancelCurrentSubscriptionRenewal(ctx); err != nil {
+			return fmt.Errorf("cancel subscription renewal before account deletion: %w", err)
+		}
+	}
+
+	if err := s.repo.DeleteUser(ctx, userID); err != nil {
+		return fmt.Errorf("delete current user account: %w", err)
+	}
+
+	s.logger.Info("deleted fittrack user account data", "user_id", userID)
+	return nil
+}

--- a/server/internal/account/service.go
+++ b/server/internal/account/service.go
@@ -16,7 +16,7 @@ type Service struct {
 }
 
 type BillingCanceler interface {
-	CancelCurrentSubscriptionRenewal(ctx context.Context) error
+	CancelCurrentSubscriptionImmediately(ctx context.Context) error
 }
 
 func NewService(logger *slog.Logger, repo Repository, billing BillingCanceler) *Service {
@@ -34,8 +34,8 @@ func (s *Service) DeleteCurrentUser(ctx context.Context) error {
 	}
 
 	if s.billing != nil {
-		if err := s.billing.CancelCurrentSubscriptionRenewal(ctx); err != nil {
-			return fmt.Errorf("cancel subscription renewal before account deletion: %w", err)
+		if err := s.billing.CancelCurrentSubscriptionImmediately(ctx); err != nil {
+			return fmt.Errorf("cancel subscription before account deletion: %w", err)
 		}
 	}
 

--- a/server/internal/account/service_test.go
+++ b/server/internal/account/service_test.go
@@ -27,12 +27,12 @@ type stubBillingCanceler struct {
 	called bool
 }
 
-func (s *stubBillingCanceler) CancelCurrentSubscriptionRenewal(ctx context.Context) error {
+func (s *stubBillingCanceler) CancelCurrentSubscriptionImmediately(ctx context.Context) error {
 	s.called = true
 	return s.err
 }
 
-func TestServiceDeleteCurrentUser_CancelsSubscriptionRenewalBeforeDeleting(t *testing.T) {
+func TestServiceDeleteCurrentUser_CancelsSubscriptionImmediatelyBeforeDeleting(t *testing.T) {
 	repo := &stubRepository{}
 	billing := &stubBillingCanceler{}
 	service := NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), repo, billing)
@@ -65,6 +65,16 @@ func TestServiceDeleteCurrentUser_ReturnsDeleteFailure(t *testing.T) {
 	err := service.DeleteCurrentUser(ctx)
 
 	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestServiceDeleteCurrentUser_ReturnsZeroRowDeleteFailure(t *testing.T) {
+	repo := &stubRepository{deleteErr: ErrUserNotDeleted}
+	service := NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), repo, nil)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	err := service.DeleteCurrentUser(ctx)
+
+	require.ErrorIs(t, err, ErrUserNotDeleted)
 }
 
 func TestServiceDeleteCurrentUser_DoesNotDeleteWhenSubscriptionCancellationFails(t *testing.T) {

--- a/server/internal/account/service_test.go
+++ b/server/internal/account/service_test.go
@@ -1,0 +1,81 @@
+package account
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Andrewy-gh/fittrack/server/internal/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubRepository struct {
+	deleteErr     error
+	deletedUserID string
+}
+
+func (s *stubRepository) DeleteUser(ctx context.Context, userID string) error {
+	s.deletedUserID = userID
+	return s.deleteErr
+}
+
+type stubBillingCanceler struct {
+	err    error
+	called bool
+}
+
+func (s *stubBillingCanceler) CancelCurrentSubscriptionRenewal(ctx context.Context) error {
+	s.called = true
+	return s.err
+}
+
+func TestServiceDeleteCurrentUser_CancelsSubscriptionRenewalBeforeDeleting(t *testing.T) {
+	repo := &stubRepository{}
+	billing := &stubBillingCanceler{}
+	service := NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), repo, billing)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	err := service.DeleteCurrentUser(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, billing.called)
+	assert.Equal(t, "user-123", repo.deletedUserID)
+}
+
+func TestServiceDeleteCurrentUser_DeletesCurrentUser(t *testing.T) {
+	repo := &stubRepository{}
+	service := NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), repo, nil)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	err := service.DeleteCurrentUser(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "user-123", repo.deletedUserID)
+}
+
+func TestServiceDeleteCurrentUser_ReturnsDeleteFailure(t *testing.T) {
+	expectedErr := errors.New("delete failed")
+	repo := &stubRepository{deleteErr: expectedErr}
+	service := NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), repo, nil)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	err := service.DeleteCurrentUser(ctx)
+
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestServiceDeleteCurrentUser_DoesNotDeleteWhenSubscriptionCancellationFails(t *testing.T) {
+	expectedErr := errors.New("stripe failed")
+	repo := &stubRepository{}
+	billing := &stubBillingCanceler{err: expectedErr}
+	service := NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), repo, billing)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	err := service.DeleteCurrentUser(ctx)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, repo.deletedUserID)
+}

--- a/server/internal/billing/models.go
+++ b/server/internal/billing/models.go
@@ -15,6 +15,7 @@ const (
 	subscriptionStatusCanceled          = "canceled"
 	subscriptionStatusIncomplete        = "incomplete"
 	subscriptionStatusIncompleteExpired = "incomplete_expired"
+	subscriptionStatusPaused            = "paused"
 )
 
 var (
@@ -75,6 +76,23 @@ type StripeSubscriptionSnapshot struct {
 
 func statusAllowsAccess(status string) bool {
 	return status == subscriptionStatusTrialing || status == subscriptionStatusActive
+}
+
+func statusCanBeCanceledImmediately(status string) bool {
+	switch status {
+	case subscriptionStatusTrialing,
+		subscriptionStatusActive,
+		subscriptionStatusPastDue,
+		subscriptionStatusIncomplete,
+		subscriptionStatusPaused:
+		return true
+	case subscriptionStatusCanceled,
+		subscriptionStatusIncompleteExpired,
+		subscriptionStatusUnpaid:
+		return false
+	default:
+		return false
+	}
 }
 
 func statusConsumesTrialPrompts(status string) bool {

--- a/server/internal/billing/models.go
+++ b/server/internal/billing/models.go
@@ -26,6 +26,7 @@ var (
 	ErrStripeUserMissing                = errors.New("stripe payload is missing fittrack user metadata")
 	ErrStripeCustomerMissing            = errors.New("stripe payload is missing customer")
 	ErrUnsupportedStripeEvent           = errors.New("unsupported stripe webhook event")
+	ErrBillingAccountDeleted            = errors.New("billing account was deleted")
 )
 
 type CheckoutSessionResponse struct {

--- a/server/internal/billing/repository.go
+++ b/server/internal/billing/repository.go
@@ -111,6 +111,15 @@ func (r *repository) UpsertSubscriptionFromWebhook(ctx context.Context, snapshot
 	}
 
 	qtx := r.queries.WithTx(tx)
+	_, err = qtx.GetUserByUserID(ctx, snapshot.UserID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		r.logger.Info("ignored stripe subscription event for deleted user", "user_id", snapshot.UserID, "stripe_subscription_id", snapshot.StripeSubscriptionID)
+		return db.StripeSubscriptions{}, ErrBillingAccountDeleted
+	}
+	if err != nil {
+		return db.StripeSubscriptions{}, fmt.Errorf("get user for stripe subscription: %w", err)
+	}
+
 	if _, err := qtx.UpsertStripeCustomer(ctx, db.UpsertStripeCustomerParams{
 		UserID:           snapshot.UserID,
 		StripeCustomerID: snapshot.StripeCustomerID,

--- a/server/internal/billing/repository.go
+++ b/server/internal/billing/repository.go
@@ -74,7 +74,17 @@ func (r *repository) UpsertStripeCustomer(ctx context.Context, userID string, st
 		return db.StripeCustomers{}, err
 	}
 
-	row, err := r.queries.WithTx(tx).UpsertStripeCustomer(ctx, db.UpsertStripeCustomerParams{
+	qtx := r.queries.WithTx(tx)
+	_, err = qtx.GetUserByUserID(ctx, userID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		r.logger.Info("ignored stripe customer event for deleted user", "user_id", userID, "stripe_customer_id", stripeCustomerID)
+		return db.StripeCustomers{}, ErrBillingAccountDeleted
+	}
+	if err != nil {
+		return db.StripeCustomers{}, fmt.Errorf("get user for stripe customer: %w", err)
+	}
+
+	row, err := qtx.UpsertStripeCustomer(ctx, db.UpsertStripeCustomerParams{
 		UserID:           userID,
 		StripeCustomerID: stripeCustomerID,
 	})

--- a/server/internal/billing/repository_integration_test.go
+++ b/server/internal/billing/repository_integration_test.go
@@ -267,45 +267,63 @@ func TestRepositoryUpsertSubscriptionFromWebhook_SameSecondRevocationBeatsGranti
 	defer pool.Close()
 	require.NoError(t, pool.Ping(ctx))
 
-	userID := "billing-same-second-revoke-user"
-	subscriptionID := "sub_same_second_revoke"
-	customerID := "cus_same_second_revoke"
-	cleanupBillingSourceScopeTest(t, pool, userID, subscriptionID, customerID)
-	defer cleanupBillingSourceScopeTest(t, pool, userID, subscriptionID, customerID)
-	seedBillingUser(t, pool, userID)
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{
+			name:   "canceled",
+			status: subscriptionStatusCanceled,
+		},
+		{
+			name:   "paused",
+			status: subscriptionStatusPaused,
+		},
+	}
 
-	repo := NewRepository(slog.New(slog.NewTextHandler(io.Discard, nil)), db.New(pool), pool)
-	periodStart := time.Now().UTC().Add(-time.Hour)
-	periodEnd := periodStart.Add(30 * 24 * time.Hour)
-	eventCreatedAt := periodStart.Add(time.Minute).Truncate(time.Second)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userID := "billing-same-second-revoke-" + tt.status
+			subscriptionID := "sub_same_second_revoke_" + tt.status
+			customerID := "cus_same_second_revoke_" + tt.status
+			cleanupBillingSourceScopeTest(t, pool, userID, subscriptionID, customerID)
+			defer cleanupBillingSourceScopeTest(t, pool, userID, subscriptionID, customerID)
+			seedBillingUser(t, pool, userID)
 
-	_, err = repo.UpsertSubscriptionFromWebhook(ctx, StripeSubscriptionSnapshot{
-		StripeSubscriptionID: subscriptionID,
-		UserID:               userID,
-		StripeCustomerID:     customerID,
-		StripePriceID:        "price_premium",
-		StripeEventCreatedAt: &eventCreatedAt,
-		Status:               subscriptionStatusCanceled,
-		CurrentPeriodStart:   &periodStart,
-		CurrentPeriodEnd:     &periodEnd,
-	})
-	require.NoError(t, err)
+			repo := NewRepository(slog.New(slog.NewTextHandler(io.Discard, nil)), db.New(pool), pool)
+			periodStart := time.Now().UTC().Add(-time.Hour)
+			periodEnd := periodStart.Add(30 * 24 * time.Hour)
+			eventCreatedAt := periodStart.Add(time.Minute).Truncate(time.Second)
 
-	_, err = repo.UpsertSubscriptionFromWebhook(ctx, StripeSubscriptionSnapshot{
-		StripeSubscriptionID: subscriptionID,
-		UserID:               userID,
-		StripeCustomerID:     customerID,
-		StripePriceID:        "price_premium",
-		StripeEventCreatedAt: &eventCreatedAt,
-		Status:               subscriptionStatusActive,
-		CurrentPeriodStart:   &periodStart,
-		CurrentPeriodEnd:     &periodEnd,
-		GrantAIChatAccess:    true,
-	})
-	require.NoError(t, err)
+			_, err = repo.UpsertSubscriptionFromWebhook(ctx, StripeSubscriptionSnapshot{
+				StripeSubscriptionID: subscriptionID,
+				UserID:               userID,
+				StripeCustomerID:     customerID,
+				StripePriceID:        "price_premium",
+				StripeEventCreatedAt: &eventCreatedAt,
+				Status:               tt.status,
+				CurrentPeriodStart:   &periodStart,
+				CurrentPeriodEnd:     &periodEnd,
+			})
+			require.NoError(t, err)
 
-	assert.Empty(t, activeAIChatSources(t, pool, userID))
-	assert.Equal(t, subscriptionStatusCanceled, currentStripeSubscriptionStatus(t, pool, userID, subscriptionID))
+			_, err = repo.UpsertSubscriptionFromWebhook(ctx, StripeSubscriptionSnapshot{
+				StripeSubscriptionID: subscriptionID,
+				UserID:               userID,
+				StripeCustomerID:     customerID,
+				StripePriceID:        "price_premium",
+				StripeEventCreatedAt: &eventCreatedAt,
+				Status:               subscriptionStatusActive,
+				CurrentPeriodStart:   &periodStart,
+				CurrentPeriodEnd:     &periodEnd,
+				GrantAIChatAccess:    true,
+			})
+			require.NoError(t, err)
+
+			assert.Empty(t, activeAIChatSources(t, pool, userID))
+			assert.Equal(t, tt.status, currentStripeSubscriptionStatus(t, pool, userID, subscriptionID))
+		})
+	}
 }
 
 func TestRepositoryUpsertSubscriptionFromWebhook_DoesNotGrantWithoutPremiumPrice(t *testing.T) {

--- a/server/internal/billing/service.go
+++ b/server/internal/billing/service.go
@@ -34,6 +34,7 @@ type Service struct {
 	createCheckoutSession func(*stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error)
 	createPortalSession   func(*stripe.BillingPortalSessionParams) (*stripe.BillingPortalSession, error)
 	updateSubscription    func(string, *stripe.SubscriptionParams) (*stripe.Subscription, error)
+	cancelSubscription    func(string, *stripe.SubscriptionCancelParams) (*stripe.Subscription, error)
 	constructEvent        func([]byte, string, string) (stripe.Event, error)
 }
 
@@ -50,6 +51,7 @@ func NewService(logger *slog.Logger, repo Repository, stripeSecretKey string, we
 		createCheckoutSession: session.New,
 		createPortalSession:   portalsession.New,
 		updateSubscription:    stripesubscription.Update,
+		cancelSubscription:    stripesubscription.Cancel,
 		constructEvent: func(payload []byte, header string, secret string) (stripe.Event, error) {
 			return webhook.ConstructEventWithOptions(payload, header, secret, webhook.ConstructEventOptions{
 				IgnoreAPIVersionMismatch: true,
@@ -255,6 +257,35 @@ func (s *Service) CancelCurrentSubscriptionRenewal(ctx context.Context) error {
 	return nil
 }
 
+func (s *Service) CancelCurrentSubscriptionImmediately(ctx context.Context) error {
+	userID, err := currentUserID(ctx)
+	if err != nil {
+		return err
+	}
+
+	subscription, err := s.repo.GetCurrentSubscriptionByUserID(ctx, userID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil
+	case err != nil:
+		return fmt.Errorf("get current billing subscription: %w", err)
+	}
+
+	if !statusAllowsAccess(subscription.Status) {
+		return nil
+	}
+	if strings.TrimSpace(s.stripeSecretKey) == "" {
+		return ErrBillingNotConfigured
+	}
+
+	stripe.Key = s.stripeSecretKey
+	_, err = s.cancelSubscription(subscription.StripeSubscriptionID, &stripe.SubscriptionCancelParams{})
+	if err != nil {
+		return fmt.Errorf("cancel stripe subscription: %w", err)
+	}
+	return nil
+}
+
 func (s *Service) EnsureAIChatPromptAllowed(ctx context.Context) error {
 	userID, err := currentUserID(ctx)
 	if err != nil {
@@ -316,6 +347,10 @@ func (s *Service) ApplySubscriptionSnapshot(ctx context.Context, snapshot Stripe
 		return err
 	}
 	_, err := s.repo.UpsertSubscriptionFromWebhook(ctx, snapshot)
+	if errors.Is(err, ErrBillingAccountDeleted) {
+		s.logger.Info("acknowledged stripe subscription event for deleted account", "user_id", snapshot.UserID, "stripe_subscription_id", snapshot.StripeSubscriptionID)
+		return nil
+	}
 	return err
 }
 
@@ -346,6 +381,10 @@ func (s *Service) applySubscriptionEvent(ctx context.Context, subscription strip
 	snapshot.StripeEventCreatedAt = eventCreatedAt
 	if snapshot.UserID == "" && snapshot.StripeCustomerID != "" {
 		customerRow, err := s.repo.GetStripeCustomerByCustomerID(ctx, snapshot.StripeCustomerID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			s.logger.Info("ignoring stripe subscription event for deleted or unknown customer", "stripe_customer_id", snapshot.StripeCustomerID, "stripe_subscription_id", snapshot.StripeSubscriptionID)
+			return nil
+		}
 		if err != nil {
 			return fmt.Errorf("find user for stripe customer: %w", err)
 		}

--- a/server/internal/billing/service.go
+++ b/server/internal/billing/service.go
@@ -271,7 +271,7 @@ func (s *Service) CancelCurrentSubscriptionImmediately(ctx context.Context) erro
 		return fmt.Errorf("get current billing subscription: %w", err)
 	}
 
-	if !statusAllowsAccess(subscription.Status) {
+	if !statusCanBeCanceledImmediately(subscription.Status) {
 		return nil
 	}
 	if strings.TrimSpace(s.stripeSecretKey) == "" {
@@ -407,6 +407,10 @@ func (s *Service) recordCheckoutCustomer(ctx context.Context, checkoutSession st
 	}
 
 	_, err := s.repo.UpsertStripeCustomer(ctx, userID, checkoutSession.Customer.ID)
+	if errors.Is(err, ErrBillingAccountDeleted) {
+		s.logger.Info("acknowledged checkout event for deleted account", "user_id", userID, "stripe_customer_id", checkoutSession.Customer.ID)
+		return nil
+	}
 	return err
 }
 

--- a/server/internal/billing/service.go
+++ b/server/internal/billing/service.go
@@ -18,6 +18,7 @@ import (
 	portalsession "github.com/stripe/stripe-go/v83/billingportal/session"
 	"github.com/stripe/stripe-go/v83/checkout/session"
 	"github.com/stripe/stripe-go/v83/customer"
+	stripesubscription "github.com/stripe/stripe-go/v83/subscription"
 	"github.com/stripe/stripe-go/v83/webhook"
 )
 
@@ -32,6 +33,7 @@ type Service struct {
 	createCustomer        func(*stripe.CustomerParams) (*stripe.Customer, error)
 	createCheckoutSession func(*stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error)
 	createPortalSession   func(*stripe.BillingPortalSessionParams) (*stripe.BillingPortalSession, error)
+	updateSubscription    func(string, *stripe.SubscriptionParams) (*stripe.Subscription, error)
 	constructEvent        func([]byte, string, string) (stripe.Event, error)
 }
 
@@ -47,6 +49,7 @@ func NewService(logger *slog.Logger, repo Repository, stripeSecretKey string, we
 		createCustomer:        customer.New,
 		createCheckoutSession: session.New,
 		createPortalSession:   portalsession.New,
+		updateSubscription:    stripesubscription.Update,
 		constructEvent: func(payload []byte, header string, secret string) (stripe.Event, error) {
 			return webhook.ConstructEventWithOptions(payload, header, secret, webhook.ConstructEventOptions{
 				IgnoreAPIVersionMismatch: true,
@@ -219,6 +222,37 @@ func (s *Service) CurrentStatus(ctx context.Context) (*StatusResponse, error) {
 	}
 
 	return resp, nil
+}
+
+func (s *Service) CancelCurrentSubscriptionRenewal(ctx context.Context) error {
+	userID, err := currentUserID(ctx)
+	if err != nil {
+		return err
+	}
+
+	subscription, err := s.repo.GetCurrentSubscriptionByUserID(ctx, userID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil
+	case err != nil:
+		return fmt.Errorf("get current billing subscription: %w", err)
+	}
+
+	if !statusAllowsAccess(subscription.Status) || subscriptionCancelScheduled(subscription) {
+		return nil
+	}
+	if strings.TrimSpace(s.stripeSecretKey) == "" {
+		return ErrBillingNotConfigured
+	}
+
+	stripe.Key = s.stripeSecretKey
+	_, err = s.updateSubscription(subscription.StripeSubscriptionID, &stripe.SubscriptionParams{
+		CancelAtPeriodEnd: stripe.Bool(true),
+	})
+	if err != nil {
+		return fmt.Errorf("schedule stripe subscription cancellation: %w", err)
+	}
+	return nil
 }
 
 func (s *Service) EnsureAIChatPromptAllowed(ctx context.Context) error {

--- a/server/internal/billing/service_portal_test.go
+++ b/server/internal/billing/service_portal_test.go
@@ -276,6 +276,69 @@ func TestServiceCancelCurrentSubscriptionImmediately_CancelsActiveSubscription(t
 	repo.AssertExpectations(t)
 }
 
+func TestServiceCancelCurrentSubscriptionImmediately_CancelsRecoverableSubscription(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	for _, status := range []string{
+		subscriptionStatusPastDue,
+		subscriptionStatusIncomplete,
+		subscriptionStatusPaused,
+	} {
+		t.Run(status, func(t *testing.T) {
+			repo := new(mockRepository)
+			service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+			ctx := user.WithContext(context.Background(), "user-123")
+
+			repo.On("GetCurrentSubscriptionByUserID", mock.Anything, "user-123").Return(db.StripeSubscriptions{
+				StripeSubscriptionID: "sub_cancelable",
+				UserID:               "user-123",
+				StripeCustomerID:     "cus_123",
+				Status:               status,
+			}, nil).Once()
+			service.cancelSubscription = func(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscription, error) {
+				assert.Equal(t, "sub_cancelable", id)
+				require.NotNil(t, params)
+				return &stripe.Subscription{ID: id, Status: stripe.SubscriptionStatusCanceled}, nil
+			}
+
+			err := service.CancelCurrentSubscriptionImmediately(ctx)
+
+			require.NoError(t, err)
+			repo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestServiceCancelCurrentSubscriptionImmediately_NonBillableSubscriptionNoops(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	for _, status := range []string{
+		subscriptionStatusCanceled,
+		subscriptionStatusIncompleteExpired,
+		subscriptionStatusUnpaid,
+	} {
+		t.Run(status, func(t *testing.T) {
+			repo := new(mockRepository)
+			service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+			ctx := user.WithContext(context.Background(), "user-123")
+
+			repo.On("GetCurrentSubscriptionByUserID", mock.Anything, "user-123").Return(db.StripeSubscriptions{
+				StripeSubscriptionID: "sub_non_billable",
+				UserID:               "user-123",
+				StripeCustomerID:     "cus_123",
+				Status:               status,
+			}, nil).Once()
+			service.cancelSubscription = func(string, *stripe.SubscriptionCancelParams) (*stripe.Subscription, error) {
+				t.Fatal("non-billable subscriptions should not call Stripe")
+				return nil, nil
+			}
+
+			err := service.CancelCurrentSubscriptionImmediately(ctx)
+
+			require.NoError(t, err)
+			repo.AssertExpectations(t)
+		})
+	}
+}
+
 func TestServiceCancelCurrentSubscriptionImmediately_StripeFailureBlocksAccountDeletion(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	repo := new(mockRepository)

--- a/server/internal/billing/service_portal_test.go
+++ b/server/internal/billing/service_portal_test.go
@@ -252,6 +252,52 @@ func TestServiceCancelCurrentSubscriptionRenewal_NotConfiguredWhenCancellationRe
 	repo.AssertExpectations(t)
 }
 
+func TestServiceCancelCurrentSubscriptionImmediately_CancelsActiveSubscription(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	repo.On("GetCurrentSubscriptionByUserID", mock.Anything, "user-123").Return(db.StripeSubscriptions{
+		StripeSubscriptionID: "sub_123",
+		UserID:               "user-123",
+		StripeCustomerID:     "cus_123",
+		Status:               subscriptionStatusActive,
+	}, nil).Once()
+	service.cancelSubscription = func(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscription, error) {
+		assert.Equal(t, "sub_123", id)
+		require.NotNil(t, params)
+		return &stripe.Subscription{ID: id, Status: stripe.SubscriptionStatusCanceled}, nil
+	}
+
+	err := service.CancelCurrentSubscriptionImmediately(ctx)
+
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestServiceCancelCurrentSubscriptionImmediately_StripeFailureBlocksAccountDeletion(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	repo.On("GetCurrentSubscriptionByUserID", mock.Anything, "user-123").Return(db.StripeSubscriptions{
+		StripeSubscriptionID: "sub_123",
+		UserID:               "user-123",
+		StripeCustomerID:     "cus_123",
+		Status:               subscriptionStatusActive,
+	}, nil).Once()
+	service.cancelSubscription = func(id string, params *stripe.SubscriptionCancelParams) (*stripe.Subscription, error) {
+		return nil, assert.AnError
+	}
+
+	err := service.CancelCurrentSubscriptionImmediately(ctx)
+
+	require.ErrorIs(t, err, assert.AnError)
+	repo.AssertExpectations(t)
+}
+
 func TestServiceCreateSubscriptionCancelPortalSession_AlreadyCanceling(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	repo := new(mockRepository)

--- a/server/internal/billing/service_portal_test.go
+++ b/server/internal/billing/service_portal_test.go
@@ -142,6 +142,116 @@ func TestServiceCreateSubscriptionCancelPortalSession_MissingSubscription(t *tes
 	repo.AssertNotCalled(t, "GetStripeCustomerByUserID", mock.Anything, mock.Anything)
 }
 
+func TestServiceCancelCurrentSubscriptionRenewal_SchedulesPeriodEndCancellation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	repo.On("GetCurrentSubscriptionByUserID", mock.Anything, "user-123").Return(db.StripeSubscriptions{
+		StripeSubscriptionID: "sub_123",
+		UserID:               "user-123",
+		StripeCustomerID:     "cus_123",
+		Status:               subscriptionStatusActive,
+	}, nil).Once()
+	service.updateSubscription = func(id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
+		assert.Equal(t, "sub_123", id)
+		require.NotNil(t, params.CancelAtPeriodEnd)
+		assert.True(t, *params.CancelAtPeriodEnd)
+		return &stripe.Subscription{ID: id}, nil
+	}
+
+	err := service.CancelCurrentSubscriptionRenewal(ctx)
+
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestServiceCancelCurrentSubscriptionRenewal_NoSubscriptionNoops(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	repo.On("GetCurrentSubscriptionByUserID", mock.Anything, "user-123").Return(db.StripeSubscriptions{}, pgx.ErrNoRows).Once()
+	service.updateSubscription = func(string, *stripe.SubscriptionParams) (*stripe.Subscription, error) {
+		t.Fatal("missing subscriptions should not call Stripe")
+		return nil, nil
+	}
+
+	err := service.CancelCurrentSubscriptionRenewal(ctx)
+
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestServiceCancelCurrentSubscriptionRenewal_AlreadyCancelingNoops(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	repo.On("GetCurrentSubscriptionByUserID", mock.Anything, "user-123").Return(db.StripeSubscriptions{
+		StripeSubscriptionID: "sub_123",
+		UserID:               "user-123",
+		Status:               subscriptionStatusActive,
+		CancelAtPeriodEnd:    true,
+	}, nil).Once()
+	service.updateSubscription = func(string, *stripe.SubscriptionParams) (*stripe.Subscription, error) {
+		t.Fatal("already canceling subscriptions should not call Stripe")
+		return nil, nil
+	}
+
+	err := service.CancelCurrentSubscriptionRenewal(ctx)
+
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestServiceCancelCurrentSubscriptionRenewal_InactiveSubscriptionNoops(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	repo.On("GetCurrentSubscriptionByUserID", mock.Anything, "user-123").Return(db.StripeSubscriptions{
+		StripeSubscriptionID: "sub_123",
+		UserID:               "user-123",
+		Status:               subscriptionStatusCanceled,
+	}, nil).Once()
+	service.updateSubscription = func(string, *stripe.SubscriptionParams) (*stripe.Subscription, error) {
+		t.Fatal("inactive subscriptions should not call Stripe")
+		return nil, nil
+	}
+
+	err := service.CancelCurrentSubscriptionRenewal(ctx)
+
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestServiceCancelCurrentSubscriptionRenewal_NotConfiguredWhenCancellationRequired(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	repo.On("GetCurrentSubscriptionByUserID", mock.Anything, "user-123").Return(db.StripeSubscriptions{
+		StripeSubscriptionID: "sub_123",
+		UserID:               "user-123",
+		Status:               subscriptionStatusTrialing,
+	}, nil).Once()
+	service.updateSubscription = func(string, *stripe.SubscriptionParams) (*stripe.Subscription, error) {
+		t.Fatal("unconfigured billing should not call Stripe")
+		return nil, nil
+	}
+
+	err := service.CancelCurrentSubscriptionRenewal(ctx)
+
+	require.ErrorIs(t, err, ErrBillingNotConfigured)
+	repo.AssertExpectations(t)
+}
+
 func TestServiceCreateSubscriptionCancelPortalSession_AlreadyCanceling(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	repo := new(mockRepository)

--- a/server/internal/billing/service_test.go
+++ b/server/internal/billing/service_test.go
@@ -257,6 +257,78 @@ func TestServiceHandleWebhook_DoesNotGrantAccessForWrongOrMissingPrice(t *testin
 	}
 }
 
+func TestServiceHandleWebhook_AcknowledgesDeletedAccountSubscriptionEvent(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	now := time.Now().UTC().Truncate(time.Second)
+	eventCreatedAt := now.Add(time.Minute)
+	raw := subscriptionEventPayloadWithoutUserMetadata(t, "sub_deleted", "canceled", now, now.Add(24*time.Hour))
+
+	service.constructEvent = func(payload []byte, header string, secret string) (stripe.Event, error) {
+		return stripe.Event{
+			ID:      "evt_deleted_account_subscription",
+			Type:    "customer.subscription.deleted",
+			Created: eventCreatedAt.Unix(),
+			Data:    &stripe.EventData{Raw: raw},
+		}, nil
+	}
+
+	repo.On("HasProcessedWebhookEvent", mock.Anything, "evt_deleted_account_subscription").Return(false, nil).Once()
+	repo.On("GetStripeCustomerByCustomerID", mock.Anything, "cus_123").Return(db.StripeCustomers{}, pgx.ErrNoRows).Once()
+	repo.On("MarkWebhookEventProcessed", mock.Anything, "evt_deleted_account_subscription", "customer.subscription.deleted").Return(nil).Once()
+
+	err := service.HandleWebhook(context.Background(), []byte("payload"), "sig")
+
+	require.NoError(t, err)
+	repo.AssertNotCalled(t, "UpsertSubscriptionFromWebhook", mock.Anything, mock.Anything)
+	repo.AssertNotCalled(t, "UpsertStripeCustomer", mock.Anything, mock.Anything, mock.Anything)
+	repo.AssertExpectations(t)
+}
+
+func TestServiceHandleWebhook_AcknowledgesDeletedAccountSubscriptionEventWithUserMetadata(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	now := time.Now().UTC().Truncate(time.Second)
+	eventCreatedAt := now.Add(time.Minute)
+	periodEnd := now.Add(24 * time.Hour)
+	raw := subscriptionEventPayload(t, "sub_deleted_with_metadata", "canceled", false, now, periodEnd)
+
+	service.constructEvent = func(payload []byte, header string, secret string) (stripe.Event, error) {
+		return stripe.Event{
+			ID:      "evt_deleted_account_subscription_with_metadata",
+			Type:    "customer.subscription.deleted",
+			Created: eventCreatedAt.Unix(),
+			Data:    &stripe.EventData{Raw: raw},
+		}, nil
+	}
+
+	expectedSnapshot := StripeSubscriptionSnapshot{
+		StripeSubscriptionID: "sub_deleted_with_metadata",
+		UserID:               "user-123",
+		StripeCustomerID:     "cus_123",
+		StripePriceID:        "price_premium",
+		StripeEventCreatedAt: &eventCreatedAt,
+		Status:               "canceled",
+		CurrentPeriodStart:   &now,
+		CurrentPeriodEnd:     &periodEnd,
+		TrialStart:           &now,
+		TrialEnd:             &periodEnd,
+		GrantAIChatAccess:    false,
+	}
+
+	repo.On("HasProcessedWebhookEvent", mock.Anything, "evt_deleted_account_subscription_with_metadata").Return(false, nil).Once()
+	repo.On("UpsertSubscriptionFromWebhook", mock.Anything, expectedSnapshot).Return(db.StripeSubscriptions{}, ErrBillingAccountDeleted).Once()
+	repo.On("MarkWebhookEventProcessed", mock.Anything, "evt_deleted_account_subscription_with_metadata", "customer.subscription.deleted").Return(nil).Once()
+
+	err := service.HandleWebhook(context.Background(), []byte("payload"), "sig")
+
+	require.NoError(t, err)
+	repo.AssertNotCalled(t, "UpsertStripeCustomer", mock.Anything, mock.Anything, mock.Anything)
+	repo.AssertExpectations(t)
+}
+
 func TestServiceCurrentStatus_AccessRules(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	now := time.Now().UTC()
@@ -508,6 +580,18 @@ func subscriptionEventPayloadWithCancelAt(t *testing.T, subscriptionID string, s
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(subscriptionEventPayload(t, subscriptionID, status, false, periodStart, periodEnd), &payload))
 	payload["cancel_at"] = cancelAt.Unix()
+
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return raw
+}
+
+func subscriptionEventPayloadWithoutUserMetadata(t *testing.T, subscriptionID string, status string, periodStart time.Time, periodEnd time.Time) []byte {
+	t.Helper()
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(subscriptionEventPayload(t, subscriptionID, status, false, periodStart, periodEnd), &payload))
+	payload["metadata"] = map[string]string{}
 
 	raw, err := json.Marshal(payload)
 	require.NoError(t, err)

--- a/server/internal/billing/service_test.go
+++ b/server/internal/billing/service_test.go
@@ -329,6 +329,34 @@ func TestServiceHandleWebhook_AcknowledgesDeletedAccountSubscriptionEventWithUse
 	repo.AssertExpectations(t)
 }
 
+func TestServiceHandleWebhook_AcknowledgesDeletedAccountCheckoutEvent(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+
+	service.constructEvent = func(payload []byte, header string, secret string) (stripe.Event, error) {
+		return stripe.Event{
+			ID:   "evt_deleted_account_checkout",
+			Type: "checkout.session.completed",
+			Data: &stripe.EventData{Raw: []byte(`{
+				"id": "cs_deleted",
+				"object": "checkout.session",
+				"client_reference_id": "user-123",
+				"customer": "cus_123"
+			}`)},
+		}, nil
+	}
+
+	repo.On("HasProcessedWebhookEvent", mock.Anything, "evt_deleted_account_checkout").Return(false, nil).Once()
+	repo.On("UpsertStripeCustomer", mock.Anything, "user-123", "cus_123").Return(db.StripeCustomers{}, ErrBillingAccountDeleted).Once()
+	repo.On("MarkWebhookEventProcessed", mock.Anything, "evt_deleted_account_checkout", "checkout.session.completed").Return(nil).Once()
+
+	err := service.HandleWebhook(context.Background(), []byte("payload"), "sig")
+
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
 func TestServiceCurrentStatus_AccessRules(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	now := time.Now().UTC()

--- a/server/internal/database/query.sql.go
+++ b/server/internal/database/query.sql.go
@@ -3287,7 +3287,7 @@ WHERE stripe_subscriptions.stripe_event_created_at < EXCLUDED.stripe_event_creat
    OR (
        stripe_subscriptions.stripe_event_created_at = EXCLUDED.stripe_event_created_at
        AND NOT (
-           stripe_subscriptions.status IN ('past_due', 'unpaid', 'canceled', 'incomplete', 'incomplete_expired')
+           stripe_subscriptions.status IN ('past_due', 'unpaid', 'canceled', 'incomplete', 'incomplete_expired', 'paused')
            AND EXCLUDED.status IN ('trialing', 'active')
        )
    )

--- a/server/internal/database/query.sql.go
+++ b/server/internal/database/query.sql.go
@@ -550,6 +550,16 @@ func (q *Queries) DeleteSetsByWorkoutAndExercise(ctx context.Context, arg Delete
 	return err
 }
 
+const deleteUser = `-- name: DeleteUser :exec
+DELETE FROM users
+WHERE user_id = $1
+`
+
+func (q *Queries) DeleteUser(ctx context.Context, userID string) error {
+	_, err := q.db.Exec(ctx, deleteUser, userID)
+	return err
+}
+
 const deleteWorkout = `-- name: DeleteWorkout :exec
 DELETE FROM workout 
 WHERE id = $1 

--- a/server/internal/database/query.sql.go
+++ b/server/internal/database/query.sql.go
@@ -550,14 +550,17 @@ func (q *Queries) DeleteSetsByWorkoutAndExercise(ctx context.Context, arg Delete
 	return err
 }
 
-const deleteUser = `-- name: DeleteUser :exec
+const deleteUser = `-- name: DeleteUser :execrows
 DELETE FROM users
 WHERE user_id = $1
 `
 
-func (q *Queries) DeleteUser(ctx context.Context, userID string) error {
-	_, err := q.db.Exec(ctx, deleteUser, userID)
-	return err
+func (q *Queries) DeleteUser(ctx context.Context, userID string) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteUser, userID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const deleteWorkout = `-- name: DeleteWorkout :exec

--- a/server/query.sql
+++ b/server/query.sql
@@ -443,6 +443,10 @@ INSERT INTO users (user_id)
 VALUES ($1)
 RETURNING id;
 
+-- name: DeleteUser :exec
+DELETE FROM users
+WHERE user_id = $1;
+
 -- Feature access queries
 -- name: ListActiveFeatureAccess :many
 SELECT

--- a/server/query.sql
+++ b/server/query.sql
@@ -443,7 +443,7 @@ INSERT INTO users (user_id)
 VALUES ($1)
 RETURNING id;
 
--- name: DeleteUser :exec
+-- name: DeleteUser :execrows
 DELETE FROM users
 WHERE user_id = $1;
 

--- a/server/query.sql
+++ b/server/query.sql
@@ -547,7 +547,7 @@ WHERE stripe_subscriptions.stripe_event_created_at < EXCLUDED.stripe_event_creat
    OR (
        stripe_subscriptions.stripe_event_created_at = EXCLUDED.stripe_event_created_at
        AND NOT (
-           stripe_subscriptions.status IN ('past_due', 'unpaid', 'canceled', 'incomplete', 'incomplete_expired')
+           stripe_subscriptions.status IN ('past_due', 'unpaid', 'canceled', 'incomplete', 'incomplete_expired', 'paused')
            AND EXCLUDED.status IN ('trialing', 'active')
        )
    )


### PR DESCRIPTION
## Summary
- Add authenticated DELETE /api/account backend route for FitTrack-local account deletion
- Schedule active/trialing Stripe subscriptions to cancel at period end before deleting local data
- No-op Stripe cancellation when the user has no current subscription, an inactive subscription, or an already scheduled cancellation

## Semantics
- Deletes FitTrack-local user data by deleting users(user_id), relying on existing ON DELETE CASCADE relationships
- Does not delete Stripe payment records, invoices, charges, or the Stack Auth identity
- If Stripe cancellation is required but fails, local deletion is not performed

## Tests
- go test ./internal/account ./internal/billing ./cmd/api
- go build ./cmd/api
- PowerShell equivalent of server test-fast: go test -short for all packages except internal/database

## Notes
- Full go test ./... still requires local Postgres for existing database integration tests.