### PR TITLE
feat: wire ai chat alerts for grafana cloud

### DIFF
--- a/docs/ai-chat-alerting-runbook.md
+++ b/docs/ai-chat-alerting-runbook.md
@@ -1,0 +1,111 @@
+# AI Chat Alerting Runbook
+
+This runbook makes the AI chat client-outcome alerts loadable into Grafana Cloud Metrics, which uses Mimir for Prometheus-compatible rule evaluation.
+
+The repo-owned rule file is `ops/grafana-cloud/ai-chat-alerts.mimir.yml`. It keeps the same paging semantics as `ops/prometheus/ai-chat-alerts.yml`:
+
+- page on true server stream failures, recovery timeouts, conversation load failures, and recovery success regression
+- do not page on user-driven stream aborts, stale load aborts, recovery aborts, or successful-recovery toast suppression
+
+## Required Access
+
+Keep credentials out of the repo. Set them only in the shell used to verify or load rules:
+
+```sh
+export MIMIR_ADDRESS="https://prometheus-<region>.grafana.net"
+export MIMIR_API_USER="<grafana-cloud-instance-id>"
+export MIMIR_API_KEY="<grafana-cloud-access-policy-token>"
+export MIMIR_QUERY_URL="${MIMIR_ADDRESS}/prometheus/api/v1/query"
+```
+
+The token needs enough Grafana Cloud Metrics permissions to query metrics and manage rules.
+
+## Confirm Fly Is Scraping The Metric
+
+Confirm Fly still has the internal metrics scrape configured:
+
+```sh
+flyctl config show -a fittrack --toml
+```
+
+Expected config:
+
+```toml
+[metrics]
+  port = 9091
+  path = "/metrics"
+```
+
+After using the beta AI chat flow, query Grafana Cloud Metrics for the counter from Grafana Explore or the Prometheus-compatible query endpoint:
+
+```sh
+curl -u "${MIMIR_API_USER}:${MIMIR_API_KEY}" \
+  --get "${MIMIR_QUERY_URL}" \
+  --data-urlencode 'query=ai_chat_client_outcomes_total'
+```
+
+The result should include `category`, `outcome`, `stage`, and `cohort` labels.
+
+## Load And Verify Rules
+
+Validate the rule file before loading:
+
+```sh
+mimirtool rules lint ops/grafana-cloud/ai-chat-alerts.mimir.yml
+```
+
+Preview the remote change:
+
+```sh
+mimirtool rules diff ops/grafana-cloud/ai-chat-alerts.mimir.yml \
+  --address="${MIMIR_ADDRESS}" \
+  --id="${MIMIR_API_USER}" \
+  --key="${MIMIR_API_KEY}"
+```
+
+Load the rules:
+
+```sh
+mimirtool rules load ops/grafana-cloud/ai-chat-alerts.mimir.yml \
+  --address="${MIMIR_ADDRESS}" \
+  --id="${MIMIR_API_USER}" \
+  --key="${MIMIR_API_KEY}"
+```
+
+Confirm the namespace and group are present:
+
+```sh
+mimirtool rules list \
+  --address="${MIMIR_ADDRESS}" \
+  --id="${MIMIR_API_USER}" \
+  --key="${MIMIR_API_KEY}"
+```
+
+Expected entry:
+
+```text
+ai_chat_rollout | ai-chat-rollout
+```
+
+Confirm Mimir is evaluating the loaded alerts:
+
+```sh
+mimirtool rules print \
+  --address="${MIMIR_ADDRESS}" \
+  --id="${MIMIR_API_USER}" \
+  --key="${MIMIR_API_KEY}"
+```
+
+In Grafana Cloud, open Alerting, then Alert rules, and confirm the `ai_chat_rollout` namespace shows the four AI chat rollout alerts.
+
+## Notification Routing
+
+These rules label page-worthy alerts with `severity="page"`. Configure notification routing in Grafana Cloud Alerting so that this label reaches the intended on-call contact point.
+
+Before enabling a production page route, confirm:
+
+- the `severity="page"` matcher routes to the expected contact point
+- the contact point is owned by the current FitTrack operator
+- no broad catch-all route sends beta rollout alerts to an unintended audience
+
+Do not commit contact point secrets, webhook URLs, phone numbers, or API keys.

--- a/docs/ai-chat-observability.md
+++ b/docs/ai-chat-observability.md
@@ -91,6 +91,8 @@ ai_chat_client_outcomes_total
 
 ## Alerting Rules
 
+Use [AI Chat Alerting Runbook](ai-chat-alerting-runbook.md) to load and verify the Grafana Cloud Metrics/Mimir rule artifact in `ops/grafana-cloud/ai-chat-alerts.mimir.yml`.
+
 Page on:
 
 - rising `stream=server_error`

