### PR TITLE
feat: add ai chat history entry

### DIFF
--- a/client/src/features/chat/api/ai-chat.test.ts
+++ b/client/src/features/chat/api/ai-chat.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/lib/local-dev-auth", () => ({
 import "@/lib/api/client-config";
 import {
   createAIChatConversation,
+  listAIChatConversations,
   pollAIChatConversationUntilSettled,
   reportAIChatTelemetry,
   resumeAIChatMessageStream,
@@ -598,5 +599,38 @@ describe("ai chat api wrapper", () => {
     expect(fetch).toHaveBeenCalledWith(expect.any(Request));
     expect(latestRequest().url).toContain("/api/ai/conversations");
     expect(latestRequest().method).toBe("POST");
+  });
+
+  it("lists recent conversations through the generated client", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            id: 72,
+            title: "Leg day plan",
+            created_at: "2026-06-25T17:00:00Z",
+            updated_at: "2026-06-25T17:05:00Z",
+            last_message_at: "2026-06-25T17:05:00Z",
+          },
+        ]),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      ),
+    );
+
+    const conversations = await listAIChatConversations();
+
+    expect(conversations).toHaveLength(1);
+    expect(conversations[0]).toMatchObject({
+      id: 72,
+      title: "Leg day plan",
+    });
+    expect(fetch).toHaveBeenCalledWith(expect.any(Request));
+    expect(latestRequest().url).toContain("/api/ai/conversations");
+    expect(latestRequest().method).toBe("GET");
   });
 });

