### PR TITLE
feat: add ai chat grafana dashboard

### DIFF
--- a/docs/ai-chat-alerting-runbook.md
+++ b/docs/ai-chat-alerting-runbook.md
@@ -98,6 +98,19 @@ mimirtool rules print \
 
 In Grafana Cloud, open Alerting, then Alert rules, and confirm the `ai_chat_rollout` namespace shows the four AI chat rollout alerts.
 
+## Import Dashboard
+
+The repo-owned dashboard file is `ops/grafana-cloud/ai-chat-observability-dashboard.json`. It uses a Grafana datasource variable named `DS_PROMETHEUS`, so the exported JSON does not contain stack IDs, URLs, tokens, or other Grafana Cloud secrets.
+
+To import it:
+
+1. In Grafana Cloud, open Dashboards, then New, then Import.
+2. Upload `ops/grafana-cloud/ai-chat-observability-dashboard.json` or paste its JSON.
+3. When Grafana asks for `DS_PROMETHEUS`, choose the Grafana Cloud Metrics datasource for the FitTrack stack.
+4. Open the imported `AI Chat Observability` dashboard.
+5. In Explore, query `ai_chat_client_outcomes_total` and confirm the result includes `category`, `outcome`, `stage`, and `cohort` labels.
+6. Compare the dashboard's beta panels with the Explore result over the same time range. Empty panels are acceptable before fresh beta AI chat traffic exists; query errors or missing labels mean the datasource or scrape path needs investigation before widening rollout.
+
 ## Notification Routing
 
 These rules label page-worthy alerts with `severity="page"`. Configure notification routing in Grafana Cloud Alerting so that this label reaches the intended on-call contact point.

