### PR TITLE
Refactor AI chat stream event parsing

### DIFF
--- a/client/src/features/chat/api/ai-chat.test.ts
+++ b/client/src/features/chat/api/ai-chat.test.ts
@@ -32,9 +32,16 @@ import {
   saveAIChatLatestWorkoutDraft,
   streamAIChatMessage,
 } from "./ai-chat";
+import type { AIChatStreamDoneEvent } from "./ai-chat";
 
 function latestRequest(): Request {
   return vi.mocked(fetch).mock.calls.at(-1)?.[0] as Request;
+}
+
+function expectDoneEvent(
+  event: unknown,
+): asserts event is AIChatStreamDoneEvent {
+  expect(event).toMatchObject({ type: "done" });
 }
 
 describe("ai chat api wrapper", () => {
@@ -137,7 +144,8 @@ describe("ai chat api wrapper", () => {
 
     expect(seen).toEqual(["start", "hello ", "done"]);
     expect(result.endedWithError).toBe(false);
-    expect(result.doneEvent?.text).toBe("hello world");
+    expectDoneEvent(result.doneEvent);
+    expect(result.doneEvent.text).toBe("hello world");
   });
 
   it("parses workout draft payloads from done events", async () => {
@@ -171,7 +179,8 @@ describe("ai chat api wrapper", () => {
 
     const result = await streamAIChatMessage(41, "build me a pull workout");
 
-    expect(result.doneEvent?.workout_draft).toEqual({
+    expectDoneEvent(result.doneEvent);
+    expect(result.doneEvent.workout_draft).toEqual({
       date: "2026-04-20T12:00:00Z",
       workoutFocus: "pull",
       exercises: [
@@ -229,8 +238,9 @@ describe("ai chat api wrapper", () => {
       }),
     );
     expect(seen).toEqual([3, 4, "done"]);
-    expect(result.doneEvent?.sequence).toBe(4);
-    expect(result.doneEvent?.workout_draft?.date).toBe("2026-04-20T12:00:00Z");
+    expectDoneEvent(result.doneEvent);
+    expect(result.doneEvent.sequence).toBe(4);
+    expect(result.doneEvent.workout_draft?.date).toBe("2026-04-20T12:00:00Z");
   });
 
   it("suppresses duplicate SSE chunks by event id", async () => {
@@ -307,6 +317,64 @@ describe("ai chat api wrapper", () => {
     await expect(streamAIChatMessage(41, "hello")).rejects.toThrow(
       "AI chat stream ended before a terminal event",
     );
+  });
+
+  it("rejects malformed SSE event JSON before handlers receive it", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            ["event: delta", 'data: {"type":"delta"', "", ""].join("\n"),
+          ),
+        );
+        controller.close();
+      },
+    });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(stream, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+        },
+      }),
+    );
+
+    const onDelta = vi.fn();
+
+    await expect(streamAIChatMessage(41, "hello", { onDelta })).rejects.toThrow(
+      "Invalid AI chat stream event JSON",
+    );
+    expect(onDelta).not.toHaveBeenCalled();
+  });
+
+  it("rejects SSE event variants that are missing required payload fields", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            ["event: delta", 'data: {"type":"delta"}', "", ""].join("\n"),
+          ),
+        );
+        controller.close();
+      },
+    });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(stream, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+        },
+      }),
+    );
+
+    const onDelta = vi.fn();
+
+    await expect(streamAIChatMessage(41, "hello", { onDelta })).rejects.toThrow(
+      "AI chat stream event delta must be a string",
+    );
+    expect(onDelta).not.toHaveBeenCalled();
   });
 
   it("polls persisted conversation state until streaming settles", async () => {

--- a/client/src/features/chat/api/ai-chat.test.ts
+++ b/client/src/features/chat/api/ai-chat.test.ts
@@ -192,6 +192,44 @@ describe("ai chat api wrapper", () => {
     });
   });
 
