### PR TITLE
fix: prevent AI chat composer iOS zoom

### DIFF
--- a/client/src/features/chat/components/chat-composer.test.tsx
+++ b/client/src/features/chat/components/chat-composer.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ChatComposer } from "./chat-composer";
+
+describe("ChatComposer", () => {
+  it("keeps the mobile textarea font at 16px to avoid iOS focus zoom", () => {
+    render(
+      <ChatComposer
+        value=""
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        placeholder="Ask FitTrack"
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText("Ask FitTrack");
+
+    expect(textarea).toHaveClass("text-base", "md:text-sm");
+    expect(textarea).not.toHaveClass("text-sm");
+  });
+});

--- a/client/src/features/chat/components/chat-composer.tsx
+++ b/client/src/features/chat/components/chat-composer.tsx
@@ -80,7 +80,7 @@ export function ChatComposer({
           autoFocus={autoFocus}
           rows={1}
           className={cn(
-            "max-h-40 min-h-[1.5rem] flex-1 resize-none bg-transparent py-1 text-sm leading-6",
+            "max-h-40 min-h-[1.5rem] flex-1 resize-none bg-transparent py-1 text-base leading-6 md:text-sm",
             "outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed",
           )}
         />


### PR DESCRIPTION
## Summary
- Keep the AI chat composer textarea at a 16px mobile font size so iOS does not focus-zoom it in installed PWA sessions.
- Preserve the smaller desktop density with `md:text-sm`.
- Add a regression test that locks the mobile/desktop text-size classes on the composer.

## Verification
- `bun run test src/features/chat/components/chat-composer.test.tsx`
- `bun run test src/features/chat/pages/chat-page.test.tsx src/features/chat/components/chat-composer.test.tsx`
- `bun run lint src/features/chat/components/chat-composer.tsx src/features/chat/components/chat-composer.test.tsx`
- `bun run fmt:check src/features/chat/components/chat-composer.tsx src/features/chat/components/chat-composer.test.tsx`
- `bun run tsc`
- `bun run build`
- Built CSS check in local Chrome: mobile composer font computed to `16px`, desktop to `14px`, viewport meta retained `viewport-fit=cover`.

## Notes
Windows/Chrome can verify the shipped CSS state, but it cannot fully reproduce iOS standalone PWA WebKit focus zoom. Final behavioral confirmation should be done on the installed iOS PWA.