--- a/client/src/features/chat/api/ai-chat.ts
+++ b/client/src/features/chat/api/ai-chat.ts
@@ -1,4 +1,5 @@
 import {
+  getAiConversations,
   getAiConversationsById,
   postAiChatTelemetry,
   postAiConversations,
@@ -20,6 +21,11 @@ export type AIChatConversation = {
   updated_at: string;
   last_message_at?: string;
 };
+
+export type AIChatConversationSummary = Pick<
+  AIChatConversation,
+  "id" | "title" | "created_at" | "updated_at" | "last_message_at"
+>;
 
 export type AIWorkoutDraftStatus = {
   source_run_id?: number;
@@ -195,6 +201,17 @@ export async function createAIChatConversation(): Promise<AIChatConversation> {
   });
 
   return response.data as AIChatConversation;
+}
+
+export async function listAIChatConversations(
+  options: ConversationRequestOptions = {},
+): Promise<AIChatConversationSummary[]> {
+  const response = await getAiConversations({
+    signal: options.signal,
+    throwOnError: true,
+  });
+
+  return response.data as AIChatConversationSummary[];
 }
 
 export async function reportAIChatTelemetry(

--- a/client/src/features/chat/components/chat-history-entry.tsx
+++ b/client/src/features/chat/components/chat-history-entry.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { MessageSquare, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  listAIChatConversations,
+  type AIChatConversationSummary,
+} from "@/features/chat/api/ai-chat";
+import { getErrorMessage } from "@/lib/errors";
+
+const MAX_VISIBLE_RECENT_CHATS = 5;
+
+type ChatHistoryEntryProps = {
+  userId: string;
+  fallback: ReactNode;
+  onResumeConversation: (conversationId: number) => void;
+  onNewChat: () => void;
+  isNewChatDisabled?: boolean;
+};
+
+export function ChatHistoryEntry({
+  userId,
+  fallback,
+  onResumeConversation,
+  onNewChat,
+  isNewChatDisabled,
+}: ChatHistoryEntryProps) {
+  const [recentConversations, setRecentConversations] = useState<
+    AIChatConversationSummary[]
+  >([]);
+  const [isLoadingRecentConversations, setIsLoadingRecentConversations] =
+    useState(false);
+  const [recentConversationsError, setRecentConversationsError] = useState<
+    string | null
+  >(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setIsLoadingRecentConversations(true);
+    setRecentConversationsError(null);
+
+    void listAIChatConversations({ signal: controller.signal })
+      .then((conversations) => {
+        setRecentConversations(conversations);
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setRecentConversations([]);
+        setRecentConversationsError(
+          getErrorMessage(error, "Could not load recent chats."),
+        );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsLoadingRecentConversations(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [userId]);
+
+  if (isLoadingRecentConversations) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Loading recent chats...
+      </div>
+    );
+  }
+
+  if (recentConversations.length === 0) {
+    return recentConversationsError ? (
+      <div className="flex flex-col gap-4">
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+          {recentConversationsError}
+        </div>
+        {fallback}
+      </div>
+    ) : (
+      fallback
+    );
+  }
+
+  return (
+    <div className="flex min-h-[70vh] flex-col justify-center gap-5 py-8">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+          AI Chat
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Resume a recent conversation or start a new chat.
+        </p>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border bg-background">
+        <div className="border-b px-4 py-3 text-sm font-medium">
+          Recent chats
+        </div>
+        <div className="divide-y">
+          {recentConversations
+            .slice(0, MAX_VISIBLE_RECENT_CHATS)
+            .map((conversation) => (
+              <button
+                key={conversation.id}
+                type="button"
+                onClick={() => onResumeConversation(conversation.id)}
+                className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-accent hover:text-accent-foreground"
+              >
+                <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                  <MessageSquare className="size-4" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium">
+                    {conversation.title?.trim() || `Chat #${conversation.id}`}
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    {formatConversationTimestamp(conversation)}
+                  </span>
+                </span>
+              </button>
+            ))}
+        </div>
+      </div>
+
+      <Button
+        type="button"
+        variant="outline"
+        onClick={onNewChat}
+        disabled={isNewChatDisabled}
+        className="w-full sm:w-fit"
+      >
+        <Plus className="size-4" />
+        New Chat
+      </Button>
+    </div>
+  );
+}
+
+function formatConversationTimestamp(
+  conversation: AIChatConversationSummary,
+): string {
+  const timestamp =
+    conversation.last_message_at ??
+    conversation.updated_at ??
+    conversation.created_at;
+
+  if (!timestamp) {
+    return "Recent activity";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(timestamp));
+}

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -7,6 +7,8 @@ import {
   deferredPromise,
   mockCreateConversation,
   mockGetConversation,
+  mockListConversations,
+  mockNavigate,
   mockPollConversation,
   mockReportTelemetry,
   mockRequestRecovery,
@@ -18,6 +20,67 @@ import {
 
 describe("ChatRouteComponent", () => {
   beforeEach(resetChatRouteMocks);
+
+  it("shows recent chats when entering without a conversation id", async () => {
+    const user = userEvent.setup();
+    mockSearch.conversationId = undefined;
+    mockListConversations.mockResolvedValue([
+      {
+        id: 72,
+        title: "Leg day plan",
+        created_at: "2026-06-25T17:00:00Z",
+        updated_at: "2026-06-25T17:05:00Z",
+        last_message_at: "2026-06-25T17:05:00Z",
+      },
+    ]);
+
+    render(<ChatRouteComponent />);
+
+    expect(await screen.findByText("Recent chats")).toBeInTheDocument();
+    expect(screen.getByText("Leg day plan")).toBeInTheDocument();
+    expect(
+      screen.queryByText("What should we train today?"),
+    ).not.toBeInTheDocument();
+    expect(mockGetConversation).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /Leg day plan/ }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/chat",
+      search: { conversationId: "72" },
+    });
+  });
+
+  it("keeps explicit New Chat available when recent chats exist", async () => {
+    const user = userEvent.setup();
+    mockSearch.conversationId = undefined;
+    mockListConversations.mockResolvedValue([
+      {
+        id: 72,
+        title: "Leg day plan",
+        created_at: "2026-06-25T17:00:00Z",
+        updated_at: "2026-06-25T17:05:00Z",
+        last_message_at: "2026-06-25T17:05:00Z",
+      },
+    ]);
+    mockCreateConversation.mockResolvedValue({
+      id: 73,
+      created_at: "2026-06-26T17:00:00Z",
+      updated_at: "2026-06-26T17:00:00Z",
+    });
+
+    render(<ChatRouteComponent />);
+
+    expect(await screen.findByText("Recent chats")).toBeInTheDocument();
+    const newChatButtons = screen.getAllByRole("button", { name: "New Chat" });
+    await user.click(newChatButtons.at(-1)!);
+
+    expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/chat",
+      search: { conversationId: "73" },
+    });
+  });
 
   it("recovers a completed reply when the stream dies before the start event reaches the client", async () => {
     const user = userEvent.setup();

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -16,6 +16,7 @@ import {
 } from "../components/ai-chat-billing-card";
 import { ChatComposer } from "../components/chat-composer";
 import { ChatEmptyState } from "../components/chat-empty-state";
+import { ChatHistoryEntry } from "../components/chat-history-entry";
 import { ChatMessageActions } from "../components/chat-message-actions";
 import { ChatTypingIndicator } from "../components/chat-typing-indicator";
 import { ChatWorkoutDraftCard } from "../components/chat-workout-draft-card";
@@ -103,6 +104,13 @@ export function ChatPage({
     }
 
     await createNewChat();
+  }
+
+  function handleResumeConversation(selectedConversationId: number) {
+    void navigate({
+      to: "/chat",
+      search: { conversationId: String(selectedConversationId) },
+    });
   }
 
   async function handleSubmit() {
@@ -201,6 +209,19 @@ export function ChatPage({
     !loadError &&
     messages.length === 0 &&
     !conversation?.latest_workout_draft;
+  const emptyState = (
+    <ChatEmptyState
+      heading={
+        hasChatAccess
+          ? "What should we train today?"
+          : "Unlock your AI training partner"
+      }
+      examples={hasChatAccess ? EXAMPLE_PROMPTS : []}
+      onSelectExample={handleSelectExample}
+      composer={composer}
+      disabled={isComposerDisabled}
+    />
+  );
 
   return (
     <div className="flex flex-col gap-4 pb-10">
@@ -254,18 +275,16 @@ export function ChatPage({
       ) : null}
 
       <div className="mx-auto w-full max-w-3xl px-4">
-        {showEmptyState ? (
-          <ChatEmptyState
-            heading={
-              hasChatAccess
-                ? "What should we train today?"
-                : "Unlock your AI training partner"
-            }
-            examples={hasChatAccess ? EXAMPLE_PROMPTS : []}
-            onSelectExample={handleSelectExample}
-            composer={composer}
-            disabled={isComposerDisabled}
+        {!conversationId && showEmptyState ? (
+          <ChatHistoryEntry
+            userId={currentUserId}
+            fallback={emptyState}
+            onResumeConversation={handleResumeConversation}
+            onNewChat={() => void handleNewChat()}
+            isNewChatDisabled={billingAccess.isCheckingAccess || !hasChatAccess}
           />
+        ) : showEmptyState ? (
+          emptyState
         ) : (
           <div className="flex flex-col gap-6">
             {loadError ? (

--- a/client/src/features/chat/test/chat-page-test-utils.tsx
+++ b/client/src/features/chat/test/chat-page-test-utils.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockCreateConversation: vi.fn(),
   mockGetConversation: vi.fn(),
+  mockListConversations: vi.fn(),
   mockPollConversation: vi.fn(),
   mockResumeStream: vi.fn(),
   mockReportTelemetry: vi.fn(),
@@ -45,6 +46,7 @@ export const {
   mockNavigate,
   mockCreateConversation,
   mockGetConversation,
+  mockListConversations,
   mockPollConversation,
   mockResumeStream,
   mockReportTelemetry,
@@ -84,6 +86,7 @@ vi.mock("@tanstack/react-router", () => ({
 vi.mock("@/features/chat/api/ai-chat", () => ({
   createAIChatConversation: mockCreateConversation,
   getAIChatConversation: mockGetConversation,
+  listAIChatConversations: mockListConversations,
   pollAIChatConversationUntilSettled: mockPollConversation,
   resumeAIChatMessageStream: mockResumeStream,
   reportAIChatTelemetry: mockReportTelemetry,
@@ -181,6 +184,7 @@ export function resetChatRouteMocks() {
   mockNavigate.mockReset();
   mockCreateConversation.mockReset();
   mockGetConversation.mockReset();
+  mockListConversations.mockReset();
   mockPollConversation.mockReset();
   mockResumeStream.mockReset();
   mockReportTelemetry.mockReset();
@@ -303,6 +307,7 @@ export function resetChatRouteMocks() {
     }),
   );
   mockReportTelemetry.mockResolvedValue(undefined);
+  mockListConversations.mockResolvedValue([]);
   mockResumeStream.mockResolvedValue({
     doneEvent: {
       type: "done",


### PR DESCRIPTION
## Product impact

PWA users can return to previous AI Chat conversations from inside the app without relying on a visible browser URL. Visiting /chat without a conversationId now loads recent conversations and shows a compact resume surface when history exists. New Chat remains explicit.

## Changes

- Add a frontend wrapper for GET /api/ai/conversations.
- Add a recent-chats entry component for bare /chat.
- Keep /chat?conversationId=... loading the exact conversation through the existing session flow.
- Add regression coverage for prior-chat re-entry and explicit New Chat.

## Verification

- bun run test src/features/chat/pages/chat-page.test.tsx src/features/chat/api/ai-chat.test.ts
- bun run fmt:check src/features/chat/api/ai-chat.ts src/features/chat/components/chat-history-entry.tsx src/features/chat/pages/chat-page.tsx src/features/chat/pages/chat-page.test.tsx src/features/chat/test/chat-page-test-utils.tsx src/features/chat/api/ai-chat.test.ts
- bun run lint
- bun run tsc

Browser check was not run in this isolated worktree because the useful path depends on authenticated chat history from the backend; the route-level regression tests cover the new UI state and navigation behavior.