### PR TITLE
feat: add account settings deletion flow

### DIFF
--- a/client/src/components/custom-user-button.test.tsx
+++ b/client/src/components/custom-user-button.test.tsx
@@ -1,0 +1,61 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseUser } = vi.hoisted(() => ({
+  mockUseUser: vi.fn(),
+}));
+
+vi.mock("@stackframe/react", () => ({
+  useUser: mockUseUser,
+}));
+
+vi.mock("@/components/theme-provider", () => ({
+  useTheme: () => ({
+    theme: "light",
+    setTheme: vi.fn(),
+  }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    to,
+    ...props
+  }: ComponentPropsWithoutRef<"a"> & { to: string }) => (
+    <a
+      href={to}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/local-dev-auth", () => ({
+  getLocalDevRouteUser: () => null,
+}));
+
+import { CustomUserButton } from "@/components/custom-user-button";
+
+describe("CustomUserButton", () => {
+  it("links signed-in users to account settings from the user menu", async () => {
+    const user = userEvent.setup();
+    mockUseUser.mockReturnValue({
+      id: "user-123",
+      displayName: "Andy",
+      primaryEmail: "andy@example.com",
+      profileImageUrl: null,
+      signOut: vi.fn(),
+    });
+
+    render(<CustomUserButton />);
+
+    await user.click(screen.getByRole("button"));
+
+    expect(
+      await screen.findByRole("menuitem", { name: /settings/i }),
+    ).toHaveAttribute("href", "/settings");
+  });
+});

--- a/client/src/components/custom-user-button.tsx
+++ b/client/src/components/custom-user-button.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { LogOut, Sun, Moon, Dumbbell } from "lucide-react";
+import { LogOut, Sun, Moon, Dumbbell, Settings } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import React from "react";
 import { useUser } from "@stackframe/react";
@@ -51,7 +51,10 @@ export function CustomUserButton() {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="outline-none">
+      <DropdownMenuTrigger
+        className="outline-none"
+        aria-label="Open account menu"
+      >
         {/* Button shows only the avatar */}
         <Avatar className="h-8.5 w-8.5">
           {user.profileImageUrl && (
@@ -122,6 +125,16 @@ export function CustomUserButton() {
           >
             <Dumbbell {...iconProps} />
             <Typography>Workouts</Typography>
+          </Link>
+        </DropdownMenuItem>
+
+        <DropdownMenuItem asChild>
+          <Link
+            to="/settings"
+            className="flex gap-2 items-center"
+          >
+            <Settings {...iconProps} />
+            <Typography>Settings</Typography>
           </Link>
         </DropdownMenuItem>
 

--- a/client/src/features/account/api/account.test.ts
+++ b/client/src/features/account/api/account.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getUser } = vi.hoisted(() => ({
+  getUser: vi.fn(),
+}));
+
+const { applyLocalDevAuthHeader } = vi.hoisted(() => ({
+  applyLocalDevAuthHeader: vi.fn((headers: Headers) => {
+    headers.set("x-fittrack-dev-e2e-user", "local-e2e-user");
+    return headers;
+  }),
+}));
+
+vi.mock("@/stack", () => ({
+  stackClientApp: {
+    getUser,
+  },
+}));
+
+vi.mock("@/lib/local-dev-auth", () => ({
+  applyLocalDevAuthHeader,
+}));
+
+import { deleteAccount } from "@/features/account/api/account";
+
+function latestRequest(): Request {
+  return vi.mocked(fetch).mock.calls.at(-1)?.[0] as Request;
+}
+
+describe("account api wrapper", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getUser.mockReset();
+    applyLocalDevAuthHeader.mockClear();
+    getUser.mockResolvedValue({
+      getAuthJson: vi.fn().mockResolvedValue({ accessToken: "token-123" }),
+    });
+  });
+
+  it("deletes the current FitTrack account", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+
+    await deleteAccount();
+
+    expect(fetch).toHaveBeenCalledWith(expect.any(Request));
+    expect(latestRequest().url).toContain("/api/account");
+    expect(latestRequest().method).toBe("DELETE");
+  });
+});

--- a/client/src/features/account/api/account.ts
+++ b/client/src/features/account/api/account.ts
@@ -1,0 +1,14 @@
+import { client } from "@/client/client.gen";
+import type { ApiError } from "@/lib/errors";
+import "@/lib/api/client-config";
+
+type DeleteAccountResponses = {
+  204: void;
+};
+
+export async function deleteAccount(): Promise<void> {
+  await client.delete<DeleteAccountResponses, ApiError, true>({
+    url: "/account",
+    throwOnError: true,
+  });
+}

--- a/client/src/features/account/pages/account-settings-page.test.tsx
+++ b/client/src/features/account/pages/account-settings-page.test.tsx
@@ -138,6 +138,40 @@ describe("AccountSettingsPage", () => {
     expect(mockNavigate).toHaveBeenCalledWith({ to: "/" });
   });
 
