### PR TITLE
refactor: make error logging safe

### DIFF
--- a/server/internal/response/json.go
+++ b/server/internal/response/json.go
@@ -10,6 +10,14 @@ import (
 	"github.com/Andrewy-gh/fittrack/server/internal/request"
 )
 
+const (
+	errorCategoryNone       = "none"
+	errorCategoryDatabase   = "database"
+	errorCategoryJWT        = "jwt"
+	errorCategoryValidation = "validation"
+	errorCategoryInternal   = "internal"
+)
+
 type Error struct {
 	Message   string `json:"message"`
 	RequestID string `json:"request_id,omitempty"`
@@ -41,17 +49,17 @@ func sanitizeErrorMessage(message string, err error) string {
 	}
 
 	errMsg := err.Error()
-	
+
 	// Allow validation errors to pass through - they are safe for users
 	if isValidationError(message, errMsg) {
 		return message
 	}
-	
+
 	// Check for database error codes that should be hidden
 	if containsDatabaseError(errMsg) {
 		// For database errors, return generic messages based on context
-		if strings.Contains(strings.ToLower(message), "unauthorized") || 
-		   strings.Contains(strings.ToLower(message), "auth") {
+		if strings.Contains(strings.ToLower(message), "unauthorized") ||
+			strings.Contains(strings.ToLower(message), "auth") {
 			return "unauthorized"
 		}
 		return "internal error"
@@ -69,12 +77,12 @@ func sanitizeErrorMessage(message string, err error) string {
 // containsDatabaseError checks if an error message contains sensitive database information
 func containsDatabaseError(errMsg string) bool {
 	lowerMsg := strings.ToLower(errMsg)
-	
+
 	// Check for go-playground/validator patterns first (these are safe)
 	if strings.Contains(errMsg, "Key: '") && strings.Contains(errMsg, "Error:Field validation") {
 		return false
 	}
-	
+
 	sensitivePatterns := []string{
 		"pq:", "pgx", "SQLSTATE", "ERROR:",
 		"23505", "23503", "42501", // PostgreSQL error codes
@@ -82,11 +90,11 @@ func containsDatabaseError(errMsg string) bool {
 		"relation", "column", "table",
 		"database", "connection", "pool",
 	}
-	
+
 	for _, pattern := range sensitivePatterns {
 		if strings.Contains(lowerMsg, strings.ToLower(pattern)) {
 			return true
-			}
+		}
 	}
 	return false
 }
@@ -98,7 +106,7 @@ func containsJWTError(errMsg string) bool {
 		"failed to parse", "failed to validate",
 		"key set", "algorithm",
 	}
-	
+
 	lowerMsg := strings.ToLower(errMsg)
 	for _, pattern := range jwtPatterns {
 		if strings.Contains(lowerMsg, pattern) {
@@ -112,14 +120,14 @@ func containsJWTError(errMsg string) bool {
 func isValidationError(message, errMsg string) bool {
 	lowerMsg := strings.ToLower(message)
 	lowerErr := strings.ToLower(errMsg)
-	
+
 	// Common validation message patterns that are safe to show users
 	validationPatterns := []string{
 		"validation", "required", "invalid format", "missing", "empty",
 		"too short", "too long", "out of range", "invalid date",
 		"field", "parameter", "input", "decode",
 	}
-	
+
 	// Check if the message indicates a validation error
 	for _, pattern := range validationPatterns {
 		if strings.Contains(lowerMsg, pattern) {
@@ -129,36 +137,66 @@ func isValidationError(message, errMsg string) bool {
 			}
 		}
 	}
-	
+
 	// Check for go-playground/validator specific errors
-	if strings.Contains(lowerErr, "validation failed") || 
-	   strings.Contains(lowerErr, "field validation") ||
-	   strings.Contains(lowerErr, "key:") || strings.Contains(lowerErr, "tag:") {
+	if strings.Contains(lowerErr, "validation failed") ||
+		strings.Contains(lowerErr, "field validation") ||
+		strings.Contains(lowerErr, "key:") || strings.Contains(lowerErr, "tag:") {
 		return !containsDatabaseError(errMsg) && !containsJWTError(errMsg)
 	}
-	
+
 	return false
 }
 
-func ErrorJSON(w http.ResponseWriter, r *http.Request, logger *slog.Logger, status int, message string, err error) {
-	// Get request ID from context
-	requestID := request.GetRequestID(r.Context())
-
-	// Log the full error details at Error level for operational monitoring
-	logger.Error(message, "error", err, "path", r.URL.Path, "method", r.Method, "status", status, "request_id", requestID)
-
-	// If there's an underlying error, log the raw details at Debug level for troubleshooting
-	if err != nil {
-		logger.Debug("raw error details", "error", err.Error(), "error_type", fmt.Sprintf("%T", err), "path", r.URL.Path, "request_id", requestID)
+func safeErrorCategory(message string, err error) string {
+	if err == nil {
+		return errorCategoryNone
 	}
+
+	errMsg := err.Error()
+	switch {
+	case isValidationError(message, errMsg):
+		return errorCategoryValidation
+	case containsDatabaseError(errMsg):
+		return errorCategoryDatabase
+	case containsJWTError(errMsg):
+		return errorCategoryJWT
+	default:
+		return errorCategoryInternal
+	}
+}
+
+func ErrorJSON(w http.ResponseWriter, r *http.Request, logger *slog.Logger, status int, message string, err error) {
+	requestID := request.GetRequestID(r.Context())
+	safeMessage := sanitizeErrorMessage(message, err)
+	logAttrs := []any{
+		"path", r.URL.Path,
+		"method", r.Method,
+		"status", status,
+		"request_id", requestID,
+		"response_message", safeMessage,
+		"error_category", safeErrorCategory(message, err),
+		"error_present", err != nil,
+	}
+	if err != nil {
+		logAttrs = append(logAttrs, "error_type", fmt.Sprintf("%T", err))
+	}
+
+	logger.Error("error response", logAttrs...)
 
 	// Create a sanitized error response - never include raw error details in HTTP responses
 	resp := Error{
-		Message:   sanitizeErrorMessage(message, err),
+		Message:   safeMessage,
 		RequestID: requestID,
 	}
 
 	if jsonErr := JSON(w, status, resp); jsonErr != nil {
-		logger.Error("failed to write error response", "error", jsonErr, "path", r.URL.Path, "request_id", requestID)
+		logger.Error("failed to write error response",
+			"path", r.URL.Path,
+			"method", r.Method,
+			"status", status,
+			"request_id", requestID,
+			"error_type", fmt.Sprintf("%T", jsonErr),
+		)
 	}
 }

--- a/server/internal/response/json_test.go
+++ b/server/internal/response/json_test.go
@@ -1,6 +1,8 @@
 package response
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -9,15 +11,17 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/Andrewy-gh/fittrack/server/internal/request"
 )
 
 func TestSanitizeErrorMessage(t *testing.T) {
 	tests := []struct {
-		name          string
-		message       string
-		err           error
-		expectedMsg   string
-		description   string
+		name        string
+		message     string
+		err         error
+		expectedMsg string
+		description string
 	}{
 		{
 			name:        "PostgreSQL error code 23505",
@@ -109,7 +113,7 @@ func TestSanitizeErrorMessage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := sanitizeErrorMessage(tt.message, tt.err)
 			if result != tt.expectedMsg {
-				t.Errorf("sanitizeErrorMessage() = %v, want %v\nDescription: %s\nOriginal error: %v", 
+				t.Errorf("sanitizeErrorMessage() = %v, want %v\nDescription: %s\nOriginal error: %v",
 					result, tt.expectedMsg, tt.description, tt.err)
 			}
 		})
@@ -198,40 +202,35 @@ func TestContainsJWTError(t *testing.T) {
 }
 
 func TestErrorJSON_NoSensitiveDataInResponse(t *testing.T) {
-	// Create a test logger that writes to a buffer so we can verify debug logging
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	
+
 	tests := []struct {
-		name                   string
-		message               string
-		err                   error
-		expectedResponseMsg   string
-		shouldContainInDebug  string
-		description          string
+		name                string
+		message             string
+		err                 error
+		expectedResponseMsg string
+		description         string
 	}{
 		{
-			name:                  "PostgreSQL constraint violation",
-			message:               "failed to create user",
-			err:                   errors.New("pq: duplicate key value violates unique constraint \"users_pkey\" SQLSTATE 23505"),
-			expectedResponseMsg:   "internal error",
-			shouldContainInDebug:  "SQLSTATE 23505",
-			description:          "Database errors should be sanitized in response but logged in debug",
+			name:                "PostgreSQL constraint violation",
+			message:             "failed to create user",
+			err:                 errors.New("pq: duplicate key value violates unique constraint \"users_pkey\" SQLSTATE 23505"),
+			expectedResponseMsg: "internal error",
+			description:         "Database errors should be sanitized in response",
 		},
 		{
-			name:                  "pgx connection error",
-			message:               "database unavailable",
-			err:                   errors.New("pgx: failed to connect to database pool"),
-			expectedResponseMsg:   "internal error",
-			shouldContainInDebug:  "pgx: failed to connect",
-			description:          "pgx errors should be sanitized in response but logged in debug",
+			name:                "pgx connection error",
+			message:             "database unavailable",
+			err:                 errors.New("pgx: failed to connect to database pool"),
+			expectedResponseMsg: "internal error",
+			description:         "pgx errors should be sanitized in response",
 		},
 		{
-			name:                  "JWT token error",
-			message:               "authentication failed",
-			err:                   errors.New("failed to parse token: invalid signature algorithm RS256"),
-			expectedResponseMsg:   "unauthorized",
-			shouldContainInDebug:  "invalid signature algorithm",
-			description:          "JWT errors should be sanitized to 'unauthorized' but logged in debug",
+			name:                "JWT token error",
+			message:             "authentication failed",
+			err:                 errors.New("failed to parse token: invalid signature algorithm RS256"),
+			expectedResponseMsg: "unauthorized",
+			description:         "JWT errors should be sanitized to 'unauthorized'",
 		},
 	}
 
@@ -247,7 +246,7 @@ func TestErrorJSON_NoSensitiveDataInResponse(t *testing.T) {
 			// Check that the HTTP response contains the sanitized message
 			responseBody := w.Body.String()
 			if !strings.Contains(responseBody, fmt.Sprintf(`"message":"%s"`, tt.expectedResponseMsg)) {
-				t.Errorf("Response body should contain sanitized message '%s', got: %s", 
+				t.Errorf("Response body should contain sanitized message '%s', got: %s",
 					tt.expectedResponseMsg, responseBody)
 			}
 
@@ -255,7 +254,7 @@ func TestErrorJSON_NoSensitiveDataInResponse(t *testing.T) {
 			if tt.err != nil {
 				sensitiveContent := tt.err.Error()
 				if strings.Contains(responseBody, sensitiveContent) {
-					t.Errorf("Response body should NOT contain sensitive error details: %s\nResponse: %s", 
+					t.Errorf("Response body should NOT contain sensitive error details: %s\nResponse: %s",
 						sensitiveContent, responseBody)
 				}
 			}
@@ -265,6 +264,55 @@ func TestErrorJSON_NoSensitiveDataInResponse(t *testing.T) {
 				t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, w.Code)
 			}
 		})
+	}
+}
+
+func TestErrorJSON_LogsSafeErrorSummary(t *testing.T) {
+	var output bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&output, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	req := httptest.NewRequest(http.MethodPost, "/api/users", nil)
+	req = req.WithContext(request.WithRequestID(req.Context(), "req-safe-logs"))
+	w := httptest.NewRecorder()
+	sensitiveErr := errors.New("pq: duplicate key value violates unique constraint \"users_email_key\" DETAIL: Key (email)=(andy@example.com) already exists. SQLSTATE 23505")
+
+	ErrorJSON(w, req, logger, http.StatusInternalServerError, "failed to create user", sensitiveErr)
+
+	logOutput := output.String()
+	for _, forbidden := range []string{
+		"pq:",
+		"SQLSTATE",
+		"23505",
+		"users_email_key",
+		"andy@example.com",
+		"duplicate key",
+	} {
+		if strings.Contains(logOutput, forbidden) {
+			t.Fatalf("error log contains sensitive raw error detail %q: %s", forbidden, logOutput)
+		}
+	}
+
+	var logEntry map[string]any
+	if err := json.Unmarshal(output.Bytes(), &logEntry); err != nil {
+		t.Fatalf("failed to decode error log output: %v", err)
+	}
+
+	if got := logEntry["msg"]; got != "error response" {
+		t.Fatalf("expected safe log message, got %v", got)
+	}
+	if got := logEntry["status"]; got != float64(http.StatusInternalServerError) {
+		t.Fatalf("expected status field, got %v", got)
+	}
+	if got := logEntry["request_id"]; got != "req-safe-logs" {
+		t.Fatalf("expected request_id field, got %v", got)
+	}
+	if got := logEntry["response_message"]; got != "internal error" {
+		t.Fatalf("expected sanitized response_message field, got %v", got)
+	}
+	if got := logEntry["error_category"]; got != errorCategoryDatabase {
+		t.Fatalf("expected database error_category field, got %v", got)
+	}
+	if got := logEntry["error_type"]; got != "*errors.errorString" {
+		t.Fatalf("expected stable error_type field, got %v", got)
 	}
 }
 
@@ -297,7 +345,7 @@ func TestNoPostgreSQLErrorCodesInResponse(t *testing.T) {
 		t.Run(fmt.Sprintf("ErrorCode_%s", errorCode), func(t *testing.T) {
 			// Create an error that contains the sensitive code/message
 			testErr := errors.New(fmt.Sprintf("Database error with code: %s and additional context", errorCode))
-			
+
 			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
 			w := httptest.NewRecorder()
 
@@ -305,10 +353,10 @@ func TestNoPostgreSQLErrorCodesInResponse(t *testing.T) {
 			ErrorJSON(w, req, logger, http.StatusInternalServerError, "operation failed", testErr)
 
 			responseBody := w.Body.String()
-			
+
 			// Assert that the sensitive error code/message does NOT appear in the HTTP response
 			if strings.Contains(responseBody, errorCode) {
-				t.Errorf("HTTP response contains sensitive database error code '%s'.\nResponse body: %s", 
+				t.Errorf("HTTP response contains sensitive database error code '%s'.\nResponse body: %s",
 					errorCode, responseBody)
 			}
 


### PR DESCRIPTION
## Summary
- Replace raw `ErrorJSON` error logging with safe structured summaries.
- Keep HTTP error response JSON shape unchanged while logging sanitized response messages, status, request id, error category, and error type.
- Add regression coverage proving sensitive database details are absent from `ErrorJSON` logs.

## Verification
- `go test -short ./internal/response`
- `go vet ./...`
- `$pkgs = go list ./... | Where-Object { $_ -notmatch '/internal/database$' }; go test -short $pkgs`
- `go build ./cmd/api`
- `git diff --check`
- pre-push hook: `make test-short`