+  it("accepts completed done events when the server omits empty text", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            [
+              "event: done",
+              'data: {"type":"done","conversation_id":41,"run_id":51,"message_id":61}',
+              "",
+              "",
+            ].join("\n"),
+          ),
+        );
+        controller.close();
+      },
+    });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(stream, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+        },
+      }),
+    );
+
+    const onDone = vi.fn();
+
+    const result = await streamAIChatMessage(41, "hello", { onDone });
+
+    expectDoneEvent(result.doneEvent);
+    expect(result.endedWithError).toBe(false);
+    expect(result.doneEvent.text).toBe("");
+    expect(onDone).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "done", text: "" }),
+    );
+  });
+
   it("resumes a chat stream after a sequence cursor", async () => {
     const stream = new ReadableStream({
       start(controller) {

--- a/client/src/features/chat/api/ai-chat.ts
+++ b/client/src/features/chat/api/ai-chat.ts
@@ -88,22 +88,43 @@ export type AIWorkoutDraft = {
   exercises: AIWorkoutExerciseInput[];
 };
 
-export type AIChatStreamEvent = {
-  type: "start" | "delta" | "done" | "error";
+type AIChatStreamEventContext = {
   request_id?: string;
   conversation_id?: number;
   run_id?: number;
   message_id?: number;
   model?: string;
-  delta?: string;
-  text?: string;
-  message?: string;
   sequence?: number;
-  workout_draft?: AIWorkoutDraft;
 };
 
+export type AIChatStreamStartEvent = {
+  type: "start";
+} & AIChatStreamEventContext;
+
+export type AIChatStreamDeltaEvent = {
+  type: "delta";
+  delta: string;
+} & AIChatStreamEventContext;
+
+export type AIChatStreamDoneEvent = {
+  type: "done";
+  text: string;
+  workout_draft?: AIWorkoutDraft;
+} & AIChatStreamEventContext;
+
+export type AIChatStreamErrorEvent = {
+  type: "error";
+  message: string;
+} & AIChatStreamEventContext;
+
+export type AIChatStreamEvent =
+  | AIChatStreamStartEvent
+  | AIChatStreamDeltaEvent
+  | AIChatStreamDoneEvent
+  | AIChatStreamErrorEvent;
+
 export type AIChatStreamResult = {
-  doneEvent?: AIChatStreamEvent;
+  doneEvent?: AIChatStreamDoneEvent | AIChatStreamErrorEvent;
   endedWithError: boolean;
 };
 
@@ -135,11 +156,13 @@ type ParsedSSEChunk = {
   id?: string;
 };
 
+type UnknownRecord = Record<string, unknown>;
+
 type StreamHandlers = {
-  onStart?: (event: AIChatStreamEvent) => void;
-  onDelta?: (event: AIChatStreamEvent) => void;
-  onDone?: (event: AIChatStreamEvent) => void;
-  onErrorEvent?: (event: AIChatStreamEvent) => void;
+  onStart?: (event: AIChatStreamStartEvent) => void;
+  onDelta?: (event: AIChatStreamDeltaEvent) => void;
+  onDone?: (event: AIChatStreamDoneEvent) => void;
+  onErrorEvent?: (event: AIChatStreamErrorEvent) => void;
   signal?: AbortSignal;
 };
 
@@ -363,7 +386,7 @@ async function readAIChatStreamResponse(
             handlers.onErrorEvent?.(event);
             return { doneEvent: event, endedWithError: true };
           default:
-            break;
+            return casesHandled(event);
         }
       }
     }
@@ -428,9 +451,223 @@ function parseSSEChunk(chunk: string): ParsedSSEChunk | null {
   }
 
   return {
-    event: JSON.parse(dataLines.join("\n")) as AIChatStreamEvent,
+    event: parseAIChatStreamEvent(dataLines.join("\n")),
     id,
   };
+}
+
+function parseAIChatStreamEvent(rawEventJson: string): AIChatStreamEvent {
+  let rawEvent: unknown;
+  try {
+    rawEvent = JSON.parse(rawEventJson);
+  } catch {
+    throw new Error("Invalid AI chat stream event JSON");
+  }
+
+  const event = parseRecord(rawEvent, "AI chat stream event");
+  const type = parseRequiredString(event, "type");
+  switch (type) {
+    case "start":
+      return { type, ...parseStreamEventContext(event) };
+    case "delta":
+      return {
+        type,
+        delta: parseRequiredString(event, "delta"),
+        ...parseStreamEventSequence(event),
+      };
+    case "done": {
+      const workoutDraft = parseOptionalWorkoutDraft(event.workout_draft);
+      return {
+        type,
+        text: parseRequiredString(event, "text"),
+        ...parseDoneEventContext(event),
+        ...(workoutDraft === undefined ? {} : { workout_draft: workoutDraft }),
+      };
+    }
+    case "error":
+      return {
+        type,
+        message: parseRequiredString(event, "message"),
+        ...parseErrorEventContext(event),
+      };
+    default:
+      throw new Error(`Unknown AI chat stream event type: ${type}`);
+  }
+}
+
+function parseStreamEventContext(
+  event: UnknownRecord,
+): AIChatStreamEventContext {
+  return {
+    ...parseStreamEventIdentity(event),
+    ...parseOptionalStringProperty(event, "request_id"),
+    ...parseOptionalStringProperty(event, "model"),
+    ...parseStreamEventSequence(event),
+  };
+}
+
+function parseDoneEventContext(
+  event: UnknownRecord,
+): Omit<AIChatStreamEventContext, "request_id"> {
+  return {
+    ...parseStreamEventIdentity(event),
+    ...parseOptionalStringProperty(event, "model"),
+    ...parseStreamEventSequence(event),
+  };
+}
+
+function parseErrorEventContext(
+  event: UnknownRecord,
+): Omit<AIChatStreamEventContext, "request_id" | "model" | "sequence"> {
+  return parseStreamEventIdentity(event);
+}
+
+function parseStreamEventIdentity(
+  event: UnknownRecord,
+): Pick<AIChatStreamEventContext, "conversation_id" | "run_id" | "message_id"> {
+  return {
+    ...parseOptionalNumberProperty(event, "conversation_id"),
+    ...parseOptionalNumberProperty(event, "run_id"),
+    ...parseOptionalNumberProperty(event, "message_id"),
+  };
+}
+
+function parseStreamEventSequence(
+  event: UnknownRecord,
+): Pick<AIChatStreamEventContext, "sequence"> {
+  return parseOptionalNumberProperty(event, "sequence");
+}
+
+function parseOptionalWorkoutDraft(
+  rawDraft: unknown,
+): AIWorkoutDraft | undefined {
+  if (rawDraft === undefined) {
+    return undefined;
+  }
+
+  const draft = parseRecord(rawDraft, "workout_draft");
+  const notes = parseOptionalStringProperty(draft, "notes");
+  const workoutFocus = parseOptionalStringProperty(draft, "workoutFocus");
+
+  return {
+    date: parseRequiredString(draft, "date"),
+    ...notes,
+    ...workoutFocus,
+    exercises: parseWorkoutExercises(draft.exercises),
+  };
+}
+
+function parseWorkoutExercises(
+  rawExercises: unknown,
+): AIWorkoutExerciseInput[] {
+  if (!Array.isArray(rawExercises)) {
+    throw new Error("AI chat workout draft exercises must be an array");
+  }
+
+  return rawExercises.map((rawExercise, exerciseIndex) => {
+    const exercise = parseRecord(
+      rawExercise,
+      `workout_draft.exercises[${exerciseIndex}]`,
+    );
+    return {
+      name: parseRequiredString(exercise, "name"),
+      sets: parseWorkoutSets(exercise.sets, exerciseIndex),
+    };
+  });
+}
+
+function parseWorkoutSets(
+  rawSets: unknown,
+  exerciseIndex: number,
+): AIWorkoutSetInput[] {
+  if (!Array.isArray(rawSets)) {
+    throw new Error(
+      `AI chat workout draft exercise ${exerciseIndex + 1} sets must be an array`,
+    );
+  }
+
+  return rawSets.map((rawSet, setIndex) => {
+    const set = parseRecord(
+      rawSet,
+      `workout_draft.exercises[${exerciseIndex}].sets[${setIndex}]`,
+    );
+    const setType = parseRequiredString(set, "setType");
+    if (setType !== "warmup" && setType !== "working") {
+      throw new Error("AI chat workout draft setType is invalid");
+    }
+
+    return {
+      ...parseOptionalNumberProperty(set, "weight"),
+      reps: parseRequiredNumber(set, "reps"),
+      setType,
+    };
+  });
+}
+
+function parseRecord(value: unknown, label: string): UnknownRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+
+  // SAFETY: The runtime object/null/array checks above establish the record shape
+  // needed for concrete field parsing in this boundary adapter.
+  return value as UnknownRecord;
+}
+
+function parseRequiredString(record: UnknownRecord, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string") {
+    throw new Error(`AI chat stream event ${key} must be a string`);
+  }
+
+  return value;
+}
+
+function parseRequiredNumber(record: UnknownRecord, key: string): number {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`AI chat stream event ${key} must be a number`);
+  }
+
+  return value;
+}
+
+function parseOptionalStringProperty<K extends string>(
+  record: UnknownRecord,
+  key: K,
+): Partial<Record<K, string>> {
+  const value = record[key];
+  if (value === undefined) {
+    return {};
+  }
+  if (typeof value !== "string") {
+    throw new Error(`AI chat stream event ${key} must be a string`);
+  }
+
+  // SAFETY: The computed key is the exact key argument, and the value was checked
+  // as a string before constructing the single-property record.
+  return { [key]: value } as Record<K, string>;
+}
+
+function parseOptionalNumberProperty<K extends string>(
+  record: UnknownRecord,
+  key: K,
+): Partial<Record<K, number>> {
+  const value = record[key];
+  if (value === undefined) {
+    return {};
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`AI chat stream event ${key} must be a number`);
+  }
+
+  // SAFETY: The computed key is the exact key argument, and the value was checked
+  // as a finite number before constructing the single-property record.
+  return { [key]: value } as Record<K, number>;
+}
+
+function casesHandled(value: never): never {
+  return value;
 }
 
 function throwIfAborted(signal?: AbortSignal): void {

--- a/client/src/features/chat/api/ai-chat.ts
+++ b/client/src/features/chat/api/ai-chat.ts
@@ -479,7 +479,7 @@ function parseAIChatStreamEvent(rawEventJson: string): AIChatStreamEvent {
       const workoutDraft = parseOptionalWorkoutDraft(event.workout_draft);
       return {
         type,
-        text: parseRequiredString(event, "text"),
+        text: parseOptionalStringValue(event, "text") ?? "",
         ...parseDoneEventContext(event),
         ...(workoutDraft === undefined ? {} : { workout_draft: workoutDraft }),
       };
@@ -636,17 +636,29 @@ function parseOptionalStringProperty<K extends string>(
   record: UnknownRecord,
   key: K,
 ): Partial<Record<K, string>> {
-  const value = record[key];
+  const value = parseOptionalStringValue(record, key);
   if (value === undefined) {
     return {};
-  }
-  if (typeof value !== "string") {
-    throw new Error(`AI chat stream event ${key} must be a string`);
   }
 
   // SAFETY: The computed key is the exact key argument, and the value was checked
   // as a string before constructing the single-property record.
   return { [key]: value } as Record<K, string>;
+}
+
+function parseOptionalStringValue(
+  record: UnknownRecord,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`AI chat stream event ${key} must be a string`);
+  }
+
+  return value;
 }
 
 function parseOptionalNumberProperty<K extends string>(

--- a/client/src/features/chat/utils/chat-resume.ts
+++ b/client/src/features/chat/utils/chat-resume.ts
@@ -1,7 +1,8 @@
 import type {
   AIChatConversationDetail,
   AIChatMessage,
-  AIChatStreamEvent,
+  AIChatStreamDoneEvent,
+  AIChatStreamErrorEvent,
 } from "@/features/chat/api/ai-chat";
 
 const storageKeyPrefix = "fittrack.ai-chat.resume";
@@ -104,7 +105,7 @@ export function updateStreamingMessageWithDelta(
 export function updateStreamingMessageWithDone(
   messages: AIChatMessage[],
   messageId: number,
-  event: AIChatStreamEvent,
+  event: AIChatStreamDoneEvent,
 ): AIChatMessage[] {
   return messages.map((message) =>
     message.id === messageId
@@ -112,7 +113,7 @@ export function updateStreamingMessageWithDone(
           ...message,
           id: event.message_id ?? message.id,
           status: "completed",
-          content: event.text ?? message.content,
+          content: event.text,
           completed_at: new Date().toISOString(),
         }
       : message,
@@ -122,7 +123,7 @@ export function updateStreamingMessageWithDone(
 export function updateStreamingMessageWithError(
   messages: AIChatMessage[],
   messageId: number,
-  event: AIChatStreamEvent,
+  event: AIChatStreamErrorEvent,
 ): AIChatMessage[] {
   return messages.map((message) =>
     message.id === messageId

--- a/client/src/features/chat/utils/chat-session-recovery.ts
+++ b/client/src/features/chat/utils/chat-session-recovery.ts
@@ -258,7 +258,11 @@ export async function resumeConversation(
       aborted: refreshed.aborted,
       error:
         refreshed.error ??
-        new Error(streamResult.doneEvent?.message ?? "AI chat resume failed"),
+        new Error(
+          streamResult.doneEvent?.type === "error"
+            ? streamResult.doneEvent.message
+            : "AI chat resume failed",
+        ),
     };
   } catch (error) {
     if (controller.signal.aborted || isAbortError(error)) {


### PR DESCRIPTION
## Summary
- Model AI chat SSE events as discriminated union variants with required payload fields per event type.
- Parse stream event JSON at the chat API boundary before handlers receive it.
- Tighten done/error stream handling and add regression tests for malformed SSE payloads.

## Checks
- bun run test src/features/chat/api/ai-chat.test.ts
- bun run tsc
- bun run lint
- bun run fmt:check