+  it("does not report a deletion failure when post-delete sign-out fails", async () => {
+    const user = userEvent.setup();
+    testUserSignOut.mockRejectedValueOnce(new Error("sign out failed"));
+
+    render(<AccountSettingsPage user={testUser} />);
+
+    const deletionSection = screen
+      .getByRole("heading", { name: "Delete account" })
+      .closest("section");
+    const deletion = within(deletionSection as HTMLElement);
+
+    await user.click(
+      deletion.getByRole("checkbox", {
+        name: /I understand this deletes my FitTrack app data/i,
+      }),
+    );
+    await user.click(deletion.getByRole("button", { name: "Delete account" }));
+
+    expect(mockDeleteAccount).toHaveBeenCalledOnce();
+    expect(mockClearCurrentDeviceAccountState).toHaveBeenCalledWith("user-123");
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(
+      deletion.queryByText("Could not delete your account. Please try again."),
+    ).not.toBeInTheDocument();
+    expect(
+      await deletion.findByText(
+        "Your account was deleted, but FitTrack could not finish signing you out on this device. Refresh the page if you still see account details.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      deletion.getByRole("button", { name: "Account deleted" }),
+    ).toBeDisabled();
+  });
+
   it("keeps local app state and the signed-in session when account deletion fails", async () => {
     const user = userEvent.setup();
     mockDeleteAccount.mockRejectedValueOnce(new Error("delete failed"));

--- a/client/src/features/account/pages/account-settings-page.test.tsx
+++ b/client/src/features/account/pages/account-settings-page.test.tsx
@@ -4,13 +4,11 @@ import type { CurrentUser } from "@stackframe/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockNavigate = vi.fn();
-const {
-  mockCreateBillingCustomerPortalSession,
-  mockRedirectToBillingPortal,
-} = vi.hoisted(() => ({
-  mockCreateBillingCustomerPortalSession: vi.fn(),
-  mockRedirectToBillingPortal: vi.fn(),
-}));
+const { mockCreateBillingCustomerPortalSession, mockRedirectToBillingPortal } =
+  vi.hoisted(() => ({
+    mockCreateBillingCustomerPortalSession: vi.fn(),
+    mockRedirectToBillingPortal: vi.fn(),
+  }));
 const { mockDeleteAccount } = vi.hoisted(() => ({
   mockDeleteAccount: vi.fn(),
 }));
@@ -85,7 +83,9 @@ describe("AccountSettingsPage", () => {
       ),
     ).toBeInTheDocument();
     expect(
-      deletion.getByText(/contact privacy@fittrack\.andrewy\.me before deleting/i),
+      deletion.getByText(
+        /contact privacy@fittrack\.andrewy\.me before deleting/i,
+      ),
     ).toBeInTheDocument();
 
     const deleteButton = deletion.getByRole("button", {
@@ -157,7 +157,9 @@ describe("AccountSettingsPage", () => {
     await user.click(deletion.getByRole("button", { name: "Delete account" }));
 
     expect(
-      await deletion.findByText("Could not delete your account. Please try again."),
+      await deletion.findByText(
+        "Could not delete your account. Please try again.",
+      ),
     ).toBeInTheDocument();
     expect(mockClearCurrentDeviceAccountState).not.toHaveBeenCalled();
     expect(testUserSignOut).not.toHaveBeenCalled();

--- a/client/src/features/account/pages/account-settings-page.test.tsx
+++ b/client/src/features/account/pages/account-settings-page.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { CurrentUser } from "@stackframe/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockNavigate = vi.fn();
+const {
+  mockCreateBillingCustomerPortalSession,
+  mockRedirectToBillingPortal,
+} = vi.hoisted(() => ({
+  mockCreateBillingCustomerPortalSession: vi.fn(),
+  mockRedirectToBillingPortal: vi.fn(),
+}));
+const { mockDeleteAccount } = vi.hoisted(() => ({
+  mockDeleteAccount: vi.fn(),
+}));
+const { mockClearCurrentDeviceAccountState } = vi.hoisted(() => ({
+  mockClearCurrentDeviceAccountState: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@/features/chat/api/billing", () => ({
+  createBillingCustomerPortalSession: mockCreateBillingCustomerPortalSession,
+  redirectToBillingPortal: mockRedirectToBillingPortal,
+}));
+
+vi.mock("@/features/account/api/account", () => ({
+  deleteAccount: mockDeleteAccount,
+}));
+
+vi.mock("@/features/account/utils/current-device-state", () => ({
+  clearCurrentDeviceAccountState: mockClearCurrentDeviceAccountState,
+}));
+
+import { AccountSettingsPage } from "@/features/account/pages/account-settings-page";
+
+const testUserSignOut = vi.fn();
+const testUser = {
+  id: "user-123",
+  displayName: "Andy",
+  primaryEmail: "andy@example.com",
+  signOut: testUserSignOut,
+} as unknown as CurrentUser;
+
+describe("AccountSettingsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateBillingCustomerPortalSession.mockResolvedValue({
+      url: "https://billing.stripe.test/session",
+    });
+    mockDeleteAccount.mockResolvedValue(undefined);
+  });
+
+  it("separates billing management from checkbox-confirmed account deletion", async () => {
+    const user = userEvent.setup();
+
+    render(<AccountSettingsPage user={testUser} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Account settings" }),
+    ).toBeInTheDocument();
+
+    const billingSection = screen
+      .getByRole("heading", { name: "Billing" })
+      .closest("section");
+    expect(billingSection).not.toBeNull();
+    expect(
+      within(billingSection as HTMLElement).getByRole("button", {
+        name: "Manage billing",
+      }),
+    ).toBeEnabled();
+
+    const deletionSection = screen
+      .getByRole("heading", { name: "Delete account" })
+      .closest("section");
+    expect(deletionSection).not.toBeNull();
+
+    const deletion = within(deletionSection as HTMLElement);
+    expect(
+      deletion.getByText(
+        "Deleting your account cancels your AI chat subscription so it will not renew. Your current billing period may already have been charged. If you recently paid and want FitTrack to review a refund, contact support@fittrack.andrewy.me.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      deletion.getByText(/contact privacy@fittrack\.andrewy\.me before deleting/i),
+    ).toBeInTheDocument();
+
+    const deleteButton = deletion.getByRole("button", {
+      name: "Delete account",
+    });
+    expect(deleteButton).toBeDisabled();
+
+    await user.click(
+      deletion.getByRole("checkbox", {
+        name: /I understand this deletes my FitTrack app data/i,
+      }),
+    );
+
+    expect(deleteButton).toBeEnabled();
+  });
+
+  it("opens the Stripe billing portal from account settings", async () => {
+    const user = userEvent.setup();
+
+    render(<AccountSettingsPage user={testUser} />);
+
+    await user.click(screen.getByRole("button", { name: "Manage billing" }));
+
+    expect(mockCreateBillingCustomerPortalSession).toHaveBeenCalledOnce();
+    expect(mockRedirectToBillingPortal).toHaveBeenCalledWith(
+      "https://billing.stripe.test/session",
+    );
+  });
+
+  it("clears local app state, signs out, and navigates home after account deletion succeeds", async () => {
+    const user = userEvent.setup();
+
+    render(<AccountSettingsPage user={testUser} />);
+
+    const deletionSection = screen
+      .getByRole("heading", { name: "Delete account" })
+      .closest("section");
+    const deletion = within(deletionSection as HTMLElement);
+
+    await user.click(
+      deletion.getByRole("checkbox", {
+        name: /I understand this deletes my FitTrack app data/i,
+      }),
+    );
+    await user.click(deletion.getByRole("button", { name: "Delete account" }));
+
+    expect(mockDeleteAccount).toHaveBeenCalledOnce();
+    expect(mockClearCurrentDeviceAccountState).toHaveBeenCalledWith("user-123");
+    expect(testUserSignOut).toHaveBeenCalledOnce();
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/" });
+  });
+
+  it("keeps local app state and the signed-in session when account deletion fails", async () => {
+    const user = userEvent.setup();
+    mockDeleteAccount.mockRejectedValueOnce(new Error("delete failed"));
+
+    render(<AccountSettingsPage user={testUser} />);
+
+    const deletionSection = screen
+      .getByRole("heading", { name: "Delete account" })
+      .closest("section");
+    const deletion = within(deletionSection as HTMLElement);
+
+    await user.click(
+      deletion.getByRole("checkbox", {
+        name: /I understand this deletes my FitTrack app data/i,
+      }),
+    );
+    await user.click(deletion.getByRole("button", { name: "Delete account" }));
+
+    expect(
+      await deletion.findByText("Could not delete your account. Please try again."),
+    ).toBeInTheDocument();
+    expect(mockClearCurrentDeviceAccountState).not.toHaveBeenCalled();
+    expect(testUserSignOut).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/features/account/pages/account-settings-page.test.tsx
+++ b/client/src/features/account/pages/account-settings-page.test.tsx
@@ -109,7 +109,9 @@ describe("AccountSettingsPage", () => {
 
     await user.click(screen.getByRole("button", { name: "Manage billing" }));
 
-    expect(mockCreateBillingCustomerPortalSession).toHaveBeenCalledOnce();
+    expect(mockCreateBillingCustomerPortalSession).toHaveBeenCalledWith(
+      "settings",
+    );
     expect(mockRedirectToBillingPortal).toHaveBeenCalledWith(
       "https://billing.stripe.test/session",
     );

--- a/client/src/features/account/pages/account-settings-page.tsx
+++ b/client/src/features/account/pages/account-settings-page.tsx
@@ -23,6 +23,7 @@ export function AccountSettingsPage({ user }: AccountSettingsPageProps) {
   const [isOpeningBilling, setIsOpeningBilling] = useState(false);
   const [billingError, setBillingError] = useState<string | null>(null);
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
+  const [isAccountDeleted, setIsAccountDeleted] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   async function handleManageBilling() {
@@ -49,13 +50,45 @@ export function AccountSettingsPage({ user }: AccountSettingsPageProps) {
 
     try {
       await deleteAccount();
-      clearCurrentDeviceAccountState(user.id);
-      await user.signOut();
-      await navigate({ to: "/" });
     } catch {
       setDeleteError("Could not delete your account. Please try again.");
       setIsDeletingAccount(false);
+      return;
     }
+
+    setIsAccountDeleted(true);
+
+    let didFinishCurrentDeviceExit = true;
+
+    try {
+      clearCurrentDeviceAccountState(user.id);
+    } catch {
+      didFinishCurrentDeviceExit = false;
+    }
+
+    try {
+      await user.signOut();
+    } catch {
+      didFinishCurrentDeviceExit = false;
+    }
+
+    if (!didFinishCurrentDeviceExit) {
+      setDeleteError(
+        "Your account was deleted, but FitTrack could not finish signing you out on this device. Refresh the page if you still see account details.",
+      );
+      setIsDeletingAccount(false);
+      return;
+    }
+
+    try {
+      await navigate({ to: "/" });
+    } catch {
+      setDeleteError(
+        "Your account was deleted, but FitTrack could not finish signing you out on this device. Refresh the page if you still see account details.",
+      );
+    }
+
+    setIsDeletingAccount(false);
   }
 
   return (
@@ -127,10 +160,16 @@ export function AccountSettingsPage({ user }: AccountSettingsPageProps) {
             type="button"
             variant="destructive"
             onClick={handleDeleteAccount}
-            disabled={!isDeletionConfirmed || isDeletingAccount}
+            disabled={
+              !isDeletionConfirmed || isDeletingAccount || isAccountDeleted
+            }
           >
             <Trash2 className="size-4" />
-            {isDeletingAccount ? "Deleting account..." : "Delete account"}
+            {isAccountDeleted
+              ? "Account deleted"
+              : isDeletingAccount
+                ? "Deleting account..."
+                : "Delete account"}
           </Button>
           {deleteError ? (
             <p className="text-sm text-destructive">{deleteError}</p>

--- a/client/src/features/account/pages/account-settings-page.tsx
+++ b/client/src/features/account/pages/account-settings-page.tsx
@@ -118,8 +118,8 @@ export function AccountSettingsPage({ user }: AccountSettingsPageProps) {
               }
             />
             <span>
-              I understand this deletes my FitTrack app data and signs me out
-              on this device.
+              I understand this deletes my FitTrack app data and signs me out on
+              this device.
             </span>
           </label>
 

--- a/client/src/features/account/pages/account-settings-page.tsx
+++ b/client/src/features/account/pages/account-settings-page.tsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import type { CurrentInternalUser, CurrentUser } from "@stackframe/react";
+import { useNavigate } from "@tanstack/react-router";
+import { CreditCard, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { deleteAccount } from "@/features/account/api/account";
+import { clearCurrentDeviceAccountState } from "@/features/account/utils/current-device-state";
+import {
+  createBillingCustomerPortalSession,
+  redirectToBillingPortal,
+} from "@/features/chat/api/billing";
+
+type AccountSettingsPageProps = {
+  user: CurrentUser | CurrentInternalUser;
+};
+
+export const accountDeletionBillingCopy =
+  "Deleting your account cancels your AI chat subscription so it will not renew. Your current billing period may already have been charged. If you recently paid and want FitTrack to review a refund, contact support@fittrack.andrewy.me.";
+
+export function AccountSettingsPage({ user }: AccountSettingsPageProps) {
+  const navigate = useNavigate();
+  const [isDeletionConfirmed, setIsDeletionConfirmed] = useState(false);
+  const [isOpeningBilling, setIsOpeningBilling] = useState(false);
+  const [billingError, setBillingError] = useState<string | null>(null);
+  const [isDeletingAccount, setIsDeletingAccount] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  async function handleManageBilling() {
+    setIsOpeningBilling(true);
+    setBillingError(null);
+
+    try {
+      const session = await createBillingCustomerPortalSession();
+      redirectToBillingPortal(session.url);
+    } catch {
+      setBillingError("Could not open billing. Please try again.");
+    } finally {
+      setIsOpeningBilling(false);
+    }
+  }
+
+  async function handleDeleteAccount() {
+    if (!isDeletionConfirmed) {
+      return;
+    }
+
+    setIsDeletingAccount(true);
+    setDeleteError(null);
+
+    try {
+      await deleteAccount();
+      clearCurrentDeviceAccountState(user.id);
+      await user.signOut();
+      await navigate({ to: "/" });
+    } catch {
+      setDeleteError("Could not delete your account. Please try again.");
+      setIsDeletingAccount(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Account settings
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Manage billing separately from destructive account deletion.
+        </p>
+      </header>
+
+      <section className="rounded-lg border bg-card p-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <h2 className="text-lg font-semibold tracking-tight">Billing</h2>
+            <p className="text-sm text-muted-foreground">
+              Open Stripe to manage your AI chat subscription, payment method,
+              invoices, or normal subscription cancellation.
+            </p>
+          </div>
+          <Button
+            type="button"
+            onClick={handleManageBilling}
+            disabled={isOpeningBilling}
+          >
+            <CreditCard className="size-4" />
+            {isOpeningBilling ? "Opening billing..." : "Manage billing"}
+          </Button>
+        </div>
+        {billingError ? (
+          <p className="mt-3 text-sm text-destructive">{billingError}</p>
+        ) : null}
+      </section>
+
+      <section className="rounded-lg border border-destructive/30 bg-card p-4">
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <h2 className="text-lg font-semibold tracking-tight text-destructive">
+              Delete account
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              This permanently deletes FitTrack app data for this signed-in
+              user. If you want a copy of your data, contact
+              privacy@fittrack.andrewy.me before deleting.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {accountDeletionBillingCopy}
+            </p>
+          </div>
+
+          <label className="flex items-start gap-3 text-sm">
+            <input
+              type="checkbox"
+              className="mt-1"
+              checked={isDeletionConfirmed}
+              onChange={(event) =>
+                setIsDeletionConfirmed(event.currentTarget.checked)
+              }
+            />
+            <span>
+              I understand this deletes my FitTrack app data and signs me out
+              on this device.
+            </span>
+          </label>
+
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleDeleteAccount}
+            disabled={!isDeletionConfirmed || isDeletingAccount}
+          >
+            <Trash2 className="size-4" />
+            {isDeletingAccount ? "Deleting account..." : "Delete account"}
+          </Button>
+          {deleteError ? (
+            <p className="text-sm text-destructive">{deleteError}</p>
+          ) : null}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/client/src/features/account/pages/account-settings-page.tsx
+++ b/client/src/features/account/pages/account-settings-page.tsx
@@ -31,7 +31,7 @@ export function AccountSettingsPage({ user }: AccountSettingsPageProps) {
     setBillingError(null);
 
     try {
-      const session = await createBillingCustomerPortalSession();
+      const session = await createBillingCustomerPortalSession("settings");
       redirectToBillingPortal(session.url);
     } catch {
       setBillingError("Could not open billing. Please try again.");

--- a/client/src/features/account/utils/current-device-state.ts
+++ b/client/src/features/account/utils/current-device-state.ts
@@ -1,0 +1,31 @@
+import { clearExerciseGoals } from "@/features/exercises/utils/exercise-goals";
+import { clearDemoData } from "@/lib/demo-data/storage";
+import { clearLocalStorage } from "@/lib/local-storage";
+
+const chatResumeStorageKeyPrefix = "fittrack.ai-chat.resume:";
+
+export function clearCurrentDeviceAccountState(userId?: string): void {
+  clearLocalStorage();
+  clearLocalStorage(userId);
+  clearDemoData();
+  clearExerciseGoals();
+  clearSessionStorageByPrefix(chatResumeStorageKeyPrefix);
+}
+
+function clearSessionStorageByPrefix(prefix: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const keysToRemove: string[] = [];
+  for (let index = 0; index < window.sessionStorage.length; index += 1) {
+    const key = window.sessionStorage.key(index);
+    if (key?.startsWith(prefix)) {
+      keysToRemove.push(key);
+    }
+  }
+
+  for (const key of keysToRemove) {
+    window.sessionStorage.removeItem(key);
+  }
+}

--- a/client/src/features/chat/api/billing.test.ts
+++ b/client/src/features/chat/api/billing.test.ts
@@ -133,6 +133,29 @@ describe("billing api wrapper", () => {
     expect(session.url).toBe("https://billing.stripe.test/session");
   });
 
+  it("requests a settings return path for account settings billing sessions", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          url: "https://billing.stripe.test/session",
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      ),
+    );
+
+    await createBillingCustomerPortalSession("settings");
+
+    expect(latestRequest().url).toContain(
+      "/api/billing/customer-portal-session?return_to=settings",
+    );
+    expect(latestRequest().method).toBe("POST");
+  });
+
   it("creates a Stripe-hosted subscription cancellation portal session", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(

--- a/client/src/features/chat/api/billing.ts
+++ b/client/src/features/chat/api/billing.ts
@@ -52,6 +52,8 @@ type BillingCustomerPortalSessionResponses = {
   200: BillingCustomerPortalSessionResponse;
 };
 
+type BillingPortalReturnDestination = "chat" | "settings";
+
 export function billingStatusQueryOptions(userId?: string) {
   return queryOptions({
     queryKey: ["billing", "ai-chatbot", "status", userId],
@@ -86,13 +88,18 @@ export async function createBillingCheckoutSession(): Promise<BillingCheckoutSes
   return response.data;
 }
 
-export async function createBillingCustomerPortalSession(): Promise<BillingCustomerPortalSessionResponse> {
+export async function createBillingCustomerPortalSession(
+  destination: BillingPortalReturnDestination = "chat",
+): Promise<BillingCustomerPortalSessionResponse> {
   const response = await client.post<
     BillingCustomerPortalSessionResponses,
     ApiError,
     true
   >({
-    url: "/billing/customer-portal-session",
+    url:
+      destination === "settings"
+        ? "/billing/customer-portal-session?return_to=settings"
+        : "/billing/customer-portal-session",
     throwOnError: true,
   });
 

--- a/client/src/features/chat/components/ai-chat-billing-card.test.tsx
+++ b/client/src/features/chat/components/ai-chat-billing-card.test.tsx
@@ -143,8 +143,7 @@ describe("AIChatBillingCard", () => {
     expect(onStartCheckout).not.toHaveBeenCalled();
   });
 
-  it("opens plan management while trialing", async () => {
-    const user = userEvent.setup();
+  it("keeps ordinary plan management out of the chat header while trialing", () => {
     const { onManageBilling, onStartCheckout } = renderCard({
       feature_key: "ai_chatbot",
       has_access: true,
@@ -170,15 +169,14 @@ describe("AIChatBillingCard", () => {
     expect(
       screen.queryByRole("button", { name: "Cancel plan" }),
     ).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Manage plan" }));
-
-    expect(onManageBilling).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("button", { name: "Manage plan" }),
+    ).not.toBeInTheDocument();
+    expect(onManageBilling).not.toHaveBeenCalled();
     expect(onStartCheckout).not.toHaveBeenCalled();
   });
 
-  it("opens plan management when premium is active without extra success copy", async () => {
-    const user = userEvent.setup();
+  it("keeps ordinary plan management out of the chat header when premium is active", () => {
     const { onManageBilling, onStartCheckout } = renderCard({
       feature_key: "ai_chatbot",
       has_access: true,
@@ -196,14 +194,14 @@ describe("AIChatBillingCard", () => {
     expect(
       screen.queryByRole("button", { name: "Cancel plan" }),
     ).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Manage plan" }));
-
-    expect(onManageBilling).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("button", { name: "Manage plan" }),
+    ).not.toBeInTheDocument();
+    expect(onManageBilling).not.toHaveBeenCalled();
     expect(onStartCheckout).not.toHaveBeenCalled();
   });
 
-  it("disables plan management while the portal is opening", () => {
+  it("does not show ordinary plan management while the portal state is loading", () => {
     const activeStatus = {
       feature_key: "ai_chatbot",
       has_access: true,
@@ -228,11 +226,9 @@ describe("AIChatBillingCard", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: "Opening billing..." }),
-    ).toBeDisabled();
-    expect(
-      screen.queryByRole("button", { name: "Cancel plan" }),
+      screen.queryByRole("button", { name: "Opening billing..." }),
     ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("shows active access without Checkout when access comes from a non-Stripe grant", () => {

--- a/client/src/features/chat/components/ai-chat-billing-card.tsx
+++ b/client/src/features/chat/components/ai-chat-billing-card.tsx
@@ -120,7 +120,8 @@ export function AIChatBillingActions({
     !isLoading &&
     billingAction &&
     (!isError || billingAction === "refresh") &&
-    (accessState !== "ready" || billingAction === "portal");
+    (accessState !== "ready" ||
+      shouldShowReadyBillingIssueAction(status, billingAction));
   const isActionLoading = getActionLoadingState({
     billingAction,
     isBillingPortalLoading,
@@ -436,6 +437,17 @@ function billingActionLoadingLabel(action: BillingAction): string {
     case "checkout":
       return "Opening Checkout...";
   }
+}
+
+function shouldShowReadyBillingIssueAction(
+  status: BillingStatusResponse | undefined,
+  action: BillingAction,
+): boolean {
+  return (
+    action === "portal" &&
+    status?.has_access === false &&
+    billingPortalStatuses.has(status.subscription?.status ?? "active")
+  );
 }
 
 function getActionLoadingState({

--- a/client/src/features/chat/hooks/use-ai-chat-billing-access.ts
+++ b/client/src/features/chat/hooks/use-ai-chat-billing-access.ts
@@ -170,7 +170,7 @@ export function useAIChatBillingAccess({
     onError: (error) => showErrorToast(error, "Could not open Checkout"),
   });
   const billingPortalMutation = useMutation({
-    mutationFn: createBillingCustomerPortalSession,
+    mutationFn: () => createBillingCustomerPortalSession(),
     onSuccess: (session) => redirectToBillingPortal(session.url),
     onError: (error) => showErrorToast(error, "Could not open billing"),
   });

--- a/client/src/features/chat/pages/chat-billing-page.test.tsx
+++ b/client/src/features/chat/pages/chat-billing-page.test.tsx
@@ -279,8 +279,7 @@ describe("ChatRouteComponent", () => {
     ).toBeDisabled();
   });
 
-  it("opens billing portal plan management for active subscribers", async () => {
-    const user = userEvent.setup();
+  it("keeps ordinary billing management out of AI chat for active subscribers", async () => {
     mockBillingQueryResult.value = {
       data: {
         feature_key: "ai_chatbot",
@@ -309,16 +308,13 @@ describe("ChatRouteComponent", () => {
 
     render(<ChatRouteComponent />);
 
-    await user.click(
-      await screen.findByRole("button", { name: "Manage plan" }),
-    );
+    expect(await screen.findByText("Premium")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Manage plan" }),
+    ).not.toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(mockCreateBillingCustomerPortalSession).toHaveBeenCalledTimes(1);
-    });
-    expect(mockRedirectToBillingPortal).toHaveBeenCalledWith(
-      "https://billing.stripe.test/session",
-    );
+    expect(mockCreateBillingCustomerPortalSession).not.toHaveBeenCalled();
+    expect(mockRedirectToBillingPortal).not.toHaveBeenCalled();
     expect(mockCreateBillingCheckoutSession).not.toHaveBeenCalled();
   });
 

--- a/client/src/features/privacy/privacy-content.test.tsx
+++ b/client/src/features/privacy/privacy-content.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { getPolicySections } from "@/features/privacy/privacy-content";
+
+describe("privacy policy account deletion copy", () => {
+  it("describes in-app deletion and the pre-deletion data request path", () => {
+    const choicesSection = getPolicySections().find(
+      (section) => section.id === "your-choices-and-rights",
+    );
+
+    expect(choicesSection).toBeDefined();
+
+    render(<>{choicesSection?.content}</>);
+
+    expect(
+      screen.getByText(/You can delete your FitTrack account in Account settings/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((_, element) =>
+        Boolean(
+          element?.tagName === "P" &&
+          element?.textContent?.includes(
+            "If you want a copy of your data, request a copy at privacy@fittrack.andrewy.me before deleting",
+          ),
+        ),
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/features/privacy/privacy-content.test.tsx
+++ b/client/src/features/privacy/privacy-content.test.tsx
@@ -13,7 +13,9 @@ describe("privacy policy account deletion copy", () => {
     render(<>{choicesSection?.content}</>);
 
     expect(
-      screen.getByText(/You can delete your FitTrack account in Account settings/i),
+      screen.getByText(
+        /You can delete your FitTrack account in Account settings/i,
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByText((_, element) =>

--- a/client/src/features/privacy/privacy-content.tsx
+++ b/client/src/features/privacy/privacy-content.tsx
@@ -246,14 +246,10 @@ export function getPolicySections(): {
           <p>
             You can update or delete workouts, exercises, and other app data
             through FitTrack features where those controls are available. You
-            can request deletion of your FitTrack account by contacting{" "}
-            <PolicyLink href={`mailto:${privacyEmail}`}>
-              {privacyEmail}
-            </PolicyLink>
-            .
+            can delete your FitTrack account in Account settings.
           </p>
           <p>
-            If you want a copy of your data, request it at{" "}
+            If you want a copy of your data, request a copy at{" "}
             <PolicyLink href={`mailto:${privacyEmail}`}>
               {privacyEmail}
             </PolicyLink>{" "}

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as HandlerSplatRouteImport } from './routes/handler.$'
+import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
 import { Route as LayoutChatRouteImport } from './routes/_layout/chat'
 import { Route as LayoutAnalyticsRouteImport } from './routes/_layout/analytics'
 import { Route as LayoutWorkoutsIndexRouteImport } from './routes/_layout/workouts/index'
@@ -40,6 +41,11 @@ const HandlerSplatRoute = HandlerSplatRouteImport.update({
   id: '/handler/$',
   path: '/handler/$',
   getParentRoute: () => rootRouteImport,
+} as any)
+const LayoutSettingsRoute = LayoutSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutChatRoute = LayoutChatRouteImport.update({
   id: '/chat',
@@ -90,6 +96,7 @@ export interface FileRoutesByFullPath {
   '/privacy': typeof PrivacyRoute
   '/analytics': typeof LayoutAnalyticsRoute
   '/chat': typeof LayoutChatRoute
+  '/settings': typeof LayoutSettingsRoute
   '/handler/$': typeof HandlerSplatRoute
   '/exercises/$exerciseId': typeof LayoutExercisesExerciseIdRoute
   '/workouts/new': typeof LayoutWorkoutsNewRoute
@@ -103,6 +110,7 @@ export interface FileRoutesByTo {
   '/privacy': typeof PrivacyRoute
   '/analytics': typeof LayoutAnalyticsRoute
   '/chat': typeof LayoutChatRoute
+  '/settings': typeof LayoutSettingsRoute
   '/handler/$': typeof HandlerSplatRoute
   '/exercises/$exerciseId': typeof LayoutExercisesExerciseIdRoute
   '/workouts/new': typeof LayoutWorkoutsNewRoute
@@ -118,6 +126,7 @@ export interface FileRoutesById {
   '/privacy': typeof PrivacyRoute
   '/_layout/analytics': typeof LayoutAnalyticsRoute
   '/_layout/chat': typeof LayoutChatRoute
+  '/_layout/settings': typeof LayoutSettingsRoute
   '/handler/$': typeof HandlerSplatRoute
   '/_layout/exercises/$exerciseId': typeof LayoutExercisesExerciseIdRoute
   '/_layout/workouts/new': typeof LayoutWorkoutsNewRoute
@@ -133,6 +142,7 @@ export interface FileRouteTypes {
     | '/privacy'
     | '/analytics'
     | '/chat'
+    | '/settings'
     | '/handler/$'
     | '/exercises/$exerciseId'
     | '/workouts/new'
@@ -146,6 +156,7 @@ export interface FileRouteTypes {
     | '/privacy'
     | '/analytics'
     | '/chat'
+    | '/settings'
     | '/handler/$'
     | '/exercises/$exerciseId'
     | '/workouts/new'
@@ -160,6 +171,7 @@ export interface FileRouteTypes {
     | '/privacy'
     | '/_layout/analytics'
     | '/_layout/chat'
+    | '/_layout/settings'
     | '/handler/$'
     | '/_layout/exercises/$exerciseId'
     | '/_layout/workouts/new'
@@ -205,6 +217,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/handler/$'
       preLoaderRoute: typeof HandlerSplatRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/_layout/settings': {
+      id: '/_layout/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof LayoutSettingsRouteImport
+      parentRoute: typeof LayoutRoute
     }
     '/_layout/chat': {
       id: '/_layout/chat'
@@ -268,6 +287,7 @@ declare module '@tanstack/react-router' {
 interface LayoutRouteChildren {
   LayoutAnalyticsRoute: typeof LayoutAnalyticsRoute
   LayoutChatRoute: typeof LayoutChatRoute
+  LayoutSettingsRoute: typeof LayoutSettingsRoute
   LayoutExercisesExerciseIdRoute: typeof LayoutExercisesExerciseIdRoute
   LayoutWorkoutsNewRoute: typeof LayoutWorkoutsNewRoute
   LayoutExercisesIndexRoute: typeof LayoutExercisesIndexRoute
@@ -279,6 +299,7 @@ interface LayoutRouteChildren {
 const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutAnalyticsRoute: LayoutAnalyticsRoute,
   LayoutChatRoute: LayoutChatRoute,
+  LayoutSettingsRoute: LayoutSettingsRoute,
   LayoutExercisesExerciseIdRoute: LayoutExercisesExerciseIdRoute,
   LayoutWorkoutsNewRoute: LayoutWorkoutsNewRoute,
   LayoutExercisesIndexRoute: LayoutExercisesIndexRoute,

--- a/client/src/routes/_layout/settings.tsx
+++ b/client/src/routes/_layout/settings.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AccountSettingsPage } from "@/features/account/pages/account-settings-page";
+
+export const Route = createFileRoute("/_layout/settings")({
+  component: SettingsRoute,
+});
+
+function SettingsRoute() {
+  const { user } = Route.useRouteContext();
+
+  if (!user) {
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-6">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Account settings
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Sign in to manage your account settings.
+        </p>
+      </main>
+    );
+  }
+
+  return <AccountSettingsPage user={user} />;
+}

--- a/server/cmd/api/routes_test.go
+++ b/server/cmd/api/routes_test.go
@@ -27,7 +27,7 @@ func (routeBillingService) CreateCheckoutSession(context.Context) (*billing.Chec
 	return &billing.CheckoutSessionResponse{URL: "https://checkout.stripe.test/session"}, nil
 }
 
-func (routeBillingService) CreateCustomerPortalSession(context.Context) (*billing.CustomerPortalSessionResponse, error) {
+func (routeBillingService) CreateCustomerPortalSession(context.Context, billing.PortalReturnDestination) (*billing.CustomerPortalSessionResponse, error) {
 	return &billing.CustomerPortalSessionResponse{URL: "https://billing.stripe.test/session"}, nil
 }
 

--- a/server/internal/billing/handler.go
+++ b/server/internal/billing/handler.go
@@ -15,7 +15,7 @@ const maxWebhookPayloadBytes = 1 << 20
 
 type billingService interface {
 	CreateCheckoutSession(ctx context.Context) (*CheckoutSessionResponse, error)
-	CreateCustomerPortalSession(ctx context.Context) (*CustomerPortalSessionResponse, error)
+	CreateCustomerPortalSession(ctx context.Context, destination PortalReturnDestination) (*CustomerPortalSessionResponse, error)
 	CreateSubscriptionCancelPortalSession(ctx context.Context) (*CustomerPortalSessionResponse, error)
 	CurrentStatus(ctx context.Context) (*StatusResponse, error)
 	HandleWebhook(ctx context.Context, payload []byte, signatureHeader string) error
@@ -46,7 +46,7 @@ func (h *Handler) CreateCheckoutSession(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h *Handler) CreateCustomerPortalSession(w http.ResponseWriter, r *http.Request) {
-	resp, err := h.service.CreateCustomerPortalSession(r.Context())
+	resp, err := h.service.CreateCustomerPortalSession(r.Context(), parsePortalReturnDestination(r))
 	if err != nil {
 		h.writeServiceError(w, r, err, http.StatusInternalServerError, "failed to create billing portal session")
 		return
@@ -55,6 +55,13 @@ func (h *Handler) CreateCustomerPortalSession(w http.ResponseWriter, r *http.Req
 	if err := response.JSON(w, http.StatusOK, resp); err != nil {
 		response.ErrorJSON(w, r, h.logger, http.StatusInternalServerError, "failed to write response", err)
 	}
+}
+
+func parsePortalReturnDestination(r *http.Request) PortalReturnDestination {
+	if r.URL.Query().Get("return_to") == string(PortalReturnSettings) {
+		return PortalReturnSettings
+	}
+	return PortalReturnChat
 }
 
 func (h *Handler) CreateSubscriptionCancelPortalSession(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/billing/handler_test.go
+++ b/server/internal/billing/handler_test.go
@@ -14,7 +14,7 @@ import (
 
 type stubBillingService struct {
 	createCheckoutSession                 func(context.Context) (*CheckoutSessionResponse, error)
-	createCustomerPortalSession           func(context.Context) (*CustomerPortalSessionResponse, error)
+	createCustomerPortalSession           func(context.Context, PortalReturnDestination) (*CustomerPortalSessionResponse, error)
 	createSubscriptionCancelPortalSession func(context.Context) (*CustomerPortalSessionResponse, error)
 	currentStatus                         func(context.Context) (*StatusResponse, error)
 	handleWebhook                         func(context.Context, []byte, string) error
@@ -27,9 +27,9 @@ func (s stubBillingService) CreateCheckoutSession(ctx context.Context) (*Checkou
 	return &CheckoutSessionResponse{URL: "https://checkout.stripe.test/session"}, nil
 }
 
-func (s stubBillingService) CreateCustomerPortalSession(ctx context.Context) (*CustomerPortalSessionResponse, error) {
+func (s stubBillingService) CreateCustomerPortalSession(ctx context.Context, destination PortalReturnDestination) (*CustomerPortalSessionResponse, error) {
 	if s.createCustomerPortalSession != nil {
-		return s.createCustomerPortalSession(ctx)
+		return s.createCustomerPortalSession(ctx, destination)
 	}
 	return &CustomerPortalSessionResponse{URL: "https://billing.stripe.test/session"}, nil
 }
@@ -56,8 +56,29 @@ func (s stubBillingService) HandleWebhook(ctx context.Context, payload []byte, s
 }
 
 func TestHandlerCreateCustomerPortalSession_ReturnsPortalURL(t *testing.T) {
-	handler := NewHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), stubBillingService{})
+	handler := NewHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), stubBillingService{
+		createCustomerPortalSession: func(_ context.Context, destination PortalReturnDestination) (*CustomerPortalSessionResponse, error) {
+			assert.Equal(t, PortalReturnChat, destination)
+			return &CustomerPortalSessionResponse{URL: "https://billing.stripe.test/session"}, nil
+		},
+	})
 	req := httptest.NewRequest(http.MethodPost, "/api/billing/customer-portal-session", nil)
+	rr := httptest.NewRecorder()
+
+	handler.CreateCustomerPortalSession(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.JSONEq(t, `{"url":"https://billing.stripe.test/session"}`, rr.Body.String())
+}
+
+func TestHandlerCreateCustomerPortalSession_UsesSettingsReturnDestination(t *testing.T) {
+	handler := NewHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), stubBillingService{
+		createCustomerPortalSession: func(_ context.Context, destination PortalReturnDestination) (*CustomerPortalSessionResponse, error) {
+			assert.Equal(t, PortalReturnSettings, destination)
+			return &CustomerPortalSessionResponse{URL: "https://billing.stripe.test/session"}, nil
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/billing/customer-portal-session?return_to=settings", nil)
 	rr := httptest.NewRecorder()
 
 	handler.CreateCustomerPortalSession(rr, req)
@@ -68,7 +89,7 @@ func TestHandlerCreateCustomerPortalSession_ReturnsPortalURL(t *testing.T) {
 
 func TestHandlerCreateCustomerPortalSession_NotConfiguredReturns503(t *testing.T) {
 	handler := NewHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), stubBillingService{
-		createCustomerPortalSession: func(context.Context) (*CustomerPortalSessionResponse, error) {
+		createCustomerPortalSession: func(context.Context, PortalReturnDestination) (*CustomerPortalSessionResponse, error) {
 			return nil, ErrBillingNotConfigured
 		},
 	})
@@ -83,7 +104,7 @@ func TestHandlerCreateCustomerPortalSession_NotConfiguredReturns503(t *testing.T
 
 func TestHandlerCreateCustomerPortalSession_MissingCustomerReturns404(t *testing.T) {
 	handler := NewHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), stubBillingService{
-		createCustomerPortalSession: func(context.Context) (*CustomerPortalSessionResponse, error) {
+		createCustomerPortalSession: func(context.Context, PortalReturnDestination) (*CustomerPortalSessionResponse, error) {
 			return nil, ErrBillingCustomerMissing
 		},
 	})

--- a/server/internal/billing/service.go
+++ b/server/internal/billing/service.go
@@ -38,6 +38,13 @@ type Service struct {
 	constructEvent        func([]byte, string, string) (stripe.Event, error)
 }
 
+type PortalReturnDestination string
+
+const (
+	PortalReturnChat     PortalReturnDestination = "chat"
+	PortalReturnSettings PortalReturnDestination = "settings"
+)
+
 func NewService(logger *slog.Logger, repo Repository, stripeSecretKey string, webhookSecret string, premiumPriceID string, appBaseURL string, trialPromptCap int) *Service {
 	return &Service{
 		logger:                logger,
@@ -113,7 +120,7 @@ func (s *Service) CreateCheckoutSession(ctx context.Context) (*CheckoutSessionRe
 	return &CheckoutSessionResponse{URL: checkoutSession.URL}, nil
 }
 
-func (s *Service) CreateCustomerPortalSession(ctx context.Context) (*CustomerPortalSessionResponse, error) {
+func (s *Service) CreateCustomerPortalSession(ctx context.Context, destination PortalReturnDestination) (*CustomerPortalSessionResponse, error) {
 	if !s.configuredForPortal() {
 		return nil, ErrBillingNotConfigured
 	}
@@ -131,7 +138,7 @@ func (s *Service) CreateCustomerPortalSession(ctx context.Context) (*CustomerPor
 
 	portalSession, err := s.createPortalSession(&stripe.BillingPortalSessionParams{
 		Customer:  stripe.String(customerID),
-		ReturnURL: stripe.String(s.appBaseURL + "/chat?billing=portal-return"),
+		ReturnURL: stripe.String(s.portalReturnURL(destination)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create stripe billing portal session: %w", err)
@@ -141,6 +148,13 @@ func (s *Service) CreateCustomerPortalSession(ctx context.Context) (*CustomerPor
 	}
 
 	return &CustomerPortalSessionResponse{URL: portalSession.URL}, nil
+}
+
+func (s *Service) portalReturnURL(destination PortalReturnDestination) string {
+	if destination == PortalReturnSettings {
+		return s.appBaseURL + "/settings"
+	}
+	return s.appBaseURL + "/chat?billing=portal-return"
 }
 
 func (s *Service) CreateSubscriptionCancelPortalSession(ctx context.Context) (*CustomerPortalSessionResponse, error) {

--- a/server/internal/billing/service_portal_test.go
+++ b/server/internal/billing/service_portal_test.go
@@ -35,7 +35,31 @@ func TestServiceCreateCustomerPortalSession(t *testing.T) {
 		return &stripe.BillingPortalSession{URL: "https://billing.stripe.test/session"}, nil
 	}
 
-	resp, err := service.CreateCustomerPortalSession(ctx)
+	resp, err := service.CreateCustomerPortalSession(ctx, PortalReturnChat)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "https://billing.stripe.test/session", resp.URL)
+	repo.AssertExpectations(t)
+}
+
+func TestServiceCreateCustomerPortalSession_SettingsReturnDestination(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := new(mockRepository)
+	service := NewService(logger, repo, "sk_test_123", "whsec_123", "price_premium", "http://localhost:5173", 30)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	repo.On("GetStripeCustomerByUserID", mock.Anything, "user-123").Return(db.StripeCustomers{
+		UserID:           "user-123",
+		StripeCustomerID: "cus_123",
+	}, nil).Once()
+	service.createPortalSession = func(params *stripe.BillingPortalSessionParams) (*stripe.BillingPortalSession, error) {
+		require.NotNil(t, params.ReturnURL)
+		assert.Equal(t, "http://localhost:5173/settings", *params.ReturnURL)
+		return &stripe.BillingPortalSession{URL: "https://billing.stripe.test/session"}, nil
+	}
+
+	resp, err := service.CreateCustomerPortalSession(ctx, PortalReturnSettings)
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -49,7 +73,7 @@ func TestServiceCreateCustomerPortalSession_NotConfigured(t *testing.T) {
 	service := NewService(logger, repo, "", "whsec_123", "price_premium", "http://localhost:5173", 30)
 	ctx := user.WithContext(context.Background(), "user-123")
 
-	resp, err := service.CreateCustomerPortalSession(ctx)
+	resp, err := service.CreateCustomerPortalSession(ctx, PortalReturnChat)
 
 	require.ErrorIs(t, err, ErrBillingNotConfigured)
 	assert.Nil(t, resp)
@@ -72,7 +96,7 @@ func TestServiceCreateCustomerPortalSession_MissingCustomerDoesNotCreateStripeCu
 		return nil, nil
 	}
 
-	resp, err := service.CreateCustomerPortalSession(ctx)
+	resp, err := service.CreateCustomerPortalSession(ctx, PortalReturnChat)
 
 	require.ErrorIs(t, err, ErrBillingCustomerMissing)
 	assert.Nil(t, resp)


### PR DESCRIPTION
## Summary
- add signed-in Account settings at /settings with Stripe billing management and checkbox-gated account deletion
- clear current-device FitTrack local state, sign out, and navigate home after successful deletion
- move ordinary plan management out of the AI chat header and update privacy copy for self-service deletion

## Verification
- bun run test
- bun run tsc
- bun run lint
- bun run build
- go test -short ./... excluding server/internal/database
- go build ./cmd/api