### PR TITLE
refactor: model chat history entry state

### DIFF
--- a/client/src/features/chat/hooks/use-chat-history-entry.test.tsx
+++ b/client/src/features/chat/hooks/use-chat-history-entry.test.tsx
@@ -76,7 +76,9 @@ describe("useChatHistoryEntry", () => {
         expect.objectContaining({ title: "User 2 current chat" }),
       ]);
     });
-    expect(view.result.current.isPreparingEntry).toBe(false);
+    expect(view.result.current.entryState).toEqual({
+      status: "openingLatestChat",
+    });
 
     await act(async () => {
       resolveStaleRefresh([conversation(73, "User 1 stale chat")]);
@@ -85,6 +87,50 @@ describe("useChatHistoryEntry", () => {
     expect(view.result.current.conversations).toEqual([
       expect.objectContaining({ title: "User 2 current chat" }),
     ]);
-    expect(view.result.current.isPreparingEntry).toBe(false);
+    expect(view.result.current.entryState).toEqual({
+      status: "openingLatestChat",
+    });
+  });
+
+  it("models the no-conversation loading path as opening the latest chat", () => {
+    mockListConversations.mockReturnValue(new Promise(() => {}));
+
+    const view = renderHook(() =>
+      useChatHistoryEntry({
+        userId: "user-1",
+        conversationId: null,
+        onOpenConversation: vi.fn(),
+      }),
+    );
+
+    expect(view.result.current.entryState).toEqual({
+      status: "openingLatestChat",
+    });
+  });
+
+  it("models no-conversation history load failures separately from ready chat content", async () => {
+    mockListConversations.mockRejectedValue(new Error("Recent chats failed"));
+
+    const view = renderHook(() =>
+      useChatHistoryEntry({
+        userId: "user-1",
+        conversationId: null,
+        onOpenConversation: vi.fn(),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(view.result.current.entryState).toEqual({
+        status: "historyLoadError",
+        message: "Recent chats failed",
+      });
+    });
+
+    view.rerender();
+
+    expect(view.result.current.entryState).toEqual({
+      status: "historyLoadError",
+      message: "Recent chats failed",
+    });
   });
 });

--- a/client/src/features/chat/hooks/use-chat-history-entry.ts
+++ b/client/src/features/chat/hooks/use-chat-history-entry.ts
@@ -18,6 +18,11 @@ type UseChatHistoryEntryOptions = {
   ) => void;
 };
 
+export type ChatHistoryEntryState =
+  | { status: "openingLatestChat" }
+  | { status: "historyLoadError"; message: string }
+  | { status: "ready" };
+
 export function useChatHistoryEntry({
   userId,
   conversationId,
@@ -117,25 +122,51 @@ export function useChatHistoryEntry({
     onOpenConversation,
   ]);
 
-  const isPreparingEntry =
-    !conversationId && (isLoading || !hasLoadedCurrentUser) && !error;
-  const isAutoOpeningRecentChat =
-    !conversationId &&
-    !isLoading &&
-    !error &&
-    hasLoadedCurrentUser &&
-    loadedCurrentUserConversations.length > 0;
+  const entryState = getChatHistoryEntryState({
+    conversationId,
+    conversations: loadedCurrentUserConversations,
+    error,
+    hasLoadedCurrentUser,
+    isLoading,
+  });
 
   return {
     conversations: loadedCurrentUserConversations,
+    entryState,
     error,
-    isAutoOpeningRecentChat,
     isCollapsed,
     isLoading,
     isMobileOpen,
-    isPreparingEntry,
     refreshConversations,
     setIsCollapsed,
     setIsMobileOpen,
   };
+}
+
+function getChatHistoryEntryState({
+  conversationId,
+  conversations,
+  error,
+  hasLoadedCurrentUser,
+  isLoading,
+}: {
+  conversationId: number | null;
+  conversations: AIChatConversationSummary[];
+  error: string | null;
+  hasLoadedCurrentUser: boolean;
+  isLoading: boolean;
+}): ChatHistoryEntryState {
+  if (conversationId !== null) {
+    return { status: "ready" };
+  }
+
+  if (error) {
+    return { status: "historyLoadError", message: error };
+  }
+
+  if (isLoading || !hasLoadedCurrentUser || conversations.length > 0) {
+    return { status: "openingLatestChat" };
+  }
+
+  return { status: "ready" };
 }

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -361,15 +361,14 @@ export function ChatPage({
           data-testid="chat-main-pane"
           className="mx-auto w-full min-w-0 max-w-3xl"
         >
-          {historyEntry.isPreparingEntry ||
-          historyEntry.isAutoOpeningRecentChat ? (
+          {historyEntry.entryState.status === "openingLatestChat" ? (
             <div className="text-sm text-muted-foreground">
               Opening latest chat...
             </div>
-          ) : historyEntry.error && !conversationId ? (
+          ) : historyEntry.entryState.status === "historyLoadError" ? (
             <div className="flex flex-col gap-4">
               <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-                {historyEntry.error}
+                {historyEntry.entryState.message}
               </div>
               {emptyState}
             </div>


### PR DESCRIPTION
## Summary
- replace loose chat history entry booleans with a single entry state union
- keep the existing latest-chat opening and history-load error UI behavior
- update focused hook tests for the explicit states

## Verification
- bun run test -- src/features/chat/hooks/use-chat-history-entry.test.tsx src/features/chat/components/chat-history-entry.test.tsx
- bun run tsc
- bun run lint
- bun run fmt:check