### PR TITLE
feat: add ai chat history sidebar

### DIFF
--- a/client/src/features/chat/components/chat-history-entry.tsx
+++ b/client/src/features/chat/components/chat-history-entry.tsx
@@ -1,137 +1,258 @@
-import { useEffect, useState, type ReactNode } from "react";
-import { MessageSquare, Plus } from "lucide-react";
+import {
+  History,
+  MessageSquare,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Plus,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
-  listAIChatConversations,
-  type AIChatConversationSummary,
-} from "@/features/chat/api/ai-chat";
-import { getErrorMessage } from "@/lib/errors";
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import type { AIChatConversationSummary } from "@/features/chat/api/ai-chat";
+import { cn } from "@/lib/utils";
 
-const MAX_VISIBLE_RECENT_CHATS = 5;
+const MAX_VISIBLE_RECENT_CHATS = 8;
 
 type ChatHistoryEntryProps = {
-  userId: string;
-  fallback: ReactNode;
+  conversations: AIChatConversationSummary[];
+  activeConversationId: number | null;
+  isLoading: boolean;
+  error: string | null;
+  isCollapsed: boolean;
+  isMobileOpen: boolean;
+  onMobileOpenChange: (open: boolean) => void;
+  onToggleCollapsed: () => void;
   onResumeConversation: (conversationId: number) => void;
   onNewChat: () => void;
   isNewChatDisabled?: boolean;
 };
 
 export function ChatHistoryEntry({
-  userId,
-  fallback,
+  conversations,
+  activeConversationId,
+  isLoading,
+  error,
+  isCollapsed,
+  isMobileOpen,
+  onMobileOpenChange,
+  onToggleCollapsed,
   onResumeConversation,
   onNewChat,
   isNewChatDisabled,
 }: ChatHistoryEntryProps) {
-  const [recentConversations, setRecentConversations] = useState<
-    AIChatConversationSummary[]
-  >([]);
-  const [isLoadingRecentConversations, setIsLoadingRecentConversations] =
-    useState(false);
-  const [recentConversationsError, setRecentConversationsError] = useState<
-    string | null
-  >(null);
+  function handleResumeConversation(conversationId: number) {
+    onResumeConversation(conversationId);
+    onMobileOpenChange(false);
+  }
 
-  useEffect(() => {
-    const controller = new AbortController();
-    setIsLoadingRecentConversations(true);
-    setRecentConversationsError(null);
+  function handleNewChat() {
+    onNewChat();
+    onMobileOpenChange(false);
+  }
 
-    void listAIChatConversations({ signal: controller.signal })
-      .then((conversations) => {
-        setRecentConversations(conversations);
-      })
-      .catch((error: unknown) => {
-        if (controller.signal.aborted) {
-          return;
-        }
-        setRecentConversations([]);
-        setRecentConversationsError(
-          getErrorMessage(error, "Could not load recent chats."),
-        );
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) {
-          setIsLoadingRecentConversations(false);
-        }
-      });
+  return (
+    <>
+      <DesktopHistoryPanel
+        conversations={conversations}
+        activeConversationId={activeConversationId}
+        isLoading={isLoading}
+        error={error}
+        isCollapsed={isCollapsed}
+        onToggleCollapsed={onToggleCollapsed}
+        onResumeConversation={onResumeConversation}
+        onNewChat={onNewChat}
+        isNewChatDisabled={isNewChatDisabled}
+      />
+      <Drawer
+        open={isMobileOpen}
+        onOpenChange={onMobileOpenChange}
+      >
+        <DrawerContent className="lg:hidden">
+          <DrawerHeader className="text-left">
+            <DrawerTitle>Chat history</DrawerTitle>
+            <DrawerDescription>
+              Resume a previous chat or start a new one.
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="max-h-[60vh] overflow-y-auto px-4 pb-4">
+            <HistoryList
+              conversations={conversations}
+              activeConversationId={activeConversationId}
+              isLoading={isLoading}
+              error={error}
+              onResumeConversation={handleResumeConversation}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleNewChat}
+              disabled={isNewChatDisabled}
+              className="mt-4 w-full"
+            >
+              <Plus className="size-4" />
+              New Chat
+            </Button>
+          </div>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+}
 
-    return () => controller.abort();
-  }, [userId]);
-
-  if (isLoadingRecentConversations) {
+function DesktopHistoryPanel({
+  conversations,
+  activeConversationId,
+  isLoading,
+  error,
+  isCollapsed,
+  onToggleCollapsed,
+  onResumeConversation,
+  onNewChat,
+  isNewChatDisabled,
+}: Omit<ChatHistoryEntryProps, "isMobileOpen" | "onMobileOpenChange">) {
+  if (isCollapsed) {
     return (
-      <div className="text-sm text-muted-foreground">
+      <aside className="hidden h-fit flex-col items-center gap-2 rounded-lg border bg-background p-2 lg:sticky lg:top-20 lg:flex">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Expand chat history"
+          onClick={onToggleCollapsed}
+        >
+          <PanelLeftOpen className="size-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="New Chat"
+          onClick={onNewChat}
+          disabled={isNewChatDisabled}
+        >
+          <Plus className="size-4" />
+        </Button>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="hidden h-fit flex-col rounded-lg border bg-background lg:sticky lg:top-20 lg:flex">
+      <div className="flex items-center justify-between gap-2 border-b p-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <History className="size-4 shrink-0 text-muted-foreground" />
+          <h2 className="truncate text-sm font-semibold">Chat history</h2>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Collapse chat history"
+          onClick={onToggleCollapsed}
+          className="size-8"
+        >
+          <PanelLeftClose className="size-4" />
+        </Button>
+      </div>
+      <div className="max-h-[calc(100vh-15rem)] overflow-y-auto p-2">
+        <HistoryList
+          conversations={conversations}
+          activeConversationId={activeConversationId}
+          isLoading={isLoading}
+          error={error}
+          onResumeConversation={onResumeConversation}
+        />
+      </div>
+      <div className="border-t p-3">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onNewChat}
+          disabled={isNewChatDisabled}
+          className="w-full"
+        >
+          <Plus className="size-4" />
+          New Chat
+        </Button>
+      </div>
+    </aside>
+  );
+}
+
+function HistoryList({
+  conversations,
+  activeConversationId,
+  isLoading,
+  error,
+  onResumeConversation,
+}: {
+  conversations: AIChatConversationSummary[];
+  activeConversationId: number | null;
+  isLoading: boolean;
+  error: string | null;
+  onResumeConversation: (conversationId: number) => void;
+}) {
+  if (isLoading) {
+    return (
+      <div className="px-2 py-3 text-sm text-muted-foreground">
         Loading recent chats...
       </div>
     );
   }
 
-  if (recentConversations.length === 0) {
-    return recentConversationsError ? (
-      <div className="flex flex-col gap-4">
-        <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-          {recentConversationsError}
-        </div>
-        {fallback}
+  if (error) {
+    return (
+      <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+        {error}
       </div>
-    ) : (
-      fallback
+    );
+  }
+
+  if (conversations.length === 0) {
+    return (
+      <div className="px-2 py-3 text-sm text-muted-foreground">
+        No recent chats yet.
+      </div>
     );
   }
 
   return (
-    <div className="flex min-h-[70vh] flex-col justify-center gap-5 py-8">
-      <div className="flex flex-col gap-2">
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
-          AI Chat
-        </h1>
-        <p className="text-sm text-muted-foreground">
-          Resume a recent conversation or start a new chat.
-        </p>
-      </div>
+    <div className="flex flex-col gap-1">
+      {conversations.slice(0, MAX_VISIBLE_RECENT_CHATS).map((conversation) => {
+        const isActive = conversation.id === activeConversationId;
 
-      <div className="overflow-hidden rounded-lg border bg-background">
-        <div className="border-b px-4 py-3 text-sm font-medium">
-          Recent chats
-        </div>
-        <div className="divide-y">
-          {recentConversations
-            .slice(0, MAX_VISIBLE_RECENT_CHATS)
-            .map((conversation) => (
-              <button
-                key={conversation.id}
-                type="button"
-                onClick={() => onResumeConversation(conversation.id)}
-                className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-accent hover:text-accent-foreground"
-              >
-                <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                  <MessageSquare className="size-4" />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-sm font-medium">
-                    {conversation.title?.trim() || `Chat #${conversation.id}`}
-                  </span>
-                  <span className="block text-xs text-muted-foreground">
-                    {formatConversationTimestamp(conversation)}
-                  </span>
-                </span>
-              </button>
-            ))}
-        </div>
-      </div>
-
-      <Button
-        type="button"
-        variant="outline"
-        onClick={onNewChat}
-        disabled={isNewChatDisabled}
-        className="w-full sm:w-fit"
-      >
-        <Plus className="size-4" />
-        New Chat
-      </Button>
+        return (
+          <button
+            key={conversation.id}
+            type="button"
+            onClick={() => onResumeConversation(conversation.id)}
+            aria-current={isActive ? "page" : undefined}
+            className={cn(
+              "flex w-full items-start gap-3 rounded-md px-3 py-2.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
+              isActive && "bg-accent text-accent-foreground",
+            )}
+          >
+            <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+              <MessageSquare className="size-4" />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-medium">
+                {conversation.title?.trim() || `Chat #${conversation.id}`}
+              </span>
+              <span className="block truncate text-xs text-muted-foreground">
+                {isActive
+                  ? "Current conversation"
+                  : formatConversationTimestamp(conversation)}
+              </span>
+            </span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/client/src/features/chat/components/chat-history-entry.tsx
+++ b/client/src/features/chat/components/chat-history-entry.tsx
@@ -146,7 +146,7 @@ function DesktopHistoryPanel({
   return (
     <aside
       aria-label="Chat history"
-      className="hidden w-72 flex-col border-r bg-background lg:fixed lg:bottom-0 lg:left-0 lg:top-[3.25rem] lg:z-20 lg:flex"
+      className="hidden w-chat-sidebar flex-col border-r bg-background lg:fixed lg:bottom-0 lg:left-0 lg:top-[3.25rem] lg:z-20 lg:flex"
     >
       <div className="flex items-center justify-between gap-2 border-b p-3">
         <div className="flex min-w-0 items-center gap-2">

--- a/client/src/features/chat/components/chat-history-entry.tsx
+++ b/client/src/features/chat/components/chat-history-entry.tsx
@@ -4,6 +4,7 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
   Plus,
+  SquarePen,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -115,7 +116,10 @@ function DesktopHistoryPanel({
 }: Omit<ChatHistoryEntryProps, "isMobileOpen" | "onMobileOpenChange">) {
   if (isCollapsed) {
     return (
-      <aside className="hidden h-fit flex-col items-center gap-2 rounded-lg border bg-background p-2 lg:sticky lg:top-20 lg:flex">
+      <aside
+        aria-label="Collapsed chat history"
+        className="hidden min-h-[calc(100vh-8rem)] w-13 flex-col items-center gap-2 border-r bg-background px-2 py-3 lg:sticky lg:top-0 lg:flex"
+      >
         <Button
           type="button"
           variant="ghost"
@@ -133,7 +137,7 @@ function DesktopHistoryPanel({
           onClick={onNewChat}
           disabled={isNewChatDisabled}
         >
-          <Plus className="size-4" />
+          <SquarePen className="size-4" />
         </Button>
       </aside>
     );

--- a/client/src/features/chat/components/chat-history-entry.tsx
+++ b/client/src/features/chat/components/chat-history-entry.tsx
@@ -118,7 +118,7 @@ function DesktopHistoryPanel({
     return (
       <aside
         aria-label="Collapsed chat history"
-        className="hidden min-h-[calc(100vh-8rem)] w-13 flex-col items-center gap-2 border-r bg-background px-2 py-3 lg:sticky lg:top-0 lg:flex"
+        className="hidden w-12 flex-col items-center gap-2 border-r bg-background px-2 py-3 lg:fixed lg:bottom-0 lg:left-0 lg:top-[3.25rem] lg:z-20 lg:flex"
       >
         <Button
           type="button"

--- a/client/src/features/chat/components/chat-history-entry.tsx
+++ b/client/src/features/chat/components/chat-history-entry.tsx
@@ -16,8 +16,6 @@ import {
 import type { AIChatConversationSummary } from "@/features/chat/api/ai-chat";
 import { cn } from "@/lib/utils";
 
-const MAX_VISIBLE_RECENT_CHATS = 8;
-
 type ChatHistoryEntryProps = {
   conversations: AIChatConversationSummary[];
   activeConversationId: number | null;
@@ -223,7 +221,7 @@ function HistoryList({
 
   return (
     <div className="flex flex-col gap-1">
-      {conversations.slice(0, MAX_VISIBLE_RECENT_CHATS).map((conversation) => {
+      {conversations.map((conversation) => {
         const isActive = conversation.id === activeConversationId;
 
         return (

--- a/client/src/features/chat/components/chat-history-entry.tsx
+++ b/client/src/features/chat/components/chat-history-entry.tsx
@@ -144,7 +144,10 @@ function DesktopHistoryPanel({
   }
 
   return (
-    <aside className="hidden h-fit flex-col rounded-lg border bg-background lg:sticky lg:top-20 lg:flex">
+    <aside
+      aria-label="Chat history"
+      className="hidden w-72 flex-col border-r bg-background lg:fixed lg:bottom-0 lg:left-0 lg:top-[3.25rem] lg:z-20 lg:flex"
+    >
       <div className="flex items-center justify-between gap-2 border-b p-3">
         <div className="flex min-w-0 items-center gap-2">
           <History className="size-4 shrink-0 text-muted-foreground" />
@@ -161,7 +164,7 @@ function DesktopHistoryPanel({
           <PanelLeftClose className="size-4" />
         </Button>
       </div>
-      <div className="max-h-[calc(100vh-15rem)] overflow-y-auto p-2">
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
         <HistoryList
           conversations={conversations}
           activeConversationId={activeConversationId}

--- a/client/src/features/chat/hooks/use-chat-history-entry.test.tsx
+++ b/client/src/features/chat/hooks/use-chat-history-entry.test.tsx
@@ -1,0 +1,90 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AIChatConversationSummary } from "@/features/chat/api/ai-chat";
+
+const { mockListConversations } = vi.hoisted(() => ({
+  mockListConversations: vi.fn(),
+}));
+
+vi.mock("@/features/chat/api/ai-chat", () => ({
+  listAIChatConversations: mockListConversations,
+}));
+
+vi.mock("@/lib/errors", () => ({
+  getErrorMessage: (
+    error: unknown,
+    fallback = "An unexpected error occurred",
+  ) => (error instanceof Error ? error.message : fallback),
+}));
+
+import { useChatHistoryEntry } from "@/features/chat/hooks/use-chat-history-entry";
+
+function conversation(id: number, title: string): AIChatConversationSummary {
+  return {
+    id,
+    title,
+    created_at: "2026-06-25T17:00:00Z",
+    updated_at: "2026-06-25T17:05:00Z",
+    last_message_at: "2026-06-25T17:05:00Z",
+  };
+}
+
+describe("useChatHistoryEntry", () => {
+  beforeEach(() => {
+    mockListConversations.mockReset();
+  });
+
+  it("ignores a stale manual refresh after the signed-in user changes", async () => {
+    let resolveStaleRefresh!: (value: AIChatConversationSummary[]) => void;
+    mockListConversations
+      .mockResolvedValueOnce([conversation(72, "User 1 initial chat")])
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveStaleRefresh = resolve;
+        }),
+      )
+      .mockResolvedValueOnce([conversation(88, "User 2 current chat")]);
+
+    const onOpenConversation = vi.fn();
+    const view = renderHook(
+      ({ userId }) =>
+        useChatHistoryEntry({
+          userId,
+          conversationId: null,
+          onOpenConversation,
+        }),
+      { initialProps: { userId: "user-1" } },
+    );
+
+    await waitFor(() => {
+      expect(view.result.current.conversations).toEqual([
+        expect.objectContaining({ title: "User 1 initial chat" }),
+      ]);
+    });
+
+    void act(() => {
+      void view.result.current.refreshConversations();
+    });
+    await waitFor(() => {
+      expect(mockListConversations).toHaveBeenCalledTimes(2);
+    });
+
+    view.rerender({ userId: "user-2" });
+
+    await waitFor(() => {
+      expect(view.result.current.conversations).toEqual([
+        expect.objectContaining({ title: "User 2 current chat" }),
+      ]);
+    });
+    expect(view.result.current.isPreparingEntry).toBe(false);
+
+    await act(async () => {
+      resolveStaleRefresh([conversation(73, "User 1 stale chat")]);
+    });
+
+    expect(view.result.current.conversations).toEqual([
+      expect.objectContaining({ title: "User 2 current chat" }),
+    ]);
+    expect(view.result.current.isPreparingEntry).toBe(false);
+  });
+});

--- a/client/src/features/chat/hooks/use-chat-history-entry.ts
+++ b/client/src/features/chat/hooks/use-chat-history-entry.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   listAIChatConversations,
   type AIChatConversationSummary,
@@ -26,60 +26,108 @@ export function useChatHistoryEntry({
   const [conversations, setConversations] = useState<
     AIChatConversationSummary[]
   >([]);
+  const [loadedUserId, setLoadedUserId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(Boolean(userId));
   const [error, setError] = useState<string | null>(null);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isMobileOpen, setIsMobileOpen] = useState(false);
 
+  const loadConversations = useCallback(
+    async (requestUserId: string, signal?: AbortSignal) => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const loadedConversations = await listAIChatConversations({ signal });
+        if (!signal?.aborted) {
+          setConversations(loadedConversations);
+          setLoadedUserId(requestUserId);
+        }
+      } catch (listError: unknown) {
+        if (!signal?.aborted) {
+          setConversations([]);
+          setLoadedUserId(null);
+          setError(getErrorMessage(listError, "Could not load recent chats."));
+        }
+      } finally {
+        if (!signal?.aborted) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     if (!userId) {
+      setConversations([]);
+      setLoadedUserId(null);
+      setError(null);
+      setIsLoading(false);
       return;
     }
 
     const controller = new AbortController();
-    setIsLoading(true);
-    setError(null);
-
-    void listAIChatConversations({ signal: controller.signal })
-      .then((loadedConversations) => {
-        setConversations(loadedConversations);
-      })
-      .catch((listError: unknown) => {
-        if (controller.signal.aborted) {
-          return;
-        }
-        setConversations([]);
-        setError(getErrorMessage(listError, "Could not load recent chats."));
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) {
-          setIsLoading(false);
-        }
-      });
+    setConversations([]);
+    setLoadedUserId(null);
+    void loadConversations(userId, controller.signal);
 
     return () => controller.abort();
-  }, [userId]);
+  }, [loadConversations, userId]);
 
-  useEffect(() => {
-    if (conversationId || isLoading || error || conversations.length === 0) {
+  const refreshConversations = useCallback(async () => {
+    if (!userId) {
       return;
     }
 
-    onOpenConversation(conversations[0].id, { replace: true });
-  }, [conversationId, conversations, error, isLoading, onOpenConversation]);
+    await loadConversations(userId);
+  }, [loadConversations, userId]);
 
-  const isPreparingEntry = !conversationId && isLoading && !error;
+  const loadedCurrentUserConversations =
+    userId && loadedUserId === userId ? conversations : [];
+  const hasLoadedCurrentUser = Boolean(userId && loadedUserId === userId);
+
+  useEffect(() => {
+    if (
+      conversationId ||
+      isLoading ||
+      error ||
+      !hasLoadedCurrentUser ||
+      loadedCurrentUserConversations.length === 0
+    ) {
+      return;
+    }
+
+    onOpenConversation(loadedCurrentUserConversations[0].id, {
+      replace: true,
+    });
+  }, [
+    conversationId,
+    error,
+    hasLoadedCurrentUser,
+    isLoading,
+    loadedCurrentUserConversations,
+    onOpenConversation,
+  ]);
+
+  const isPreparingEntry =
+    !conversationId && (isLoading || !hasLoadedCurrentUser) && !error;
   const isAutoOpeningRecentChat =
-    !conversationId && !isLoading && !error && conversations.length > 0;
+    !conversationId &&
+    !isLoading &&
+    !error &&
+    hasLoadedCurrentUser &&
+    loadedCurrentUserConversations.length > 0;
 
   return {
-    conversations,
+    conversations: loadedCurrentUserConversations,
     error,
     isAutoOpeningRecentChat,
     isCollapsed,
     isLoading,
     isMobileOpen,
     isPreparingEntry,
+    refreshConversations,
     setIsCollapsed,
     setIsMobileOpen,
   };

--- a/client/src/features/chat/hooks/use-chat-history-entry.ts
+++ b/client/src/features/chat/hooks/use-chat-history-entry.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   listAIChatConversations,
   type AIChatConversationSummary,
@@ -31,26 +31,32 @@ export function useChatHistoryEntry({
   const [error, setError] = useState<string | null>(null);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isMobileOpen, setIsMobileOpen] = useState(false);
+  const requestIdRef = useRef(0);
 
   const loadConversations = useCallback(
     async (requestUserId: string, signal?: AbortSignal) => {
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+      const isCurrentRequest = () =>
+        !signal?.aborted && requestIdRef.current === requestId;
+
       setIsLoading(true);
       setError(null);
 
       try {
         const loadedConversations = await listAIChatConversations({ signal });
-        if (!signal?.aborted) {
+        if (isCurrentRequest()) {
           setConversations(loadedConversations);
           setLoadedUserId(requestUserId);
         }
       } catch (listError: unknown) {
-        if (!signal?.aborted) {
+        if (isCurrentRequest()) {
           setConversations([]);
           setLoadedUserId(null);
           setError(getErrorMessage(listError, "Could not load recent chats."));
         }
       } finally {
-        if (!signal?.aborted) {
+        if (isCurrentRequest()) {
           setIsLoading(false);
         }
       }
@@ -60,6 +66,7 @@ export function useChatHistoryEntry({
 
   useEffect(() => {
     if (!userId) {
+      requestIdRef.current += 1;
       setConversations([]);
       setLoadedUserId(null);
       setError(null);

--- a/client/src/features/chat/hooks/use-chat-history-entry.ts
+++ b/client/src/features/chat/hooks/use-chat-history-entry.ts
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import {
+  listAIChatConversations,
+  type AIChatConversationSummary,
+} from "@/features/chat/api/ai-chat";
+import { getErrorMessage } from "@/lib/errors";
+
+type OpenConversationOptions = {
+  replace?: boolean;
+};
+
+type UseChatHistoryEntryOptions = {
+  userId?: string;
+  conversationId: number | null;
+  onOpenConversation: (
+    conversationId: number,
+    options?: OpenConversationOptions,
+  ) => void;
+};
+
+export function useChatHistoryEntry({
+  userId,
+  conversationId,
+  onOpenConversation,
+}: UseChatHistoryEntryOptions) {
+  const [conversations, setConversations] = useState<
+    AIChatConversationSummary[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(Boolean(userId));
+  const [error, setError] = useState<string | null>(null);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
+
+  useEffect(() => {
+    if (!userId) {
+      return;
+    }
+
+    const controller = new AbortController();
+    setIsLoading(true);
+    setError(null);
+
+    void listAIChatConversations({ signal: controller.signal })
+      .then((loadedConversations) => {
+        setConversations(loadedConversations);
+      })
+      .catch((listError: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setConversations([]);
+        setError(getErrorMessage(listError, "Could not load recent chats."));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [userId]);
+
+  useEffect(() => {
+    if (conversationId || isLoading || error || conversations.length === 0) {
+      return;
+    }
+
+    onOpenConversation(conversations[0].id, { replace: true });
+  }, [conversationId, conversations, error, isLoading, onOpenConversation]);
+
+  const isPreparingEntry = !conversationId && isLoading && !error;
+  const isAutoOpeningRecentChat =
+    !conversationId && !isLoading && !error && conversations.length > 0;
+
+  return {
+    conversations,
+    error,
+    isAutoOpeningRecentChat,
+    isCollapsed,
+    isLoading,
+    isMobileOpen,
+    isPreparingEntry,
+    setIsCollapsed,
+    setIsMobileOpen,
+  };
+}

--- a/client/src/features/chat/pages/chat-billing-page-usage.test.tsx
+++ b/client/src/features/chat/pages/chat-billing-page-usage.test.tsx
@@ -93,8 +93,13 @@ describe("ChatRouteComponent billing usage", () => {
     render(<ChatRouteComponent />);
 
     expect(
-      await screen.findByText("1 of 30 trial prompts used"),
-    ).toBeInTheDocument();
+      await screen.findByPlaceholderText(
+        "Ask about training, recovery, exercise choices, or FitTrack usage...",
+      ),
+    ).toBeEnabled();
+    expect(
+      screen.queryByText("1 of 30 trial prompts used"),
+    ).not.toBeInTheDocument();
     await user.type(
       screen.getByPlaceholderText(
         "Ask about training, recovery, exercise choices, or FitTrack usage...",

--- a/client/src/features/chat/pages/chat-billing-page.test.tsx
+++ b/client/src/features/chat/pages/chat-billing-page.test.tsx
@@ -375,7 +375,11 @@ describe("ChatRouteComponent", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("Premium")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "New Chat" })).toBeEnabled();
+    expect(
+      screen
+        .getAllByRole("button", { name: "New Chat" })
+        .some((button) => !button.hasAttribute("disabled")),
+    ).toBe(true);
     expect(
       screen.queryByText("Access continues until Jun 10, 2026."),
     ).not.toBeInTheDocument();

--- a/client/src/features/chat/pages/chat-billing-page.test.tsx
+++ b/client/src/features/chat/pages/chat-billing-page.test.tsx
@@ -75,7 +75,10 @@ describe("ChatRouteComponent", () => {
         "Ask about training, recovery, exercise choices, or FitTrack usage...",
       ),
     ).toBeEnabled();
-    expect(screen.getByText("Premium")).toBeInTheDocument();
+    expect(screen.queryByText("Premium")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Start 7-day trial" }),
+    ).not.toBeInTheDocument();
     expect(mockRefetchFeatureAccess).not.toHaveBeenCalled();
     expect(mockRefetchBillingStatus).not.toHaveBeenCalled();
   });
@@ -308,7 +311,12 @@ describe("ChatRouteComponent", () => {
 
     render(<ChatRouteComponent />);
 
-    expect(await screen.findByText("Premium")).toBeInTheDocument();
+    expect(
+      await screen.findByPlaceholderText(
+        "Ask about training, recovery, exercise choices, or FitTrack usage...",
+      ),
+    ).toBeEnabled();
+    expect(screen.queryByText("Premium")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Manage plan" }),
     ).not.toBeInTheDocument();
@@ -374,7 +382,7 @@ describe("ChatRouteComponent", () => {
         "Returned from billing. We are refreshing your AI chat billing status.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Premium")).toBeInTheDocument();
+    expect(screen.queryByText("Premium")).not.toBeInTheDocument();
     expect(
       screen
         .getAllByRole("button", { name: "New Chat" })
@@ -410,8 +418,13 @@ describe("ChatRouteComponent", () => {
     render(<ChatRouteComponent />);
 
     expect(
-      await screen.findByText("Access continues until Jun 10, 2026."),
+      await screen.findByText(
+        "Cancellation received. We are refreshing your AI chat billing status.",
+      ),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Access continues until Jun 10, 2026."),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Cancel plan" }),
     ).not.toBeInTheDocument();
@@ -442,8 +455,13 @@ describe("ChatRouteComponent", () => {
     render(<ChatRouteComponent />);
 
     expect(
-      await screen.findByText("Access continues until Jul 10, 2026."),
+      await screen.findByText(
+        "Cancellation received. We are refreshing your AI chat billing status.",
+      ),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Access continues until Jul 10, 2026."),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Cancel plan" }),
     ).not.toBeInTheDocument();
@@ -553,11 +571,10 @@ describe("ChatRouteComponent", () => {
     expect(
       screen.queryByRole("button", { name: "Start 7-day trial" }),
     ).not.toBeInTheDocument();
-    expect(screen.getByText("Access active")).toBeInTheDocument();
+    expect(screen.queryByText("Access active")).not.toBeInTheDocument();
   });
 
-  it("keeps chat enabled when a manual feature grant overrides blocked Stripe billing", async () => {
-    const user = userEvent.setup();
+  it("keeps chat enabled without billing chrome when a manual feature grant overrides blocked Stripe billing", async () => {
     mockBillingQueryResult.value = {
       data: {
         feature_key: "ai_chatbot",
@@ -592,10 +609,10 @@ describe("ChatRouteComponent", () => {
       ),
     ).toBeEnabled();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
-    expect(screen.getByText("Access active")).toBeInTheDocument();
+    expect(screen.queryByText("Access active")).not.toBeInTheDocument();
     expect(
-      screen.getByText("Update billing to keep chat available."),
-    ).toBeInTheDocument();
+      screen.queryByText("Update billing to keep chat available."),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText(
         "AI chat is paused until the payment issue is resolved.",
@@ -604,12 +621,10 @@ describe("ChatRouteComponent", () => {
     expect(
       screen.queryByText("Start or restore premium access to use AI chat."),
     ).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Manage plan" }));
-
-    await waitFor(() => {
-      expect(mockCreateBillingCustomerPortalSession).toHaveBeenCalledTimes(1);
-    });
+    expect(
+      screen.queryByRole("button", { name: "Manage plan" }),
+    ).not.toBeInTheDocument();
+    expect(mockCreateBillingCustomerPortalSession).not.toHaveBeenCalled();
     expect(mockCreateBillingCheckoutSession).not.toHaveBeenCalled();
   });
 });

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -155,6 +155,93 @@ describe("ChatRouteComponent", () => {
     expect(mockListConversations).toHaveBeenCalledTimes(2);
   });
 
+  it("refreshes chat history after the first prompt creates a conversation", async () => {
+    const user = userEvent.setup();
+    mockSearch.conversationId = undefined;
+    mockListConversations
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: 73,
+          created_at: "2026-06-26T17:00:00Z",
+          updated_at: "2026-06-26T17:00:00Z",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 73,
+          title: "What should we train",
+          created_at: "2026-06-26T17:00:00Z",
+          updated_at: "2026-06-26T17:05:00Z",
+          last_message_at: "2026-06-26T17:05:00Z",
+        },
+      ]);
+    mockCreateConversation.mockResolvedValue({
+      id: 73,
+      created_at: "2026-06-26T17:00:00Z",
+      updated_at: "2026-06-26T17:00:00Z",
+    });
+    mockGetConversation.mockResolvedValue({
+      conversation: {
+        id: 73,
+        title: "What should we train",
+        created_at: "2026-06-26T17:00:00Z",
+        updated_at: "2026-06-26T17:05:00Z",
+        last_message_at: "2026-06-26T17:05:00Z",
+      },
+      messages: [],
+    });
+    mockStreamMessage.mockImplementation(
+      async (
+        _conversationId: number,
+        _prompt: string,
+        options?: {
+          onStart?: (event: Record<string, unknown>) => void;
+          onDone?: (event: Record<string, unknown>) => void;
+        },
+      ) => {
+        options?.onStart?.({
+          type: "start",
+          message_id: 72,
+        });
+        options?.onDone?.({
+          type: "done",
+          message_id: 72,
+          text: "Start with squats.",
+        });
+
+        return {
+          doneEvent: {
+            type: "done",
+            message_id: 72,
+            text: "Start with squats.",
+          },
+          endedWithError: false,
+        };
+      },
+    );
+
+    render(<ChatRouteComponent />);
+
+    await user.type(
+      await screen.findByPlaceholderText(
+        "Ask about training, recovery, exercise choices, or FitTrack usage...",
+      ),
+      "What should we train?",
+    );
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/chat",
+      search: { conversationId: "73" },
+    });
+    expect(await screen.findByText("What should we train")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockListConversations).toHaveBeenCalledTimes(3);
+    });
+  });
+
   it("shows every recent chat returned by the history endpoint", async () => {
     mockGetConversation.mockResolvedValue(conversationDetail([]));
     mockListConversations.mockResolvedValue(

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -49,18 +49,91 @@ describe("ChatRouteComponent", () => {
     expect(mockGetConversation).not.toHaveBeenCalled();
   });
 
+  it("does not auto-open stale history after the signed-in user changes", async () => {
+    mockSearch.conversationId = undefined;
+    let resolveNextHistory!: (value: Array<Record<string, unknown>>) => void;
+    mockListConversations
+      .mockResolvedValueOnce([
+        {
+          id: 72,
+          title: "Leg day plan",
+          created_at: "2026-06-25T17:00:00Z",
+          updated_at: "2026-06-25T17:05:00Z",
+          last_message_at: "2026-06-25T17:05:00Z",
+        },
+      ])
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveNextHistory = resolve;
+        }),
+      );
+
+    const view = render(<ChatRouteComponent userId="user-123" />);
+
+    expect(await screen.findByText("Leg day plan")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/chat",
+        search: { conversationId: "72" },
+        replace: true,
+      });
+    });
+
+    mockNavigate.mockClear();
+    view.rerender(<ChatRouteComponent userId="user-456" />);
+
+    expect(screen.queryByText("Leg day plan")).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    resolveNextHistory([
+      {
+        id: 88,
+        title: "Back day plan",
+        created_at: "2026-06-26T17:00:00Z",
+        updated_at: "2026-06-26T17:05:00Z",
+        last_message_at: "2026-06-26T17:05:00Z",
+      },
+    ]);
+
+    expect(await screen.findByText("Back day plan")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/chat",
+        search: { conversationId: "88" },
+        replace: true,
+      });
+    });
+  });
+
   it("keeps explicit New Chat available from chat history", async () => {
     const user = userEvent.setup();
     mockGetConversation.mockResolvedValue(conversationDetail([]));
-    mockListConversations.mockResolvedValue([
-      {
-        id: 41,
-        title: "Leg day plan",
-        created_at: "2026-06-25T17:00:00Z",
-        updated_at: "2026-06-25T17:05:00Z",
-        last_message_at: "2026-06-25T17:05:00Z",
-      },
-    ]);
+    mockListConversations
+      .mockResolvedValueOnce([
+        {
+          id: 41,
+          title: "Leg day plan",
+          created_at: "2026-06-25T17:00:00Z",
+          updated_at: "2026-06-25T17:05:00Z",
+          last_message_at: "2026-06-25T17:05:00Z",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 73,
+          title: "Fresh chat",
+          created_at: "2026-06-26T17:00:00Z",
+          updated_at: "2026-06-26T17:00:00Z",
+          last_message_at: "2026-06-26T17:00:00Z",
+        },
+        {
+          id: 41,
+          title: "Leg day plan",
+          created_at: "2026-06-25T17:00:00Z",
+          updated_at: "2026-06-25T17:05:00Z",
+          last_message_at: "2026-06-25T17:05:00Z",
+        },
+      ]);
     mockCreateConversation.mockResolvedValue({
       id: 73,
       created_at: "2026-06-26T17:00:00Z",
@@ -78,6 +151,25 @@ describe("ChatRouteComponent", () => {
       to: "/chat",
       search: { conversationId: "73" },
     });
+    expect(await screen.findByText("Fresh chat")).toBeInTheDocument();
+    expect(mockListConversations).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows every recent chat returned by the history endpoint", async () => {
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+    mockListConversations.mockResolvedValue(
+      Array.from({ length: 10 }, (_, index) => ({
+        id: index + 1,
+        title: `Recent chat ${index + 1}`,
+        created_at: "2026-06-25T17:00:00Z",
+        updated_at: "2026-06-25T17:05:00Z",
+        last_message_at: "2026-06-25T17:05:00Z",
+      })),
+    );
+
+    render(<ChatRouteComponent />);
+
+    expect(await screen.findByText("Recent chat 10")).toBeInTheDocument();
   });
 
   it("lets desktop users collapse and expand chat history", async () => {

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -187,8 +187,11 @@ describe("ChatRouteComponent", () => {
 
     render(<ChatRouteComponent />);
 
+    const expandedHistory = await screen.findByLabelText("Chat history");
+    expect(expandedHistory).toHaveClass("lg:fixed", "lg:left-0");
+
     await user.click(
-      await screen.findByRole("button", { name: "Collapse chat history" }),
+      screen.getByRole("button", { name: "Collapse chat history" }),
     );
 
     expect(

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -190,9 +190,10 @@ describe("ChatRouteComponent", () => {
     const expandedHistory = await screen.findByLabelText("Chat history");
     expect(expandedHistory).toHaveClass("lg:fixed", "lg:left-0");
     expect(screen.getByTestId("chat-page-layout")).toHaveClass(
-      "lg:pl-76",
-      "lg:mx-0",
+      "lg:ml-72",
+      "lg:max-w-none",
     );
+    expect(screen.getByTestId("chat-main-pane")).toHaveClass("lg:max-w-5xl");
 
     await user.click(
       screen.getByRole("button", { name: "Collapse chat history" }),
@@ -207,6 +208,7 @@ describe("ChatRouteComponent", () => {
       "mx-auto",
       "max-w-3xl",
     );
+    expect(screen.getByTestId("chat-main-pane")).toHaveClass("lg:max-w-3xl");
     expect(
       within(collapsedHistory)
         .getAllByRole("button")

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -158,7 +158,7 @@ describe("ChatRouteComponent", () => {
   it("shows every recent chat returned by the history endpoint", async () => {
     mockGetConversation.mockResolvedValue(conversationDetail([]));
     mockListConversations.mockResolvedValue(
-      Array.from({ length: 10 }, (_, index) => ({
+      Array.from({ length: 50 }, (_, index) => ({
         id: index + 1,
         title: `Recent chat ${index + 1}`,
         created_at: "2026-06-25T17:00:00Z",
@@ -169,7 +169,7 @@ describe("ChatRouteComponent", () => {
 
     render(<ChatRouteComponent />);
 
-    expect(await screen.findByText("Recent chat 10")).toBeInTheDocument();
+    expect(await screen.findByText("Recent chat 50")).toBeInTheDocument();
   });
 
   it("lets desktop users collapse and expand chat history", async () => {
@@ -190,10 +190,12 @@ describe("ChatRouteComponent", () => {
     const expandedHistory = await screen.findByLabelText("Chat history");
     expect(expandedHistory).toHaveClass("lg:fixed", "lg:left-0");
     expect(screen.getByTestId("chat-page-layout")).toHaveClass(
-      "lg:ml-72",
-      "lg:max-w-none",
+      "lg:px-chat-gutter",
     );
-    expect(screen.getByTestId("chat-main-pane")).toHaveClass("lg:max-w-5xl");
+    expect(screen.getByTestId("chat-main-pane")).toHaveClass(
+      "mx-auto",
+      "max-w-3xl",
+    );
 
     await user.click(
       screen.getByRole("button", { name: "Collapse chat history" }),
@@ -205,10 +207,12 @@ describe("ChatRouteComponent", () => {
     const collapsedHistory = screen.getByLabelText("Collapsed chat history");
     expect(collapsedHistory).toHaveClass("lg:fixed", "lg:left-0");
     expect(screen.getByTestId("chat-page-layout")).toHaveClass(
+      "lg:px-chat-gutter",
+    );
+    expect(screen.getByTestId("chat-main-pane")).toHaveClass(
       "mx-auto",
       "max-w-3xl",
     );
-    expect(screen.getByTestId("chat-main-pane")).toHaveClass("lg:max-w-3xl");
     expect(
       within(collapsedHistory)
         .getAllByRole("button")

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -189,6 +189,10 @@ describe("ChatRouteComponent", () => {
 
     const expandedHistory = await screen.findByLabelText("Chat history");
     expect(expandedHistory).toHaveClass("lg:fixed", "lg:left-0");
+    expect(screen.getByTestId("chat-page-layout")).toHaveClass(
+      "lg:pl-76",
+      "lg:mx-0",
+    );
 
     await user.click(
       screen.getByRole("button", { name: "Collapse chat history" }),
@@ -199,6 +203,10 @@ describe("ChatRouteComponent", () => {
     ).toBeInTheDocument();
     const collapsedHistory = screen.getByLabelText("Collapsed chat history");
     expect(collapsedHistory).toHaveClass("lg:fixed", "lg:left-0");
+    expect(screen.getByTestId("chat-page-layout")).toHaveClass(
+      "mx-auto",
+      "max-w-3xl",
+    );
     expect(
       within(collapsedHistory)
         .getAllByRole("button")
@@ -226,6 +234,29 @@ describe("ChatRouteComponent", () => {
     expect(await screen.findByText("Leg day plan")).toBeInTheDocument();
     expect(screen.queryByText("Access active")).not.toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "New Chat" })).toHaveLength(1);
+  });
+
+  it("adds top padding when showing an existing conversation", async () => {
+    mockGetConversation.mockResolvedValue(
+      conversationDetail([
+        {
+          id: 61,
+          conversation_id: 41,
+          role: "user",
+          content: "Hello anybody there?",
+          status: "completed",
+          created_at: "2026-03-26T17:00:00Z",
+          updated_at: "2026-03-26T17:00:00Z",
+          completed_at: "2026-03-26T17:00:00Z",
+        },
+      ]),
+    );
+    mockListConversations.mockResolvedValue([]);
+
+    render(<ChatRouteComponent />);
+
+    expect(await screen.findByText("Hello anybody there?")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-conversation-body")).toHaveClass("pt-4");
   });
 
   it("recovers a completed reply when the stream dies before the start event reaches the client", async () => {

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -21,8 +21,7 @@ import {
 describe("ChatRouteComponent", () => {
   beforeEach(resetChatRouteMocks);
 
-  it("shows recent chats when entering without a conversation id", async () => {
-    const user = userEvent.setup();
+  it("opens the newest recent chat when entering without a conversation id", async () => {
     mockSearch.conversationId = undefined;
     mockListConversations.mockResolvedValue([
       {
@@ -36,27 +35,26 @@ describe("ChatRouteComponent", () => {
 
     render(<ChatRouteComponent />);
 
-    expect(await screen.findByText("Recent chats")).toBeInTheDocument();
-    expect(screen.getByText("Leg day plan")).toBeInTheDocument();
+    expect(await screen.findByText("Leg day plan")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/chat",
+        search: { conversationId: "72" },
+        replace: true,
+      });
+    });
     expect(
       screen.queryByText("What should we train today?"),
     ).not.toBeInTheDocument();
     expect(mockGetConversation).not.toHaveBeenCalled();
-
-    await user.click(screen.getByRole("button", { name: /Leg day plan/ }));
-
-    expect(mockNavigate).toHaveBeenCalledWith({
-      to: "/chat",
-      search: { conversationId: "72" },
-    });
   });
 
-  it("keeps explicit New Chat available when recent chats exist", async () => {
+  it("keeps explicit New Chat available from chat history", async () => {
     const user = userEvent.setup();
-    mockSearch.conversationId = undefined;
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
     mockListConversations.mockResolvedValue([
       {
-        id: 72,
+        id: 41,
         title: "Leg day plan",
         created_at: "2026-06-25T17:00:00Z",
         updated_at: "2026-06-25T17:05:00Z",
@@ -71,7 +69,7 @@ describe("ChatRouteComponent", () => {
 
     render(<ChatRouteComponent />);
 
-    expect(await screen.findByText("Recent chats")).toBeInTheDocument();
+    expect(await screen.findByText("Leg day plan")).toBeInTheDocument();
     const newChatButtons = screen.getAllByRole("button", { name: "New Chat" });
     await user.click(newChatButtons.at(-1)!);
 
@@ -80,6 +78,30 @@ describe("ChatRouteComponent", () => {
       to: "/chat",
       search: { conversationId: "73" },
     });
+  });
+
+  it("lets desktop users collapse and expand chat history", async () => {
+    const user = userEvent.setup();
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+    mockListConversations.mockResolvedValue([
+      {
+        id: 41,
+        title: "Leg day plan",
+        created_at: "2026-06-25T17:00:00Z",
+        updated_at: "2026-06-25T17:05:00Z",
+        last_message_at: "2026-06-25T17:05:00Z",
+      },
+    ]);
+
+    render(<ChatRouteComponent />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Collapse chat history" }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Expand chat history" }),
+    ).toBeInTheDocument();
   });
 
   it("recovers a completed reply when the stream dies before the start event reaches the client", async () => {
@@ -565,7 +587,7 @@ describe("ChatRouteComponent", () => {
       expect(mockStreamMessage).toHaveBeenCalledTimes(1);
     });
 
-    await user.click(screen.getByRole("button", { name: "New Chat" }));
+    await user.click(screen.getAllByRole("button", { name: "New Chat" })[0]);
 
     await waitFor(() => {
       expect(mockShowErrorToast).toHaveBeenCalledWith(

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
@@ -194,6 +194,15 @@ describe("ChatRouteComponent", () => {
     expect(
       screen.getByRole("button", { name: "Expand chat history" }),
     ).toBeInTheDocument();
+    const collapsedHistory = screen.getByLabelText("Collapsed chat history");
+    expect(
+      within(collapsedHistory)
+        .getAllByRole("button")
+        .map((button) => button.getAttribute("aria-label")),
+    ).toEqual(["Expand chat history", "New Chat"]);
+    expect(
+      screen.queryByLabelText("Collapse chat history"),
+    ).not.toBeInTheDocument();
   });
 
   it("recovers a completed reply when the stream dies before the start event reaches the client", async () => {

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -195,6 +195,7 @@ describe("ChatRouteComponent", () => {
       screen.getByRole("button", { name: "Expand chat history" }),
     ).toBeInTheDocument();
     const collapsedHistory = screen.getByLabelText("Collapsed chat history");
+    expect(collapsedHistory).toHaveClass("lg:fixed", "lg:left-0");
     expect(
       within(collapsedHistory)
         .getAllByRole("button")
@@ -203,6 +204,25 @@ describe("ChatRouteComponent", () => {
     expect(
       screen.queryByLabelText("Collapse chat history"),
     ).not.toBeInTheDocument();
+  });
+
+  it("omits ready access chrome from the chat page", async () => {
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+    mockListConversations.mockResolvedValue([
+      {
+        id: 41,
+        title: "Leg day plan",
+        created_at: "2026-06-25T17:00:00Z",
+        updated_at: "2026-06-25T17:05:00Z",
+        last_message_at: "2026-06-25T17:05:00Z",
+      },
+    ]);
+
+    render(<ChatRouteComponent />);
+
+    expect(await screen.findByText("Leg day plan")).toBeInTheDocument();
+    expect(screen.queryByText("Access active")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "New Chat" })).toHaveLength(1);
   });
 
   it("recovers a completed reply when the stream dies before the start event reaches the client", async () => {

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -95,6 +95,7 @@ export function ChatPage({
         to: "/chat",
         search: { conversationId: String(createdConversationId) },
       });
+      await historyEntry.refreshConversations();
     },
   });
   const billingAccess = useAIChatBillingAccess({

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -145,6 +145,7 @@ export function ChatPage({
     }
 
     await submitPrompt();
+    void historyEntry.refreshConversations();
     billingAccess.refreshAccess();
   }
 
@@ -155,6 +156,7 @@ export function ChatPage({
 
     setPrompt(text);
     await submitPromptValue(text);
+    void historyEntry.refreshConversations();
     billingAccess.refreshAccess();
   }
 
@@ -175,6 +177,7 @@ export function ChatPage({
     }
 
     await submitPromptValue(lastUserPrompt);
+    void historyEntry.refreshConversations();
     billingAccess.refreshAccess();
   }
 

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -322,7 +322,7 @@ export function ChatPage({
           "w-full px-4",
           historyEntry.isCollapsed
             ? "mx-auto max-w-3xl"
-            : "mx-auto max-w-6xl lg:mx-0 lg:max-w-none lg:pl-76 lg:pr-4",
+            : "mx-auto max-w-6xl lg:ml-72 lg:mr-0 lg:max-w-none lg:px-8",
         )}
       >
         <ChatHistoryEntry
@@ -341,7 +341,15 @@ export function ChatPage({
           isNewChatDisabled={billingAccess.isCheckingAccess || !hasChatAccess}
         />
 
-        <div className="min-w-0 lg:max-w-3xl">
+        <div
+          data-testid="chat-main-pane"
+          className={cn(
+            "min-w-0",
+            historyEntry.isCollapsed
+              ? "w-full lg:max-w-3xl"
+              : "w-full lg:max-w-5xl",
+          )}
+        >
           {historyEntry.isPreparingEntry ||
           historyEntry.isAutoOpeningRecentChat ? (
             <div className="text-sm text-muted-foreground">

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -316,14 +316,11 @@ export function ChatPage({
         </div>
       ) : null}
 
+      {/* Symmetric gutter (history rail width + 2rem, see --spacing-chat-gutter)
+          keeps the reading column centered in the viewport and clear of the rail. */}
       <div
         data-testid="chat-page-layout"
-        className={cn(
-          "w-full px-4",
-          historyEntry.isCollapsed
-            ? "mx-auto max-w-3xl"
-            : "mx-auto max-w-6xl lg:ml-72 lg:mr-0 lg:max-w-none lg:px-8",
-        )}
+        className="w-full px-4 lg:px-chat-gutter"
       >
         <ChatHistoryEntry
           conversations={historyEntry.conversations}
@@ -343,12 +340,7 @@ export function ChatPage({
 
         <div
           data-testid="chat-main-pane"
-          className={cn(
-            "min-w-0",
-            historyEntry.isCollapsed
-              ? "w-full lg:max-w-3xl"
-              : "w-full lg:max-w-5xl",
-          )}
+          className="mx-auto w-full min-w-0 max-w-3xl"
         >
           {historyEntry.isPreparingEntry ||
           historyEntry.isAutoOpeningRecentChat ? (

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -317,11 +317,12 @@ export function ChatPage({
       ) : null}
 
       <div
+        data-testid="chat-page-layout"
         className={cn(
-          "mx-auto w-full px-4",
+          "w-full px-4",
           historyEntry.isCollapsed
-            ? "max-w-3xl"
-            : "max-w-6xl lg:grid lg:grid-cols-[18rem_minmax(0,48rem)] lg:items-start lg:gap-4",
+            ? "mx-auto max-w-3xl"
+            : "mx-auto max-w-6xl lg:mx-0 lg:max-w-none lg:pl-76 lg:pr-4",
         )}
       >
         <ChatHistoryEntry
@@ -356,7 +357,10 @@ export function ChatPage({
           ) : showEmptyState ? (
             emptyState
           ) : (
-            <div className="flex flex-col gap-6">
+            <div
+              data-testid="chat-conversation-body"
+              className="flex flex-col gap-6 pt-4"
+            >
               {loadError ? (
                 <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
                   {loadError}

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -1,4 +1,5 @@
-import { Plus } from "lucide-react";
+import { useCallback } from "react";
+import { History, Plus } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -22,6 +23,7 @@ import { ChatTypingIndicator } from "../components/chat-typing-indicator";
 import { ChatWorkoutDraftCard } from "../components/chat-workout-draft-card";
 import { useAIChatBillingAccess } from "../hooks/use-ai-chat-billing-access";
 import { useAIChatSession } from "../hooks/use-ai-chat-session";
+import { useChatHistoryEntry } from "../hooks/use-chat-history-entry";
 
 type ChatCheckoutSearch = "success" | "cancelled";
 type ChatBillingSearch = "cancelled" | "portal-return";
@@ -47,6 +49,31 @@ export function ChatPage({
   billing,
 }: ChatPageProps) {
   const navigate = useNavigate({ from: "/chat" });
+  const openConversation = useCallback(
+    (
+      selectedConversationId: number,
+      options: {
+        replace?: boolean;
+      } = {},
+    ) => {
+      const target = {
+        to: "/chat",
+        search: { conversationId: String(selectedConversationId) },
+      } as const;
+
+      void navigate(
+        options.replace === undefined
+          ? target
+          : { ...target, replace: options.replace },
+      );
+    },
+    [navigate],
+  );
+  const historyEntry = useChatHistoryEntry({
+    userId,
+    conversationId,
+    onOpenConversation: openConversation,
+  });
   const {
     conversation,
     messages,
@@ -107,10 +134,7 @@ export function ChatPage({
   }
 
   function handleResumeConversation(selectedConversationId: number) {
-    void navigate({
-      to: "/chat",
-      search: { conversationId: String(selectedConversationId) },
-    });
+    openConversation(selectedConversationId);
   }
 
   async function handleSubmit() {
@@ -225,7 +249,7 @@ export function ChatPage({
 
   return (
     <div className="flex flex-col gap-4 pb-10">
-      <div className="mx-auto w-full max-w-3xl px-4 pt-4">
+      <div className="mx-auto w-full max-w-6xl px-4 pt-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="sm:flex-1">
             <AIChatBillingCard
@@ -251,6 +275,16 @@ export function ChatPage({
             <Button
               type="button"
               variant="outline"
+              aria-label="Open chat history"
+              onClick={() => historyEntry.setIsMobileOpen(true)}
+              className="w-full lg:hidden"
+            >
+              <History className="size-4" />
+              History
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
               aria-label="New Chat"
               onClick={handleNewChat}
               disabled={billingAccess.isCheckingAccess || !hasChatAccess}
@@ -264,99 +298,126 @@ export function ChatPage({
       </div>
 
       {billingAccess.checkoutNotice ? (
-        <div className="mx-auto w-full max-w-3xl px-4">
+        <div className="mx-auto w-full max-w-6xl px-4">
           <CheckoutNotice checkout={billingAccess.checkoutNotice} />
         </div>
       ) : null}
       {billingAccess.billingNotice ? (
-        <div className="mx-auto w-full max-w-3xl px-4">
+        <div className="mx-auto w-full max-w-6xl px-4">
           <BillingReturnNotice billing={billingAccess.billingNotice} />
         </div>
       ) : null}
 
-      <div className="mx-auto w-full max-w-3xl px-4">
-        {!conversationId && showEmptyState ? (
-          <ChatHistoryEntry
-            userId={currentUserId}
-            fallback={emptyState}
-            onResumeConversation={handleResumeConversation}
-            onNewChat={() => void handleNewChat()}
-            isNewChatDisabled={billingAccess.isCheckingAccess || !hasChatAccess}
-          />
-        ) : showEmptyState ? (
-          emptyState
-        ) : (
-          <div className="flex flex-col gap-6">
-            {loadError ? (
-              <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-                {loadError}
-              </div>
-            ) : isLoadingConversation && messages.length === 0 ? (
-              <div className="text-sm text-muted-foreground">
-                Loading conversation...
-              </div>
-            ) : (
-              <div className="flex flex-col gap-6">
-                {messages.map((message) => (
-                  <MessageBubble
-                    key={`${message.id}-${message.updated_at}`}
-                    message={message}
-                    isLastAssistant={message.id === lastAssistantMessageId}
-                    onRetry={handleRetry}
-                    workoutDraft={
-                      message.id === latestWorkoutDraftMessageId
-                        ? conversation?.latest_workout_draft
-                        : undefined
-                    }
-                    onEditWorkoutDraft={() => {
-                      if (conversation?.latest_workout_draft) {
-                        handleEditInWorkoutForm(
-                          conversation.latest_workout_draft,
-                        );
-                      }
-                    }}
-                    onSaveWorkoutDraft={() => {
-                      if (conversation?.latest_workout_draft) {
-                        void handleSaveWorkoutDraft();
-                      }
-                    }}
-                    onOpenSavedWorkout={
-                      savedWorkoutId
-                        ? () => handleOpenSavedWorkout(savedWorkoutId)
-                        : undefined
-                    }
-                    isSavingWorkoutDraft={isSavingWorkoutDraft}
-                    isSavedWorkoutDraft={isLatestWorkoutDraftSaved}
-                    savedWorkoutId={savedWorkoutId}
-                  />
-                ))}
-              </div>
-            )}
-
-            {conversation?.latest_workout_draft &&
-            latestWorkoutDraftMessageId === null ? (
-              <ChatWorkoutDraftCard
-                draft={conversation.latest_workout_draft}
-                isSaving={isSavingWorkoutDraft}
-                isSaved={isLatestWorkoutDraftSaved}
-                savedWorkoutId={savedWorkoutId}
-                onSave={() => void handleSaveWorkoutDraft()}
-                onEdit={() =>
-                  handleEditInWorkoutForm(conversation.latest_workout_draft!)
-                }
-                onOpenSavedWorkout={
-                  savedWorkoutId
-                    ? () => handleOpenSavedWorkout(savedWorkoutId)
-                    : undefined
-                }
-              />
-            ) : null}
-
-            <div className="bg-background pt-2 md:sticky md:bottom-4">
-              {composer}
-            </div>
-          </div>
+      <div
+        className={cn(
+          "mx-auto grid w-full max-w-6xl gap-4 px-4 lg:grid-cols-[18rem_minmax(0,48rem)] lg:items-start",
+          historyEntry.isCollapsed && "lg:grid-cols-[3.25rem_minmax(0,48rem)]",
         )}
+      >
+        <ChatHistoryEntry
+          conversations={historyEntry.conversations}
+          activeConversationId={conversationId}
+          isLoading={historyEntry.isLoading}
+          error={historyEntry.error}
+          isCollapsed={historyEntry.isCollapsed}
+          isMobileOpen={historyEntry.isMobileOpen}
+          onMobileOpenChange={historyEntry.setIsMobileOpen}
+          onToggleCollapsed={() =>
+            historyEntry.setIsCollapsed((value) => !value)
+          }
+          onResumeConversation={handleResumeConversation}
+          onNewChat={() => void handleNewChat()}
+          isNewChatDisabled={billingAccess.isCheckingAccess || !hasChatAccess}
+        />
+
+        <div className="min-w-0 lg:max-w-3xl">
+          {historyEntry.isPreparingEntry ||
+          historyEntry.isAutoOpeningRecentChat ? (
+            <div className="text-sm text-muted-foreground">
+              Opening latest chat...
+            </div>
+          ) : historyEntry.error && !conversationId ? (
+            <div className="flex flex-col gap-4">
+              <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+                {historyEntry.error}
+              </div>
+              {emptyState}
+            </div>
+          ) : showEmptyState ? (
+            emptyState
+          ) : (
+            <div className="flex flex-col gap-6">
+              {loadError ? (
+                <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+                  {loadError}
+                </div>
+              ) : isLoadingConversation && messages.length === 0 ? (
+                <div className="text-sm text-muted-foreground">
+                  Loading conversation...
+                </div>
+              ) : (
+                <div className="flex flex-col gap-6">
+                  {messages.map((message) => (
+                    <MessageBubble
+                      key={`${message.id}-${message.updated_at}`}
+                      message={message}
+                      isLastAssistant={message.id === lastAssistantMessageId}
+                      onRetry={handleRetry}
+                      workoutDraft={
+                        message.id === latestWorkoutDraftMessageId
+                          ? conversation?.latest_workout_draft
+                          : undefined
+                      }
+                      onEditWorkoutDraft={() => {
+                        if (conversation?.latest_workout_draft) {
+                          handleEditInWorkoutForm(
+                            conversation.latest_workout_draft,
+                          );
+                        }
+                      }}
+                      onSaveWorkoutDraft={() => {
+                        if (conversation?.latest_workout_draft) {
+                          void handleSaveWorkoutDraft();
+                        }
+                      }}
+                      onOpenSavedWorkout={
+                        savedWorkoutId
+                          ? () => handleOpenSavedWorkout(savedWorkoutId)
+                          : undefined
+                      }
+                      isSavingWorkoutDraft={isSavingWorkoutDraft}
+                      isSavedWorkoutDraft={isLatestWorkoutDraftSaved}
+                      savedWorkoutId={savedWorkoutId}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {conversation?.latest_workout_draft &&
+              latestWorkoutDraftMessageId === null ? (
+                <ChatWorkoutDraftCard
+                  draft={conversation.latest_workout_draft}
+                  isSaving={isSavingWorkoutDraft}
+                  isSaved={isLatestWorkoutDraftSaved}
+                  savedWorkoutId={savedWorkoutId}
+                  onSave={() => void handleSaveWorkoutDraft()}
+                  onEdit={() =>
+                    handleEditInWorkoutForm(conversation.latest_workout_draft!)
+                  }
+                  onOpenSavedWorkout={
+                    savedWorkoutId
+                      ? () => handleOpenSavedWorkout(savedWorkoutId)
+                      : undefined
+                  }
+                />
+              ) : null}
+
+              <div className="bg-background pt-2 md:sticky md:bottom-4">
+                {composer}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { History, Plus } from "lucide-react";
+import { History } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -125,6 +125,7 @@ export function ChatPage({
   const hasChatAccess = billingAccess.hasChatAccess;
   const isComposerDisabled =
     isSubmitting || billingAccess.isCheckingAccess || !hasChatAccess;
+  const showBillingAccessPanel = billingAccess.accessState !== "ready";
 
   async function handleNewChat() {
     if (!hasChatAccess || billingAccess.isCheckingAccess) {
@@ -250,53 +251,59 @@ export function ChatPage({
 
   return (
     <div className="flex flex-col gap-4 pb-10">
-      <div className="mx-auto w-full max-w-6xl px-4 pt-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="sm:flex-1">
-            <AIChatBillingCard
-              status={billingAccess.billingStatus}
-              accessState={billingAccess.accessState}
-              isLoading={billingAccess.isBillingCardLoading}
-              isError={billingAccess.isBillingError}
-            />
+      {showBillingAccessPanel ? (
+        <div className="mx-auto w-full max-w-6xl px-4 pt-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="sm:flex-1">
+              <AIChatBillingCard
+                status={billingAccess.billingStatus}
+                accessState={billingAccess.accessState}
+                isLoading={billingAccess.isBillingCardLoading}
+                isError={billingAccess.isBillingError}
+              />
+            </div>
+            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-start">
+              <AIChatBillingActions
+                status={billingAccess.billingStatus}
+                accessState={billingAccess.accessState}
+                isLoading={billingAccess.isBillingCardLoading}
+                isError={billingAccess.isBillingError}
+                isRefreshingAccess={billingAccess.isRefreshingAccess}
+                isCheckoutLoading={billingAccess.isCheckoutLoading}
+                isBillingPortalLoading={billingAccess.isBillingPortalLoading}
+                onStartCheckout={billingAccess.startCheckout}
+                onManageBilling={billingAccess.manageBilling}
+                onRefreshAccess={billingAccess.refreshAccess}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                aria-label="Open chat history"
+                onClick={() => historyEntry.setIsMobileOpen(true)}
+                className="w-full lg:hidden"
+              >
+                <History className="size-4" />
+                History
+              </Button>
+            </div>
           </div>
-          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-start">
-            <AIChatBillingActions
-              status={billingAccess.billingStatus}
-              accessState={billingAccess.accessState}
-              isLoading={billingAccess.isBillingCardLoading}
-              isError={billingAccess.isBillingError}
-              isRefreshingAccess={billingAccess.isRefreshingAccess}
-              isCheckoutLoading={billingAccess.isCheckoutLoading}
-              isBillingPortalLoading={billingAccess.isBillingPortalLoading}
-              onStartCheckout={billingAccess.startCheckout}
-              onManageBilling={billingAccess.manageBilling}
-              onRefreshAccess={billingAccess.refreshAccess}
-            />
+        </div>
+      ) : (
+        <div className="mx-auto w-full max-w-6xl px-4 pt-4 lg:hidden">
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-start sm:justify-end">
             <Button
               type="button"
               variant="outline"
               aria-label="Open chat history"
               onClick={() => historyEntry.setIsMobileOpen(true)}
-              className="w-full lg:hidden"
+              className="w-full"
             >
               <History className="size-4" />
               History
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              aria-label="New Chat"
-              onClick={handleNewChat}
-              disabled={billingAccess.isCheckingAccess || !hasChatAccess}
-              className="w-full sm:w-auto"
-            >
-              <Plus className="size-4" />
-              New Chat
-            </Button>
           </div>
         </div>
-      </div>
+      )}
 
       {billingAccess.checkoutNotice ? (
         <div className="mx-auto w-full max-w-6xl px-4">
@@ -311,8 +318,10 @@ export function ChatPage({
 
       <div
         className={cn(
-          "mx-auto grid w-full max-w-6xl gap-4 px-4 lg:grid-cols-[18rem_minmax(0,48rem)] lg:items-start",
-          historyEntry.isCollapsed && "lg:grid-cols-[3.25rem_minmax(0,48rem)]",
+          "mx-auto w-full px-4",
+          historyEntry.isCollapsed
+            ? "max-w-3xl"
+            : "max-w-6xl lg:grid lg:grid-cols-[18rem_minmax(0,48rem)] lg:items-start lg:gap-4",
         )}
       >
         <ChatHistoryEntry

--- a/client/src/features/chat/test/chat-page-test-utils.tsx
+++ b/client/src/features/chat/test/chat-page-test-utils.tsx
@@ -132,10 +132,14 @@ vi.mock("sonner", () => ({
 
 const { ChatPage } = await import("@/features/chat/pages/chat-page");
 
-export function ChatRouteComponent() {
+export function ChatRouteComponent({
+  userId = "user-123",
+}: {
+  userId?: string;
+} = {}) {
   return (
     <ChatPage
-      userId="user-123"
+      userId={userId}
       conversationId={parseConversationId(mockSearch.conversationId)}
       conversationIdSearch={mockSearch.conversationId}
       checkout={mockSearch.checkout}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -55,6 +55,9 @@ code {
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: Menlo, Monaco, "Courier New", monospace;
   --radius: 0.75rem;
+  /* Width of the expanded chat history rail; the chat page derives its centered
+     gutter from this (see --spacing-chat-gutter below). */
+  --chat-sidebar-w: 18rem;
   --shadow-2xs: 0px 4px 16px -2px hsl(0 0% 0% / 0.03);
   --shadow-xs: 0px 4px 16px -2px hsl(0 0% 0% / 0.03);
   --shadow-sm:
@@ -181,6 +184,11 @@ code {
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+
+  /* Chat layout: w-chat-sidebar matches the expanded history rail; the gutter
+     (rail + 2rem) keeps the centered chat column clear of it at all widths. */
+  --spacing-chat-sidebar: var(--chat-sidebar-w);
+  --spacing-chat-gutter: calc(var(--chat-sidebar-w) + 2rem);
 
   --shadow-2xs: var(--shadow-2xs);
   --shadow-xs: var(--shadow-xs);


### PR DESCRIPTION
## Summary
- Moves AI chat history into a dedicated chat-history surface: left sidebar on desktop, bottom drawer on smaller/PWA screens.
- Auto-opens the newest prior conversation when users enter `/chat` without a `conversationId`, so PWA bottom-nav re-entry no longer strands them on a blank new-chat state.
- Keeps New Chat explicit from both the main chat actions and the history surface, with a desktop collapse/expand control for the history sidebar.

## Product impact
PWA users can return to previous AI chats without relying on a visible browser URL. Desktop users get chat history beside the conversation, while smaller screens keep the compact History button and drawer flow.

## Verification
- `bun run test src/features/chat/pages/chat-page.test.tsx src/features/chat/pages/chat-billing-page.test.tsx src/features/chat/api/ai-chat.test.ts`
- `bun run test src/features/chat/pages/chat-workout-draft-page.test.tsx`
- `bun run lint`
- `bun run tsc`
- Browser check on local dev stack: `/chat` auto-resumed an existing conversation; desktop showed the left chat-history sidebar and collapse/expand rail; mobile viewport showed History button and bottom-sheet history with New Chat.

## Note
The full pre-commit `vitest run` pass hit a timeout in `chat-workout-draft-page.test.tsx`; that same file passed immediately when rerun in isolation.