### PR TITLE
Refactor chat workout draft save state

### DIFF
--- a/client/src/features/chat/components/chat-workout-draft-card.test.tsx
+++ b/client/src/features/chat/components/chat-workout-draft-card.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { AIWorkoutDraft } from "@/features/chat/api/ai-chat";
+import { ChatWorkoutDraftCard } from "./chat-workout-draft-card";
+
+const draft: AIWorkoutDraft = {
+  date: "2026-04-20T12:00:00Z",
+  workoutFocus: "pull",
+  exercises: [
+    {
+      name: "Chest Supported Row",
+      sets: [{ reps: 10, setType: "working" }],
+    },
+  ],
+};
+
+describe("ChatWorkoutDraftCard", () => {
+  it("shows a saved draft without an open-workout action when no saved workout is available", () => {
+    render(
+      <ChatWorkoutDraftCard
+        draft={draft}
+        saveState={{ status: "saved" }}
+        onSave={vi.fn()}
+        onEdit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Saved" })).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Open saved workout" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the open-workout action attached to the saved-with-workout state", async () => {
+    const user = userEvent.setup();
+    const onOpenSavedWorkout = vi.fn();
+    render(
+      <ChatWorkoutDraftCard
+        draft={draft}
+        saveState={{
+          status: "savedWithWorkout",
+          workoutId: 42,
+          onOpenSavedWorkout,
+        }}
+        onSave={vi.fn()}
+        onEdit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Saved" })).toBeDisabled();
+
+    await user.click(
+      screen.getByRole("button", { name: "Open saved workout" }),
+    );
+
+    expect(onOpenSavedWorkout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/features/chat/components/chat-workout-draft-card.tsx
+++ b/client/src/features/chat/components/chat-workout-draft-card.tsx
@@ -6,31 +6,39 @@ import type {
 } from "@/features/chat/api/ai-chat";
 import { cn } from "@/lib/utils";
 
+/** Save/open state for a structured workout draft card. */
+export type ChatWorkoutDraftSaveState =
+  | { readonly status: "idle" }
+  | { readonly status: "saving" }
+  | { readonly status: "saved" }
+  | {
+      readonly status: "savedWithWorkout";
+      readonly workoutId: number;
+      readonly onOpenSavedWorkout: () => void;
+    };
+
 type ChatWorkoutDraftCardProps = {
-  draft: AIWorkoutDraft;
-  isSaving?: boolean;
-  isSaved?: boolean;
-  savedWorkoutId?: number;
-  onSave: () => void;
-  onEdit: () => void;
-  onOpenSavedWorkout?: () => void;
-  className?: string;
+  readonly draft: AIWorkoutDraft;
+  readonly saveState: ChatWorkoutDraftSaveState;
+  readonly onSave: () => void;
+  readonly onEdit: () => void;
+  readonly className?: string;
 };
 
 export function ChatWorkoutDraftCard({
   draft,
-  isSaving = false,
-  isSaved = false,
-  savedWorkoutId,
+  saveState,
   onSave,
   onEdit,
-  onOpenSavedWorkout,
   className,
 }: ChatWorkoutDraftCardProps) {
   const totalSets = draft.exercises.reduce(
     (count, exercise) => count + exercise.sets.length,
     0,
   );
+  const isSaving = saveState.status === "saving";
+  const isSaved =
+    saveState.status === "saved" || saveState.status === "savedWithWorkout";
 
   return (
     <div
@@ -81,11 +89,11 @@ export function ChatWorkoutDraftCard({
           >
             Edit in workout form
           </Button>
-          {isSaved && savedWorkoutId && onOpenSavedWorkout ? (
+          {saveState.status === "savedWithWorkout" ? (
             <Button
               type="button"
               variant="outline"
-              onClick={onOpenSavedWorkout}
+              onClick={saveState.onOpenSavedWorkout}
             >
               Open saved workout
             </Button>

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -20,7 +20,10 @@ import { ChatEmptyState } from "../components/chat-empty-state";
 import { ChatHistoryEntry } from "../components/chat-history-entry";
 import { ChatMessageActions } from "../components/chat-message-actions";
 import { ChatTypingIndicator } from "../components/chat-typing-indicator";
-import { ChatWorkoutDraftCard } from "../components/chat-workout-draft-card";
+import {
+  ChatWorkoutDraftCard,
+  type ChatWorkoutDraftSaveState,
+} from "../components/chat-workout-draft-card";
 import { useAIChatBillingAccess } from "../hooks/use-ai-chat-billing-access";
 import { useAIChatSession } from "../hooks/use-ai-chat-session";
 import { useChatHistoryEntry } from "../hooks/use-chat-history-entry";
@@ -212,6 +215,13 @@ export function ChatPage({
     conversation?.latest_workout_draft_status?.is_saved ?? false;
   const savedWorkoutId =
     conversation?.latest_workout_draft_status?.saved_workout_id;
+  const workoutDraftSaveState = getWorkoutDraftSaveState({
+    isSaving: isSavingWorkoutDraft,
+    isSaved: isLatestWorkoutDraftSaved,
+    savedWorkoutId,
+    onOpenSavedWorkout: handleOpenSavedWorkout,
+  });
+  const latestWorkoutDraft = conversation?.latest_workout_draft;
 
   let lastAssistantMessageId: number | null = null;
   for (let index = messages.length - 1; index >= 0; index -= 1) {
@@ -393,39 +403,22 @@ export function ChatPage({
                         }
                       }}
                       onSaveWorkoutDraft={() => {
-                        if (conversation?.latest_workout_draft) {
+                        if (latestWorkoutDraft) {
                           void handleSaveWorkoutDraft();
                         }
                       }}
-                      onOpenSavedWorkout={
-                        savedWorkoutId
-                          ? () => handleOpenSavedWorkout(savedWorkoutId)
-                          : undefined
-                      }
-                      isSavingWorkoutDraft={isSavingWorkoutDraft}
-                      isSavedWorkoutDraft={isLatestWorkoutDraftSaved}
-                      savedWorkoutId={savedWorkoutId}
+                      workoutDraftSaveState={workoutDraftSaveState}
                     />
                   ))}
                 </div>
               )}
 
-              {conversation?.latest_workout_draft &&
-              latestWorkoutDraftMessageId === null ? (
+              {latestWorkoutDraft && latestWorkoutDraftMessageId === null ? (
                 <ChatWorkoutDraftCard
-                  draft={conversation.latest_workout_draft}
-                  isSaving={isSavingWorkoutDraft}
-                  isSaved={isLatestWorkoutDraftSaved}
-                  savedWorkoutId={savedWorkoutId}
+                  draft={latestWorkoutDraft}
+                  saveState={workoutDraftSaveState}
                   onSave={() => void handleSaveWorkoutDraft()}
-                  onEdit={() =>
-                    handleEditInWorkoutForm(conversation.latest_workout_draft!)
-                  }
-                  onOpenSavedWorkout={
-                    savedWorkoutId
-                      ? () => handleOpenSavedWorkout(savedWorkoutId)
-                      : undefined
-                  }
+                  onEdit={() => handleEditInWorkoutForm(latestWorkoutDraft)}
                 />
               ) : null}
 
@@ -481,23 +474,17 @@ function MessageBubble({
   isLastAssistant,
   onRetry,
   workoutDraft,
-  isSavingWorkoutDraft,
-  isSavedWorkoutDraft,
-  savedWorkoutId,
+  workoutDraftSaveState,
   onSaveWorkoutDraft,
   onEditWorkoutDraft,
-  onOpenSavedWorkout,
 }: {
   message: AIChatMessage;
   isLastAssistant?: boolean;
   onRetry?: () => void;
   workoutDraft?: AIWorkoutDraft;
-  isSavingWorkoutDraft?: boolean;
-  isSavedWorkoutDraft?: boolean;
-  savedWorkoutId?: number;
+  workoutDraftSaveState: ChatWorkoutDraftSaveState;
   onSaveWorkoutDraft?: () => void;
   onEditWorkoutDraft?: () => void;
-  onOpenSavedWorkout?: () => void;
 }) {
   const isUser = message.role === "user";
 
@@ -549,14 +536,41 @@ function MessageBubble({
         <ChatWorkoutDraftCard
           className={cn("mt-1 w-full")}
           draft={workoutDraft}
-          isSaving={isSavingWorkoutDraft}
-          isSaved={isSavedWorkoutDraft}
-          savedWorkoutId={savedWorkoutId}
+          saveState={workoutDraftSaveState}
           onSave={onSaveWorkoutDraft}
           onEdit={onEditWorkoutDraft}
-          onOpenSavedWorkout={onOpenSavedWorkout}
         />
       ) : null}
     </div>
   );
+}
+
+function getWorkoutDraftSaveState({
+  isSaving,
+  isSaved,
+  savedWorkoutId,
+  onOpenSavedWorkout,
+}: {
+  readonly isSaving: boolean;
+  readonly isSaved: boolean;
+  readonly savedWorkoutId: number | undefined;
+  readonly onOpenSavedWorkout: (workoutId: number) => void;
+}): ChatWorkoutDraftSaveState {
+  if (isSaving) {
+    return { status: "saving" };
+  }
+
+  if (!isSaved) {
+    return { status: "idle" };
+  }
+
+  if (savedWorkoutId === undefined) {
+    return { status: "saved" };
+  }
+
+  return {
+    status: "savedWithWorkout",
+    workoutId: savedWorkoutId,
+    onOpenSavedWorkout: () => onOpenSavedWorkout(savedWorkoutId),
+  };
 }


### PR DESCRIPTION
## Summary
- Model the chat workout draft save/open UI as an explicit discriminated union.
- Keep the visible draft card behavior unchanged while making impossible prop combinations unrepresentable.
- Add focused component regression coverage for saved draft states.

## Checks
- bun run test src/features/chat/components/chat-workout-draft-card.test.tsx src/features/chat/pages/chat-workout-draft-page.test.tsx
- bun run tsc
- bun run lint
- bun run fmt:check