### PR TITLE
refactor: model ai chat run lifecycle

### DIFF
--- a/server/internal/aichat/repository_stream.go
+++ b/server/internal/aichat/repository_stream.go
@@ -231,6 +231,10 @@ func (r *repository) ClaimRunGeneration(ctx context.Context, run *ChatRun, owner
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
+	if !newChatRunLifecycle(run, now).CanClaimGeneration() {
+		return pgx.ErrNoRows
+	}
+
 	runRow, err := r.queries.ClaimAIChatRunGeneration(ctx, db.ClaimAIChatRunGenerationParams{
 		ID:     run.ID,
 		UserID: run.UserID,

--- a/server/internal/aichat/run_lifecycle.go
+++ b/server/internal/aichat/run_lifecycle.go
@@ -1,0 +1,100 @@
+package aichat
+
+import "time"
+
+type chatRunLifecycleState string
+
+const (
+	chatRunLifecycleInvalid             chatRunLifecycleState = "invalid"
+	chatRunLifecycleQueued              chatRunLifecycleState = "queued"
+	chatRunLifecycleOwnedGeneration     chatRunLifecycleState = "owned_generation"
+	chatRunLifecycleRecoverableStaleRun chatRunLifecycleState = "recoverable_stale_run"
+	chatRunLifecycleTerminal            chatRunLifecycleState = "terminal"
+)
+
+type chatRunLifecycle struct {
+	run   *ChatRun
+	now   time.Time
+	state chatRunLifecycleState
+}
+
+func newChatRunLifecycle(run *ChatRun, now time.Time) chatRunLifecycle {
+	lifecycle := chatRunLifecycle{
+		run:   run,
+		now:   now.UTC(),
+		state: chatRunLifecycleInvalid,
+	}
+	lifecycle.state = lifecycle.resolveState()
+	return lifecycle
+}
+
+func (l chatRunLifecycle) State() chatRunLifecycleState {
+	return l.state
+}
+
+func (l chatRunLifecycle) IsQueued() bool {
+	return l.state == chatRunLifecycleQueued
+}
+
+func (l chatRunLifecycle) IsOwnedGeneration() bool {
+	return l.state == chatRunLifecycleOwnedGeneration
+}
+
+func (l chatRunLifecycle) IsRecoverableStaleRun() bool {
+	return l.state == chatRunLifecycleRecoverableStaleRun
+}
+
+func (l chatRunLifecycle) IsTerminal() bool {
+	return l.state == chatRunLifecycleTerminal
+}
+
+func (l chatRunLifecycle) ShouldRecover() bool {
+	return l.IsRecoverableStaleRun()
+}
+
+func (l chatRunLifecycle) CanClaimGeneration() bool {
+	if l.GenerationAttemptsExhausted() {
+		return false
+	}
+	return l.IsQueued() || l.IsRecoverableStaleRun()
+}
+
+func (l chatRunLifecycle) GenerationAttemptsExhausted() bool {
+	return l.run != nil && l.run.GenerationAttempt >= maxGenerationAttempts
+}
+
+func (l chatRunLifecycle) resolveState() chatRunLifecycleState {
+	if l.run == nil {
+		return chatRunLifecycleInvalid
+	}
+	if l.run.Status != statusStreaming || isTerminalGenerationStatus(l.run.GenerationStatus) {
+		return chatRunLifecycleTerminal
+	}
+
+	switch l.run.GenerationStatus {
+	case generationStatusQueued:
+		if isStreamingRunStale(l.run.UpdatedAt, l.now) {
+			return chatRunLifecycleRecoverableStaleRun
+		}
+		return chatRunLifecycleQueued
+	case generationStatusGenerating:
+		if l.run.LeaseExpiresAt != nil && l.now.After(l.run.LeaseExpiresAt.UTC()) {
+			return chatRunLifecycleRecoverableStaleRun
+		}
+		if l.run.GenerationOwner != nil && l.run.LeaseExpiresAt != nil {
+			return chatRunLifecycleOwnedGeneration
+		}
+		return chatRunLifecycleInvalid
+	default:
+		return chatRunLifecycleInvalid
+	}
+}
+
+func isTerminalGenerationStatus(status string) bool {
+	switch status {
+	case generationStatusCompleted, generationStatusFailed, generationStatusInterrupted:
+		return true
+	default:
+		return false
+	}
+}

--- a/server/internal/aichat/run_lifecycle_test.go
+++ b/server/internal/aichat/run_lifecycle_test.go
@@ -1,0 +1,169 @@
+package aichat
+
+import (
+	"testing"
+	"time"
+)
+
+func TestChatRunLifecycleStates(t *testing.T) {
+	now := time.Date(2026, 6, 29, 15, 0, 0, 0, time.UTC)
+	staleUpdatedAt := now.Add(-streamingRunStaleAfter - time.Second)
+	freshUpdatedAt := now.Add(-streamingRunStaleAfter + time.Second)
+	expiredLease := now.Add(-time.Second)
+	validLease := now.Add(time.Second)
+	owner := "api:worker-1"
+
+	tests := []struct {
+		name              string
+		run               *ChatRun
+		wantState         chatRunLifecycleState
+		wantQueued        bool
+		wantOwned         bool
+		wantRecoverable   bool
+		wantTerminal      bool
+		wantCanClaim      bool
+		wantAttemptsSpent bool
+	}{
+		{
+			name:      "nil run",
+			wantState: chatRunLifecycleInvalid,
+		},
+		{
+			name: "completed run is terminal",
+			run: &ChatRun{
+				Status:           statusCompleted,
+				GenerationStatus: generationStatusCompleted,
+			},
+			wantState:    chatRunLifecycleTerminal,
+			wantTerminal: true,
+		},
+		{
+			name: "fresh queued streaming run can be claimed but does not need recovery",
+			run: &ChatRun{
+				Status:           statusStreaming,
+				GenerationStatus: generationStatusQueued,
+				UpdatedAt:        freshUpdatedAt,
+			},
+			wantState:    chatRunLifecycleQueued,
+			wantQueued:   true,
+			wantCanClaim: true,
+		},
+		{
+			name: "stale queued streaming run is recoverable",
+			run: &ChatRun{
+				Status:           statusStreaming,
+				GenerationStatus: generationStatusQueued,
+				UpdatedAt:        staleUpdatedAt,
+			},
+			wantState:       chatRunLifecycleRecoverableStaleRun,
+			wantRecoverable: true,
+			wantCanClaim:    true,
+		},
+		{
+			name: "fresh owned generation is not claimable",
+			run: &ChatRun{
+				Status:           statusStreaming,
+				GenerationStatus: generationStatusGenerating,
+				GenerationOwner:  &owner,
+				LeaseExpiresAt:   &validLease,
+			},
+			wantState: chatRunLifecycleOwnedGeneration,
+			wantOwned: true,
+		},
+		{
+			name: "expired owned generation is recoverable and claimable",
+			run: &ChatRun{
+				Status:           statusStreaming,
+				GenerationStatus: generationStatusGenerating,
+				GenerationOwner:  &owner,
+				LeaseExpiresAt:   &expiredLease,
+			},
+			wantState:       chatRunLifecycleRecoverableStaleRun,
+			wantRecoverable: true,
+			wantCanClaim:    true,
+		},
+		{
+			name: "generating run without lease is invalid",
+			run: &ChatRun{
+				Status:           statusStreaming,
+				GenerationStatus: generationStatusGenerating,
+				GenerationOwner:  &owner,
+			},
+			wantState: chatRunLifecycleInvalid,
+		},
+		{
+			name: "interrupted generation is terminal even when run status is failed",
+			run: &ChatRun{
+				Status:           statusFailed,
+				GenerationStatus: generationStatusInterrupted,
+			},
+			wantState:    chatRunLifecycleTerminal,
+			wantTerminal: true,
+		},
+		{
+			name: "exhausted stale generation still needs recovery but cannot be claimed",
+			run: &ChatRun{
+				Status:            statusStreaming,
+				GenerationStatus:  generationStatusGenerating,
+				GenerationOwner:   &owner,
+				LeaseExpiresAt:    &expiredLease,
+				GenerationAttempt: maxGenerationAttempts,
+			},
+			wantState:         chatRunLifecycleRecoverableStaleRun,
+			wantRecoverable:   true,
+			wantAttemptsSpent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lifecycle := newChatRunLifecycle(tt.run, now)
+
+			if lifecycle.State() != tt.wantState {
+				t.Fatalf("state = %q, want %q", lifecycle.State(), tt.wantState)
+			}
+			if lifecycle.IsQueued() != tt.wantQueued {
+				t.Fatalf("IsQueued = %t, want %t", lifecycle.IsQueued(), tt.wantQueued)
+			}
+			if lifecycle.IsOwnedGeneration() != tt.wantOwned {
+				t.Fatalf("IsOwnedGeneration = %t, want %t", lifecycle.IsOwnedGeneration(), tt.wantOwned)
+			}
+			if lifecycle.IsRecoverableStaleRun() != tt.wantRecoverable {
+				t.Fatalf("IsRecoverableStaleRun = %t, want %t", lifecycle.IsRecoverableStaleRun(), tt.wantRecoverable)
+			}
+			if lifecycle.IsTerminal() != tt.wantTerminal {
+				t.Fatalf("IsTerminal = %t, want %t", lifecycle.IsTerminal(), tt.wantTerminal)
+			}
+			if lifecycle.ShouldRecover() != tt.wantRecoverable {
+				t.Fatalf("ShouldRecover = %t, want %t", lifecycle.ShouldRecover(), tt.wantRecoverable)
+			}
+			if lifecycle.CanClaimGeneration() != tt.wantCanClaim {
+				t.Fatalf("CanClaimGeneration = %t, want %t", lifecycle.CanClaimGeneration(), tt.wantCanClaim)
+			}
+			if lifecycle.GenerationAttemptsExhausted() != tt.wantAttemptsSpent {
+				t.Fatalf("GenerationAttemptsExhausted = %t, want %t", lifecycle.GenerationAttemptsExhausted(), tt.wantAttemptsSpent)
+			}
+		})
+	}
+}
+
+func TestShouldRecoverRunUsesLifecycle(t *testing.T) {
+	now := time.Date(2026, 6, 29, 15, 0, 0, 0, time.UTC)
+	expiredLease := now.Add(-time.Second)
+	validLease := now.Add(time.Second)
+
+	if !shouldRecoverRun(&ChatRun{
+		Status:           statusStreaming,
+		GenerationStatus: generationStatusGenerating,
+		LeaseExpiresAt:   &expiredLease,
+	}, now) {
+		t.Fatal("expired generating run should be recoverable")
+	}
+	if shouldRecoverRun(&ChatRun{
+		Status:           statusStreaming,
+		GenerationStatus: generationStatusGenerating,
+		LeaseExpiresAt:   &validLease,
+	}, now) {
+		t.Fatal("fresh generating run should not be recoverable")
+	}
+}

--- a/server/internal/aichat/service_recovery.go
+++ b/server/internal/aichat/service_recovery.go
@@ -127,19 +127,9 @@ func (s *Service) RecoverStreamingRun(ctx context.Context, request RunRecoveryRe
 }
 
 func shouldRecoverRun(run *ChatRun, now time.Time) bool {
-	if run == nil || run.Status != statusStreaming {
-		return false
-	}
-	switch run.GenerationStatus {
-	case generationStatusGenerating:
-		return run.LeaseExpiresAt != nil && now.UTC().After(run.LeaseExpiresAt.UTC())
-	case generationStatusQueued:
-		return isStreamingRunStale(run.UpdatedAt, now)
-	default:
-		return false
-	}
+	return newChatRunLifecycle(run, now).ShouldRecover()
 }
 
 func generationAttemptsExhausted(run *ChatRun) bool {
-	return run != nil && run.GenerationAttempt >= maxGenerationAttempts
+	return newChatRunLifecycle(run, time.Now().UTC()).GenerationAttemptsExhausted()
 }


### PR DESCRIPTION
## Summary
- Add a feature-local AI chat run lifecycle helper for queued, owned generation, recoverable stale, and terminal run states.
- Route recovery predicates and repository claim eligibility through the lifecycle helper while leaving SQL claim enforcement in place.
- Add focused unit coverage for lifecycle parsing and recovery/claim decisions.

## Checks
- go test -short ./internal/aichat
- go vet ./internal/aichat
- go vet ./...
- git diff --check
- pre-push make test-short