### PR TITLE
fix: use app shell on privacy page

### DIFF
--- a/client/src/routes/privacy.tsx
+++ b/client/src/routes/privacy.tsx
@@ -1,43 +1,31 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { ShieldCheck } from "lucide-react";
+import { AppShell } from "@/components/nav/app-shell";
 import { Badge } from "@/components/ui/badge";
 import {
   getPolicySections,
   effectiveDate,
 } from "@/features/privacy/privacy-content";
+import { useDisplayMode } from "@/hooks/use-display-mode";
 
 export const Route = createFileRoute("/privacy")({
   component: PrivacyPage,
 });
 
-function PrivacyPage() {
+export function PrivacyPage() {
+  const { user } = Route.useRouteContext();
+  const displayMode = useDisplayMode();
   const sections = getPolicySections();
 
   return (
-    <main className="min-h-screen bg-background">
-      <header className="border-b border-border bg-background/90 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-          <Link
-            to="/"
-            className="flex items-center gap-2 font-bold tracking-wide text-foreground"
-          >
-            <img
-              src="/favicon.svg"
-              alt=""
-              aria-hidden="true"
-              className="h-6 w-6 rounded-sm"
-            />
-            FITTRACK
-          </Link>
-          <Link
-            to="/"
-            className="text-sm font-medium text-muted-foreground hover:text-foreground"
-          >
-            Home
-          </Link>
-        </div>
-      </header>
-
+    <main
+      className={
+        displayMode === "pwa"
+          ? "min-h-screen bg-background pt-[env(safe-area-inset-top)] pb-[calc(5rem+env(safe-area-inset-bottom))]"
+          : "min-h-screen bg-background"
+      }
+    >
+      <AppShell user={user} />
       <section className="px-6 py-14">
         <div className="mx-auto max-w-6xl">
           <div className="mb-12 max-w-3xl space-y-4">

--- a/client/src/test/routes/privacy.test.tsx
+++ b/client/src/test/routes/privacy.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const routeContextMock = vi.hoisted(() => vi.fn());
+const displayModeMock = vi.hoisted(() => vi.fn());
+const appShellMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (config: object) => ({
+    ...config,
+    useRouteContext: routeContextMock,
+  }),
+}));
+
+vi.mock("@/components/nav/app-shell", () => ({
+  AppShell: ({ user }: { user: { id: string } | null }) => {
+    appShellMock(user);
+
+    return <div data-testid="app-shell" />;
+  },
+}));
+
+vi.mock("@/features/privacy/privacy-content", () => ({
+  effectiveDate: "June 28, 2026",
+  getPolicySections: () => [
+    {
+      id: "summary",
+      title: "Summary",
+      content: <p>FitTrack privacy details.</p>,
+    },
+  ],
+}));
+
+vi.mock("@/hooks/use-display-mode", () => ({
+  useDisplayMode: displayModeMock,
+}));
+
+import { PrivacyPage } from "@/routes/privacy";
+
+describe("privacy route", () => {
+  it("renders the shared app shell with the route user", () => {
+    const user = { id: "user_1" };
+    routeContextMock.mockReturnValue({ user });
+    displayModeMock.mockReturnValue("browser");
+
+    render(<PrivacyPage />);
+
+    expect(screen.getByTestId("app-shell")).toBeInTheDocument();
+    expect(appShellMock).toHaveBeenCalledWith(user);
+    expect(
+      screen.getByRole("heading", { name: "Privacy Policy" }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the one-off /privacy header with the shared AppShell
- preserve browser and PWA spacing behavior for the privacy route
- add a route regression test that verifies the shared shell receives the route user

## Checks
- PASS: bun run fmt:check src/routes/privacy.tsx src/test/routes/privacy.test.tsx
- PASS: bun run test src/test/routes/privacy.test.tsx
- PASS: bun run lint
- PASS: bun run tsc
- NOTE: pre-commit full bun run test was blocked by existing chat billing page failures in src/features/chat/pages/chat-billing-page*.test.tsx; the new privacy route test passed in that run.