### PR TITLE
feat: expose internal Fly metrics scrape

### DIFF
--- a/docs/ai-chat-observability.md
+++ b/docs/ai-chat-observability.md
@@ -2,6 +2,8 @@
 
 This repo records client-observed AI chat outcomes into Prometheus via `ai_chat_client_outcomes_total{category,outcome,stage,cohort}`.
 
+Fly scrapes Prometheus metrics from the internal metrics listener on `METRICS_PORT`, which defaults to `9091`. The public `GET /metrics` endpoint remains Basic Auth protected when `METRICS_USERNAME` and `METRICS_PASSWORD` are configured.
+
 Outcome taxonomy:
 
 - `stream`: `completed`, `server_error`, `transport_ended_pre_terminal`, `client_aborted`
@@ -65,6 +67,26 @@ Beta vs non-beta comparison:
 
 ```promql
 sum by (cohort, outcome) (rate(ai_chat_client_outcomes_total{category="stream"}[15m]))
+```
+
+## Fly Scrape Verification
+
+After deploy, verify Fly is configured to scrape the internal listener:
+
+```sh
+flyctl config show -a fittrack --toml
+```
+
+Confirm the public metrics endpoint still requires credentials when metrics auth is configured:
+
+```sh
+curl -i https://fittrack.fly.dev/metrics
+```
+
+The unauthenticated public request should return `401 Unauthorized`; Fly scrapes the internal `9091` listener instead. After sending a test AI chat telemetry event, query Fly/Grafana for:
+
+```promql
+ai_chat_client_outcomes_total
 ```
 
 ## Alerting Rules

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,10 @@ primary_region = 'ewr'
 
 [build]
 
+[metrics]
+  port = 9091
+  path = "/metrics"
+
 [http_service]
   internal_port = 8080
   force_https = true

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -77,6 +77,19 @@ func newHTTPServer(cfg *config.Config, handler http.Handler) *http.Server {
 	}
 }
 
+func newMetricsServer(cfg *config.Config, handler http.Handler) *http.Server {
+	mux := http.NewServeMux()
+	mux.Handle("GET /metrics", handler)
+
+	return &http.Server{
+		Addr:         fmt.Sprintf(":%d", cfg.MetricsPort),
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+}
+
 func main() {
 	// Load and validate configuration
 	cfg, err := config.Load()
@@ -110,6 +123,7 @@ func main() {
 	logger.Info("starting application",
 		"environment", cfg.Environment,
 		"port", cfg.Port,
+		"metrics_port", cfg.MetricsPort,
 		"log_level", cfg.LogLevel,
 		"db_max_conns", cfg.DBMaxConns,
 		"rate_limit_rpm", cfg.RateLimitRPM,
@@ -250,16 +264,21 @@ func main() {
 
 	// Configure HTTP server with timeouts
 	srv := newHTTPServer(cfg, handler)
+	metricsSrv := newMetricsServer(cfg, api.metricsHandler())
 
 	// Set up signal handling for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
 
 	// Start server in a goroutine
-	serverErrors := make(chan error, 1)
+	serverErrors := make(chan error, 2)
 	go func() {
 		logger.Info("starting server", "addr", srv.Addr)
 		serverErrors <- srv.ListenAndServe()
+	}()
+	go func() {
+		logger.Info("starting metrics server", "addr", metricsSrv.Addr)
+		serverErrors <- metricsSrv.ListenAndServe()
 	}()
 
 	// Block until we receive a signal or server error
@@ -281,6 +300,11 @@ func main() {
 		// Attempt graceful shutdown
 		if err := srv.Shutdown(shutdownCtx); err != nil {
 			logger.Error("forced shutdown", "error", err)
+			pool.Close()
+			os.Exit(1)
+		}
+		if err := metricsSrv.Shutdown(shutdownCtx); err != nil {
+			logger.Error("forced metrics shutdown", "error", err)
 			pool.Close()
 			os.Exit(1)
 		}

--- a/server/cmd/api/main_test.go
+++ b/server/cmd/api/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -13,5 +14,32 @@ func TestNewHTTPServerUsesBoundedWriteTimeout(t *testing.T) {
 
 	if srv.WriteTimeout != 10*time.Second {
 		t.Fatalf("WriteTimeout = %v, want %v", srv.WriteTimeout, 10*time.Second)
+	}
+}
+
+func TestNewMetricsServerUsesConfiguredPortAndMetricsPath(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := newMetricsServer(&config.Config{MetricsPort: 9092}, handler)
+
+	if srv.Addr != ":9092" {
+		t.Fatalf("Addr = %q, want %q", srv.Addr, ":9092")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d", http.StatusNoContent, rr.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/not-metrics", nil)
+	rr = httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, rr.Code)
 	}
 }

--- a/server/cmd/api/routes.go
+++ b/server/cmd/api/routes.go
@@ -28,15 +28,8 @@ func (api *api) routes(wh *workout.WorkoutHandler, eh *exercise.ExerciseHandler,
 		mux.HandleFunc("POST /stripe/webhook", bh.Webhook)
 	}
 
-	// Metrics endpoint (basic auth if configured)
-	metricsHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Update database metrics before serving
-		middleware.UpdateDatabaseMetrics(api.pool)
-		promhttp.Handler().ServeHTTP(w, r)
-	})
-
 	// Wrap with basic auth if credentials are configured
-	protectedMetrics := middleware.BasicAuth(api.cfg.MetricsUsername, api.cfg.MetricsPassword, api.logger)(metricsHandler)
+	protectedMetrics := middleware.BasicAuth(api.cfg.MetricsUsername, api.cfg.MetricsPassword, api.logger)(api.metricsHandler())
 	mux.Handle("GET /metrics", protectedMetrics)
 
 	// API endpoints (authentication required)
@@ -87,6 +80,13 @@ func (api *api) routes(wh *workout.WorkoutHandler, eh *exercise.ExerciseHandler,
 	mux.HandleFunc("GET /", api.handleStaticFiles())
 
 	return mux
+}
+
+func (api *api) metricsHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		middleware.UpdateDatabaseMetrics(api.pool)
+		promhttp.Handler().ServeHTTP(w, r)
+	})
 }
 
 func (api *api) handleStaticFiles() http.HandlerFunc {

--- a/server/cmd/api/routes_test.go
+++ b/server/cmd/api/routes_test.go
@@ -139,6 +139,34 @@ func TestRoutes_DoesNotExposeAIChatValidationEndpoints(t *testing.T) {
 	}
 }
 