--- a/ops/grafana-cloud/ai-chat-alerts.mimir.yml
+++ b/ops/grafana-cloud/ai-chat-alerts.mimir.yml
@@ -1,0 +1,63 @@
+namespace: ai_chat_rollout
+groups:
+  - name: ai-chat-rollout
+    rules:
+      - alert: AIChatTrueStreamFailuresHigh
+        expr: |
+          (
+            sum(rate(ai_chat_client_outcomes_total{category="stream",outcome="server_error",cohort="beta"}[15m]))
+            /
+            clamp_min(sum(rate(ai_chat_client_outcomes_total{category="stream",outcome=~"completed|server_error|transport_ended_pre_terminal|client_aborted",cohort="beta"}[15m])), 0.001)
+          ) > 0.03
+          and sum(rate(ai_chat_client_outcomes_total{category="stream",outcome="server_error",cohort="beta"}[15m])) > 0.02
+        for: 15m
+        labels:
+          severity: page
+        annotations:
+          summary: AI chat true stream failures are rising
+          description: Pages only on server-side stream failures and excludes client aborts and stale-load cancels.
+
+      - alert: AIChatRecoveryTimeoutsHigh
+        expr: |
+          (
+            sum(rate(ai_chat_client_outcomes_total{category="recovery",outcome="recovery_timeout",cohort="beta"}[30m]))
+            /
+            clamp_min(sum(rate(ai_chat_client_outcomes_total{category="recovery",outcome=~"recovered_completed|recovered_failed|recovery_timeout",cohort="beta"}[30m])), 0.001)
+          ) > 0.10
+          and sum(rate(ai_chat_client_outcomes_total{category="recovery",outcome=~"recovered_completed|recovered_failed|recovery_timeout",cohort="beta"}[30m])) > 0.01
+        for: 30m
+        labels:
+          severity: page
+        annotations:
+          summary: AI chat recovery timeouts are rising
+          description: Recovery timeout paging excludes recovery_aborted so navigation and clear-chat actions do not page.
+
+      - alert: AIChatConversationLoadFailuresHigh
+        expr: |
+          (
+            sum(rate(ai_chat_client_outcomes_total{category="load",outcome="load_failed",cohort="beta"}[15m]))
+            /
+            clamp_min(sum(rate(ai_chat_client_outcomes_total{category="load",outcome=~"load_completed|load_failed",cohort="beta"}[15m])), 0.001)
+          ) > 0.05
+          and sum(rate(ai_chat_client_outcomes_total{category="load",outcome="load_failed",cohort="beta"}[15m])) > 0.02
+        for: 15m
+        labels:
+          severity: page
+        annotations:
+          summary: Persisted conversation fetch failures are rising
+          description: Pages on real conversation-load failures and excludes load_aborted_stale.
+
+      - alert: AIChatRecoverySuccessRateRegression
+        expr: |
+          (
+            sum(rate(ai_chat_client_outcomes_total{category="recovery",outcome="recovered_completed",cohort="beta"}[30m]))
+            /
+            clamp_min(sum(rate(ai_chat_client_outcomes_total{category="recovery",outcome=~"recovered_completed|recovered_failed|recovery_timeout",cohort="beta"}[30m])), 0.001)
+          ) < 0.80
+          and sum(rate(ai_chat_client_outcomes_total{category="recovery",outcome=~"recovered_completed|recovered_failed|recovery_timeout",cohort="beta"}[30m])) > 0.01
+        for: 30m
+        labels:
+          severity: page
+        annotations:
+          summary: AI chat recovery success rate regressed after interrupted streams
+          description: Uses only completed, failed, and timeout recovery outcomes and ignores recovery_aborted.


### PR DESCRIPTION
## User impact

FitTrack can now turn the AI chat rollout metric into real paging alerts after the internal Fly scrape is deployed. This helps catch true beta failures before access is widened.

## Product behavior

- Adds a Grafana Cloud Metrics/Mimir rule artifact at `ops/grafana-cloud/ai-chat-alerts.mimir.yml`.
- Keeps paging focused on true stream server errors, recovery timeouts, conversation load failures, and recovery success regression.
- Keeps user-driven stream aborts, stale load aborts, recovery aborts, and successful-recovery toast suppression out of paging.
- Adds a runbook for confirming Fly scrape, querying `ai_chat_client_outcomes_total`, loading rules, checking evaluation, and reviewing notification routing.

## Risk

Low. This PR only adds repo-owned alerting config and docs. It does not deploy production code, modify Fly config, or change live Grafana Cloud notification settings.

## Verification

- Confirmed branch started from `origin/main` at `f2b56e1 feat: expose internal Fly metrics scrape`.
- Parsed both `ops/prometheus/ai-chat-alerts.yml` and `ops/grafana-cloud/ai-chat-alerts.mimir.yml` as YAML with the repo's Go YAML dependency.
- Ran `git diff --cached --check` before commit.

## Follow-up after merge

With Grafana Cloud credentials, run the new runbook to load the `ai_chat_rollout` namespace, confirm the rules are evaluating, and wire `severity="page"` to the intended contact point.