--- a/ops/grafana-cloud/ai-chat-observability-dashboard.json
+++ b/ops/grafana-cloud/ai-chat-observability-dashboard.json
@@ -1,0 +1,497 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Server-side stream failures divided by all beta stream outcomes. Client aborts stay in the denominator so this tracks real stream health without paging on navigation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.02
+              },
+              {
+                "color": "red",
+                "value": 0.03
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ai_chat_client_outcomes_total{category=\"stream\",outcome=\"server_error\",cohort=\"beta\"}[15m])) / clamp_min(sum(rate(ai_chat_client_outcomes_total{category=\"stream\",outcome=~\"completed|server_error|transport_ended_pre_terminal|client_aborted\",cohort=\"beta\"}[15m])), 0.001)",
+          "legendFormat": "server_error / all beta streams",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "True stream failure rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "User-driven or navigation-driven stream aborts divided by all beta stream outcomes. This should explain churn without being treated as a server failure.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ai_chat_client_outcomes_total{category=\"stream\",outcome=\"client_aborted\",cohort=\"beta\"}[15m])) / clamp_min(sum(rate(ai_chat_client_outcomes_total{category=\"stream\",outcome=~\"completed|server_error|transport_ended_pre_terminal|client_aborted\",cohort=\"beta\"}[15m])), 0.001)",
+          "legendFormat": "client_aborted / all beta streams",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Client abort rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Recovered beta streams divided by completed, failed, and timed-out recovery attempts. Aborted recovery attempts are excluded so user navigation does not depress the rollout gate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.8
+              },
+              {
+                "color": "green",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ai_chat_client_outcomes_total{category=\"recovery\",outcome=\"recovered_completed\",cohort=\"beta\"}[30m])) / clamp_min(sum(rate(ai_chat_client_outcomes_total{category=\"recovery\",outcome=~\"recovered_completed|recovered_failed|recovery_timeout\",cohort=\"beta\"}[30m])), 0.001)",
+          "legendFormat": "recovered_completed / recovery attempts",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Recovery success rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Beta streams that ended before the first start event, divided by all beta stream outcomes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ai_chat_client_outcomes_total{category=\"stream\",outcome=\"transport_ended_pre_terminal\",stage=\"pre_start\",cohort=\"beta\"}[15m])) / clamp_min(sum(rate(ai_chat_client_outcomes_total{category=\"stream\",outcome=~\"completed|server_error|transport_ended_pre_terminal|client_aborted\",cohort=\"beta\"}[15m])), 0.001)",
+          "legendFormat": "pre_start disconnect / all beta streams",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pre-start disconnect rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Timed-out recovery attempts divided by completed, failed, and timed-out beta recovery attempts.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ai_chat_client_outcomes_total{category=\"recovery\",outcome=\"recovery_timeout\",cohort=\"beta\"}[30m])) / clamp_min(sum(rate(ai_chat_client_outcomes_total{category=\"recovery\",outcome=~\"recovered_completed|recovered_failed|recovery_timeout\",cohort=\"beta\"}[30m])), 0.001)",
+          "legendFormat": "recovery_timeout / recovery attempts",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Recovery timeout rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Client-visible failure toasts divided by all beta stream outcomes. This tracks user-visible pain separately from server-side failure semantics.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ai_chat_client_outcomes_total{category=\"ux\",outcome=\"failure_toast_shown\",cohort=\"beta\"}[15m])) / clamp_min(sum(rate(ai_chat_client_outcomes_total{category=\"stream\",outcome=~\"completed|server_error|transport_ended_pre_terminal|client_aborted\",cohort=\"beta\"}[15m])), 0.001)",
+          "legendFormat": "failure_toast_shown / all beta streams",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Client-visible error toast rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
+      "description": "Stream outcome rates grouped by cohort and outcome so beta behavior can be compared with non-beta traffic.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 3,
+          "mappings": [],
+          "min": 0,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cohort, outcome) (rate(ai_chat_client_outcomes_total{category=\"stream\"}[15m]))",
+          "legendFormat": "{{cohort}} {{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Beta vs non-beta stream outcomes",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["ai-chat", "rollout", "grafana-cloud"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AI Chat Observability",
+  "uid": "ai-chat-observability",
+  "version": 1,
+  "weekStart": ""
+}

--- a/ops/grafana-cloud/ai-chat-observability-dashboard.json
+++ b/ops/grafana-cloud/ai-chat-observability-dashboard.json
@@ -401,6 +401,77 @@
         "type": "prometheus",
         "uid": "$DS_PROMETHEUS"
       },
+      "description": "Persisted conversation load failures divided by completed and failed beta load outcomes. Stale aborted loads are excluded so refreshes or superseded loads do not inflate the rollout gate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.03
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ai_chat_client_outcomes_total{category=\"load\",outcome=\"load_failed\",cohort=\"beta\"}[15m])) / clamp_min(sum(rate(ai_chat_client_outcomes_total{category=\"load\",outcome=~\"load_completed|load_failed\",cohort=\"beta\"}[15m])), 0.001)",
+          "legendFormat": "load_failed / completed or failed beta loads",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Conversation load failure rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$DS_PROMETHEUS"
+      },
       "description": "Stream outcome rates grouped by cohort and outcome so beta behavior can be compared with non-beta traffic.",
       "fieldConfig": {
         "defaults": {
@@ -431,9 +502,9 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 24
       },
-      "id": 7,
+      "id": 8,
       "options": {
         "legend": {
           "calcs": ["lastNotNull"],


### PR DESCRIPTION
## User impact

This makes the AI chat rollout health dashboard reviewable and importable before Andy widens access. The dashboard turns the documented client-outcome PromQL into Grafana panels for stream failures, aborts, recovery health, visible error toasts, and beta vs non-beta stream outcomes.

## Product behavior

- Adds `ops/grafana-cloud/ai-chat-observability-dashboard.json` as a Grafana dashboard export.
- Uses the existing `ai_chat_client_outcomes_total{category,outcome,stage,cohort}` metric and the PromQL already documented in `docs/ai-chat-observability.md`.
- Uses a `DS_PROMETHEUS` datasource variable so no Grafana Cloud stack IDs, URLs, tokens, or secrets are committed.
- Documents how to import the dashboard and validate it against `ai_chat_client_outcomes_total` in Grafana Explore.

## Risk

Low. This is a dashboard/docs-only PR with no app code, alert threshold, rule semantic, deploy, or live Grafana Cloud API changes. The main remaining risk is Grafana import compatibility with the target Cloud stack, which Andy can validate by importing the JSON and selecting the FitTrack Metrics datasource.

## Verification

- Confirmed branch started from `origin/main` at `dd7c90c feat: wire ai chat alerts for grafana cloud (#194)`.
- Parsed `ops/grafana-cloud/ai-chat-observability-dashboard.json` with PowerShell `ConvertFrom-Json`.
- Checked the dashboard has 7 panels and a `DS_PROMETHEUS` datasource variable.
- Checked panel PromQL coverage for server errors, client aborts, recovery success, pre-start disconnects, recovery timeouts, failure toasts, and beta vs non-beta stream outcomes.
- Ran `git diff --check`.
- Skipped frontend lint because this PR only touches docs/ops JSON and `client/node_modules` is not installed in the clean worktree.