+func TestRoutes_ProtectsPublicMetricsWhenCredentialsConfigured(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	api := &api{
+		logger: logger,
+		cfg: &config.Config{
+			MetricsUsername: "metrics-user",
+			MetricsPassword: "metrics-password",
+		},
+		pool: nil,
+	}
+
+	wh := &workout.WorkoutHandler{}
+	eh := &exercise.ExerciseHandler{}
+	fh := &featureaccess.Handler{}
+	hh := health.NewHandler(logger, nil)
+	ah := aichat.NewHandler(logger, nil)
+
+	mux := api.routes(wh, eh, fh, hh, ah, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+}
+
 func TestRoutes_RegistersBillingCustomerPortalSession(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	api := &api{

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 
 	// Optional fields with defaults
 	Port           int    `validate:"omitempty,min=1,max=65535"`
+	MetricsPort    int    `validate:"omitempty,min=1,max=65535"`
 	LogLevel       string `validate:"omitempty,oneof=debug info warn error"`
 	Environment    string `validate:"omitempty,oneof=development staging production"`
 	RateLimitRPM   int    `validate:"omitempty,min=1"`
@@ -58,6 +59,7 @@ func Load() (*Config, error) {
 		DatabaseURL:         os.Getenv("DATABASE_URL"),
 		ProjectID:           os.Getenv("PROJECT_ID"),
 		Port:                getEnvInt("PORT", 8080),
+		MetricsPort:         getEnvInt("METRICS_PORT", 9091),
 		LogLevel:            getEnvString("LOG_LEVEL", "info"),
 		Environment:         getEnvString("ENVIRONMENT", "development"),
 		RateLimitRPM:        getEnvInt("RATE_LIMIT_RPM", 100),

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -102,6 +102,10 @@ func TestLoad_DefaultValues(t *testing.T) {
 		t.Errorf("expected default Port to be 8080, got: %d", cfg.Port)
 	}
 
+	if cfg.MetricsPort != 9091 {
+		t.Errorf("expected default MetricsPort to be 9091, got: %d", cfg.MetricsPort)
+	}
+
 	if cfg.LogLevel != "info" {
 		t.Errorf("expected default LogLevel to be 'info', got: %s", cfg.LogLevel)
 	}
@@ -127,6 +131,7 @@ func TestLoad_CustomValues(t *testing.T) {
 	os.Setenv("DATABASE_URL", "postgresql://user:pass@localhost:5432/testdb")
 	os.Setenv("PROJECT_ID", "test-project-123")
 	os.Setenv("PORT", "9000")
+	os.Setenv("METRICS_PORT", "9092")
 	os.Setenv("LOG_LEVEL", "debug")
 	os.Setenv("ENVIRONMENT", "production")
 	os.Setenv("RATE_LIMIT_RPM", "200")
@@ -139,6 +144,10 @@ func TestLoad_CustomValues(t *testing.T) {
 
 	if cfg.Port != 9000 {
 		t.Errorf("expected Port to be 9000, got: %d", cfg.Port)
+	}
+
+	if cfg.MetricsPort != 9092 {
+		t.Errorf("expected MetricsPort to be 9092, got: %d", cfg.MetricsPort)
 	}
 
 	if cfg.LogLevel != "debug" {
@@ -435,6 +444,7 @@ func TestLoad_InvalidIntegerValues(t *testing.T) {
 	os.Setenv("DATABASE_URL", "postgresql://user:pass@localhost:5432/testdb")
 	os.Setenv("PROJECT_ID", "test-project-123")
 	os.Setenv("PORT", "not-a-number")
+	os.Setenv("METRICS_PORT", "also-not-a-number")
 	os.Setenv("RATE_LIMIT_RPM", "invalid")
 	defer cleanupEnv()
 
@@ -448,6 +458,10 @@ func TestLoad_InvalidIntegerValues(t *testing.T) {
 		t.Errorf("expected Port to be default (8080), got: %d", cfg.Port)
 	}
 
+	if cfg.MetricsPort != 9091 {
+		t.Errorf("expected MetricsPort to be default (9091), got: %d", cfg.MetricsPort)
+	}
+
 	if cfg.RateLimitRPM != 100 {
 		t.Errorf("expected RateLimitRPM to be default (100), got: %d", cfg.RateLimitRPM)
 	}
@@ -456,6 +470,9 @@ func TestLoad_InvalidIntegerValues(t *testing.T) {
 	logOutput := buf.String()
 	if !bytes.Contains([]byte(logOutput), []byte("PORT")) {
 		t.Error("expected log to contain 'PORT'")
+	}
+	if !bytes.Contains([]byte(logOutput), []byte("METRICS_PORT")) {
+		t.Error("expected log to contain 'METRICS_PORT'")
 	}
 	if !bytes.Contains([]byte(logOutput), []byte("RATE_LIMIT_RPM")) {
 		t.Error("expected log to contain 'RATE_LIMIT_RPM'")
@@ -467,6 +484,7 @@ func cleanupEnv() {
 	os.Unsetenv("DATABASE_URL")
 	os.Unsetenv("PROJECT_ID")
 	os.Unsetenv("PORT")
+	os.Unsetenv("METRICS_PORT")
 	os.Unsetenv("LOG_LEVEL")
 	os.Unsetenv("ENVIRONMENT")
 	os.Unsetenv("RATE_LIMIT_RPM")
@@ -476,6 +494,8 @@ func cleanupEnv() {
 	os.Unsetenv("DB_MAX_CONN_IDLE")
 	os.Unsetenv("DB_MAX_CONN_LIFE")
 	os.Unsetenv("DB_HEALTHCHECK")
+	os.Unsetenv("METRICS_USERNAME")
+	os.Unsetenv("METRICS_PASSWORD")
 	os.Unsetenv("INNGEST_EVENT_KEY")
 	os.Unsetenv("INNGEST_SIGNING_KEY")
 	os.Unsetenv("E2E_LOCAL_AUTH_ENABLED")


### PR DESCRIPTION
## User impact

AI chat reliability metrics can be scraped by Fly after deploy, which makes the existing `ai_chat_client_outcomes_total` telemetry usable in Fly/Grafana without exposing unauthenticated public metrics.

## Product behavior

- Adds a separate internal metrics listener on `METRICS_PORT`, defaulting to `9091`.
- Keeps public `GET /metrics` behavior unchanged: it remains Basic Auth protected when metrics credentials are configured.
- Configures Fly custom metrics to scrape `9091` at `/metrics`.
- Reuses the same Prometheus metrics handler for both public and internal metrics paths.

## Risk

Low. This does not change AI chat behavior, billing, auth, dashboards, alerts, or deploy settings beyond Fly's metrics scrape target. The main risk is startup failing if `METRICS_PORT` is already occupied, which should be visible immediately on deploy.

## Verification

- `go test ./cmd/api ./internal/config`
- `$pkgs = go list ./... | Where-Object { $_ -notmatch '/internal/database$' }; go test -short $pkgs`
- `go vet ./...`
- `go build ./cmd/api`
- `git diff --check`

## Post-deploy checks

- `flyctl config show -a fittrack --toml`
- `curl -i https://fittrack.fly.dev/metrics` should return `401 Unauthorized` when metrics credentials are configured.
- After a test AI chat telemetry event, query Fly/Grafana for `ai_chat_client_outcomes_total`.

No production deploy included.