### PR TITLE
fix: make PWA updates prompt reliably

### DIFF
--- a/client/src/components/reload-prompt.test.tsx
+++ b/client/src/components/reload-prompt.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ReloadPrompt } from "./reload-prompt";
+
+const swMock = vi.hoisted(() => ({
+  needRefresh: false,
+  options: undefined as
+    | {
+        onRegisteredSW?: (
+          swUrl: string,
+          registration?: ServiceWorkerRegistration,
+        ) => void;
+      }
+    | undefined,
+  updateServiceWorker: vi.fn(),
+}));
+
+vi.mock("@/lib/pwa-register", async () => {
+  const React = await import("react");
+
+  return {
+    useRegisterSW(options: typeof swMock.options) {
+      swMock.options = options;
+      const [needRefresh, setNeedRefresh] = React.useState(swMock.needRefresh);
+
+      return {
+        needRefresh: [needRefresh, setNeedRefresh],
+        offlineReady: [false, vi.fn()],
+        updateServiceWorker: swMock.updateServiceWorker,
+      };
+    },
+  };
+});
+
+describe("ReloadPrompt", () => {
+  beforeEach(() => {
+    swMock.needRefresh = false;
+    swMock.options = undefined;
+    swMock.updateServiceWorker.mockReset();
+  });
+
+  it("shows the update prompt and reloads through the service worker", async () => {
+    swMock.needRefresh = true;
+
+    render(<ReloadPrompt />);
+
+    expect(screen.getByText("New update available")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Reload" }));
+
+    expect(swMock.updateServiceWorker).toHaveBeenCalledWith(true);
+  });
+
+  it("checks for a service worker update when the installed app resumes", async () => {
+    const registration = {
+      update: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ServiceWorkerRegistration;
+
+    render(<ReloadPrompt />);
+
+    swMock.options?.onRegisteredSW?.("/sw.js", registration);
+    expect(registration.update).toHaveBeenCalledTimes(1);
+
+    fireEvent.focus(window);
+    expect(registration.update).toHaveBeenCalledTimes(2);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    fireEvent(document, new Event("visibilitychange"));
+    expect(registration.update).toHaveBeenCalledTimes(2);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    fireEvent(document, new Event("visibilitychange"));
+    expect(registration.update).toHaveBeenCalledTimes(3);
+  });
+});

--- a/client/src/components/reload-prompt.tsx
+++ b/client/src/components/reload-prompt.tsx
@@ -1,17 +1,48 @@
-import { useRegisterSW } from "virtual:pwa-register/react";
+import { useEffect, useRef } from "react";
+import { useRegisterSW } from "@/lib/pwa-register";
 import { Button } from "./ui/button";
 
 export function ReloadPrompt() {
+  const registrationRef = useRef<ServiceWorkerRegistration | null>(null);
+
+  const checkForUpdate = () => {
+    void registrationRef.current?.update().catch((error: unknown) => {
+      if (import.meta.env.DEV) {
+        console.error("SW update check failed", error);
+      }
+    });
+  };
+
   const {
     needRefresh: [needRefresh, setNeedRefresh],
     updateServiceWorker,
   } = useRegisterSW({
+    onRegisteredSW(_swUrl, registration) {
+      registrationRef.current = registration ?? null;
+      checkForUpdate();
+    },
     onRegisterError(error: Error) {
       if (import.meta.env.DEV) {
         console.error("SW registration error", error);
       }
     },
   });
+
+  useEffect(() => {
+    const checkWhenVisible = () => {
+      if (document.visibilityState === "visible") {
+        checkForUpdate();
+      }
+    };
+
+    document.addEventListener("visibilitychange", checkWhenVisible);
+    window.addEventListener("focus", checkForUpdate);
+
+    return () => {
+      document.removeEventListener("visibilitychange", checkWhenVisible);
+      window.removeEventListener("focus", checkForUpdate);
+    };
+  }, []);
 
   const close = () => {
     setNeedRefresh(false);

--- a/client/src/lib/pwa-register.ts
+++ b/client/src/lib/pwa-register.ts
@@ -1,0 +1,1 @@
+export { useRegisterSW } from "virtual:pwa-register/react";

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -13,7 +13,7 @@ export default defineConfig({
     viteReact(),
     tailwindcss(),
     VitePWA({
-      registerType: "autoUpdate",
+      registerType: "prompt",
       includeAssets: [
         "favicon.svg",
         "favicon.ico",

--- a/server/cmd/api/routes.go
+++ b/server/cmd/api/routes.go
@@ -95,6 +95,7 @@ func (api *api) handleStaticFiles() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		_, err := http.Dir("./dist").Open(r.URL.Path)
 		if err == nil {
+			setStaticCacheHeader(w, r.URL.Path)
 			fs.ServeHTTP(w, r)
 			return
 		}
@@ -110,10 +111,22 @@ func (api *api) handleStaticFiles() http.HandlerFunc {
 		// SPA fallback only for browser navigation requests.
 		accept := r.Header.Get("Accept")
 		if r.Method == http.MethodGet && strings.Contains(accept, "text/html") {
+			setStaticCacheHeader(w, "/index.html")
 			http.ServeFile(w, r, "./dist/index.html")
 			return
 		}
 
 		http.NotFound(w, r)
+	}
+}
+
+func setStaticCacheHeader(w http.ResponseWriter, requestPath string) {
+	switch {
+	case requestPath == "/" || requestPath == "/index.html" || requestPath == "/sw.js" || requestPath == "/manifest.webmanifest" || requestPath == "/manifest.json":
+		w.Header().Set("Cache-Control", "no-cache")
+	case strings.HasPrefix(requestPath, "/assets/"):
+		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	default:
+		w.Header().Set("Cache-Control", "public, max-age=3600")
 	}
 }

--- a/server/cmd/api/routes_test.go
+++ b/server/cmd/api/routes_test.go
@@ -6,8 +6,11 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Andrewy-gh/fittrack/server/internal/account"
 	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
@@ -218,4 +221,93 @@ func TestRoutes_RegistersAccountDeletion(t *testing.T) {
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("expected status %d, got %d with body %s", http.StatusNoContent, rr.Code, rr.Body.String())
 	}
+}
+
+func TestStaticFiles_SetCacheHeadersForPWAUpdates(t *testing.T) {
+	writeStaticTestFile(t, "index.html", "<!doctype html>")
+	writeStaticTestFile(t, "sw.js", "self.skipWaiting()")
+	writeStaticTestFile(t, "manifest.webmanifest", "{}")
+	writeStaticTestFile(t, filepath.Join("assets", "index-abc123.js"), "console.log('ok')")
+
+	api := &api{}
+	handler := api.handleStaticFiles()
+
+	tests := []struct {
+		name       string
+		path       string
+		accept     string
+		wantStatus int
+		wantCache  string
+	}{
+		{
+			name:       "app shell fallback is revalidated",
+			path:       "/workouts",
+			accept:     "text/html",
+			wantStatus: http.StatusOK,
+			wantCache:  "no-cache",
+		},
+		{
+			name:       "service worker is revalidated",
+			path:       "/sw.js",
+			wantStatus: http.StatusOK,
+			wantCache:  "no-cache",
+		},
+		{
+			name:       "manifest is revalidated",
+			path:       "/manifest.webmanifest",
+			wantStatus: http.StatusOK,
+			wantCache:  "no-cache",
+		},
+		{
+			name:       "hashed assets are immutable",
+			path:       "/assets/index-abc123.js",
+			wantStatus: http.StatusOK,
+			wantCache:  "public, max-age=31536000, immutable",
+		},
+		{
+			name:       "missing old assets are still not rewritten to html",
+			path:       "/assets/missing-old-build.js",
+			wantStatus: http.StatusNotFound,
+			wantCache:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			if tt.accept != "" {
+				req.Header.Set("Accept", tt.accept)
+			}
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d with body %s", tt.wantStatus, rr.Code, rr.Body.String())
+			}
+			if got := rr.Header().Get("Cache-Control"); got != tt.wantCache {
+				t.Fatalf("expected Cache-Control %q, got %q", tt.wantCache, got)
+			}
+		})
+	}
+}
+
+func writeStaticTestFile(t *testing.T, relativePath string, contents string) {
+	t.Helper()
+
+	path := filepath.Join("dist", relativePath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create static test directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write static test file: %v", err)
+	}
+	t.Cleanup(func() {
+		for range 10 {
+			if err := os.RemoveAll("dist"); err == nil || os.IsNotExist(err) {
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- switch PWA registration from auto-update to prompt mode so the in-app reload prompt can actually appear
- ask the service worker registration to check for updates when the installed app is focused or becomes visible again
- set explicit cache headers for app shell, service worker, manifest, and hashed assets

## Verification
- bun run fmt:check
- bun run lint
- bun run knip
- bun run tsc
- bun run test
- bun run build
- go test ./cmd/api
- go test ./... (fails without local Postgres on 127.0.0.1:5432)
- go test -short ./... (passed via pre-push hook after starting local Postgres)

Note: Vite build still reports the existing large chunk warning.