### PR TITLE
refactor: parse browser storage data

### DIFF
--- a/client/src/features/exercises/utils/exercise-goals.test.ts
+++ b/client/src/features/exercises/utils/exercise-goals.test.ts
@@ -47,6 +47,38 @@ describe("exercise-goals", () => {
     expect(getExerciseGoal({ exerciseId: 8 })).toBeNull();
   });
 
+  it("reads valid persisted goals from browser storage", () => {
+    localStorage.setItem(
+      "fittrack-exercise-goals-v1",
+      JSON.stringify({
+        "id:12": {
+          targetWeight: 225,
+          targetReps: 5,
+          frequencyPerWeek: 2,
+        },
+      }),
+    );
+
+    expect(getExerciseGoal({ exerciseId: 12 })).toEqual({
+      targetWeight: 225,
+      targetReps: 5,
+      frequencyPerWeek: 2,
+    });
+  });
+
+  it("discards structurally invalid persisted goals", () => {
+    localStorage.setItem(
+      "fittrack-exercise-goals-v1",
+      JSON.stringify({
+        "id:12": {
+          targetWeight: "225",
+        },
+      }),
+    );
+
+    expect(getExerciseGoal({ exerciseId: 12 })).toBeNull();
+  });
+
   it("formats a readable goal summary", () => {
     expect(
       formatExerciseGoalSummary({

--- a/client/src/features/exercises/utils/exercise-goals.ts
+++ b/client/src/features/exercises/utils/exercise-goals.ts
@@ -1,3 +1,5 @@
+import * as v from "valibot";
+
 export type ExerciseGoal = {
   targetWeight?: number;
   targetReps?: number;
@@ -14,6 +16,14 @@ type ExerciseGoalLookup = {
 };
 
 const STORAGE_KEY = "fittrack-exercise-goals-v1";
+
+const ExerciseGoalSchema = v.object({
+  targetWeight: v.optional(v.number()),
+  targetReps: v.optional(v.number()),
+  frequencyPerWeek: v.optional(v.number()),
+});
+
+const ExerciseGoalRecordSchema = v.record(v.string(), ExerciseGoalSchema);
 
 function normalizeExerciseName(exerciseName: string): string {
   return exerciseName.trim().toLowerCase();
@@ -34,6 +44,13 @@ function getExerciseGoalKey({
   return null;
 }
 
+function parseExerciseGoalRecord(
+  input: unknown,
+): Record<string, ExerciseGoal> | null {
+  const result = v.safeParse(ExerciseGoalRecordSchema, input);
+  return result.success ? result.output : null;
+}
+
 function readExerciseGoals(): Record<string, ExerciseGoal> {
   if (typeof window === "undefined") {
     return {};
@@ -45,7 +62,8 @@ function readExerciseGoals(): Record<string, ExerciseGoal> {
   }
 
   try {
-    return JSON.parse(storedValue) as Record<string, ExerciseGoal>;
+    const parsed: unknown = JSON.parse(storedValue);
+    return parseExerciseGoalRecord(parsed) ?? {};
   } catch {
     return {};
   }

--- a/client/src/lib/demo-data/historical-1rm.ts
+++ b/client/src/lib/demo-data/historical-1rm.ts
@@ -1,5 +1,6 @@
 import type { StoredSet } from "./types";
 import { STORAGE_KEYS } from "./types";
+import * as v from "valibot";
 
 type Historical1RmEntry = {
   historical_1rm: number;
@@ -9,12 +10,56 @@ type Historical1RmEntry = {
 
 type Historical1RmMap = Record<string, Historical1RmEntry>;
 
-function getFromStorage<T>(key: string, defaultValue: T): T {
+type StorageParser<T> = (input: unknown) => T | null;
+
+const StoredSetSchema = v.object({
+  id: v.number(),
+  exercise_id: v.number(),
+  workout_id: v.number(),
+  weight: v.optional(v.number()),
+  reps: v.number(),
+  set_type: v.picklist(["warmup", "working"]),
+  exercise_order: v.number(),
+  set_order: v.number(),
+  user_id: v.string(),
+  created_at: v.string(),
+});
+
+const Historical1RmEntrySchema = v.object({
+  historical_1rm: v.number(),
+  updated_at: v.string(),
+  source_workout_id: v.nullable(v.number()),
+});
+
+const StoredSetsSchema = v.array(StoredSetSchema);
+const Historical1RmMapSchema = v.record(v.string(), Historical1RmEntrySchema);
+
+function parseWithSchema<
+  TSchema extends v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+>(schema: TSchema, input: unknown): v.InferOutput<TSchema> | null {
+  const result = v.safeParse(schema, input);
+  return result.success ? result.output : null;
+}
+
+function parseStoredSets(input: unknown): StoredSet[] | null {
+  return parseWithSchema(StoredSetsSchema, input);
+}
+
+function parseHistorical1RmMap(input: unknown): Historical1RmMap | null {
+  return parseWithSchema(Historical1RmMapSchema, input);
+}
+
+function getFromStorage<T>(
+  key: string,
+  defaultValue: T,
+  parseStoredValue: StorageParser<T>,
+): T {
   if (typeof window === "undefined") return defaultValue;
   const stored = localStorage.getItem(key);
   if (!stored) return defaultValue;
   try {
-    return JSON.parse(stored) as T;
+    const parsed: unknown = JSON.parse(stored);
+    return parseStoredValue(parsed) ?? defaultValue;
   } catch {
     return defaultValue;
   }
@@ -31,11 +76,11 @@ function removeFromStorage(key: string): void {
 }
 
 function getAllSets(): StoredSet[] {
-  return getFromStorage<StoredSet[]>(STORAGE_KEYS.SETS, []);
+  return getFromStorage(STORAGE_KEYS.SETS, [], parseStoredSets);
 }
 
 function getMap(): Historical1RmMap {
-  return getFromStorage<Historical1RmMap>(STORAGE_KEYS.HISTORICAL_1RM, {});
+  return getFromStorage(STORAGE_KEYS.HISTORICAL_1RM, {}, parseHistorical1RmMap);
 }
 
 function setMap(map: Historical1RmMap): void {

--- a/client/src/lib/demo-data/storage.test.ts
+++ b/client/src/lib/demo-data/storage.test.ts
@@ -1,8 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { updateExercise, createExercise, getAllExercises } from "./storage";
+import {
+  updateExercise,
+  createExercise,
+  getExerciseById,
+  getExerciseDetail,
+  getAllExercises,
+  getAllWorkouts,
+  getWorkoutById,
+} from "./storage";
+import { recomputeDemoExerciseHistorical1Rm } from "./historical-1rm";
+import { STORAGE_KEYS } from "./types";
 
 afterEach(() => {
   vi.useRealTimers();
+  localStorage.clear();
 });
 
 describe("updateExercise", () => {
@@ -69,5 +80,143 @@ describe("updateExercise", () => {
     const updated = exercises.find((ex) => ex.id === exercise.id);
 
     expect(updated?.updated_at).not.toBe(oldUpdatedAt);
+  });
+
+  it("reads valid persisted demo collections through storage APIs", () => {
+    localStorage.setItem(
+      STORAGE_KEYS.EXERCISES,
+      JSON.stringify([
+        {
+          id: 1,
+          name: "Bench Press",
+          user_id: "demo-user",
+          created_at: "2026-03-15T10:00:00.000Z",
+          updated_at: "2026-03-15T10:00:00.000Z",
+        },
+      ]),
+    );
+    localStorage.setItem(
+      STORAGE_KEYS.WORKOUTS,
+      JSON.stringify([
+        {
+          id: 2,
+          date: "2026-03-16",
+          notes: "Heavy triples",
+          workout_focus: "Upper",
+          user_id: "demo-user",
+          created_at: "2026-03-16T10:00:00.000Z",
+          updated_at: "2026-03-16T10:00:00.000Z",
+        },
+      ]),
+    );
+    localStorage.setItem(
+      STORAGE_KEYS.SETS,
+      JSON.stringify([
+        {
+          id: 3,
+          exercise_id: 1,
+          workout_id: 2,
+          weight: 185,
+          reps: 3,
+          set_type: "working",
+          exercise_order: 0,
+          set_order: 0,
+          user_id: "demo-user",
+          created_at: "2026-03-16T10:00:00.000Z",
+        },
+      ]),
+    );
+
+    expect(getAllExercises()).toEqual([
+      {
+        id: 1,
+        name: "Bench Press",
+        user_id: "demo-user",
+        created_at: "2026-03-15T10:00:00.000Z",
+        updated_at: "2026-03-15T10:00:00.000Z",
+      },
+    ]);
+    expect(getAllWorkouts()).toEqual([
+      {
+        id: 2,
+        date: "2026-03-16",
+        notes: "Heavy triples",
+        workout_focus: "Upper",
+        user_id: "demo-user",
+        created_at: "2026-03-16T10:00:00.000Z",
+        updated_at: "2026-03-16T10:00:00.000Z",
+      },
+    ]);
+    expect(getWorkoutById(2)).toEqual([
+      {
+        workout_id: 2,
+        workout_date: "2026-03-16",
+        workout_notes: "Heavy triples",
+        workout_focus: "Upper",
+        set_id: 3,
+        exercise_id: 1,
+        exercise_name: "Bench Press",
+        exercise_order: 0,
+        set_order: 0,
+        reps: 3,
+        weight: 185,
+        set_type: "working",
+        volume: 555,
+      },
+    ]);
+  });
+
+  it("defaults corrupt demo storage collections", () => {
+    localStorage.setItem(
+      STORAGE_KEYS.EXERCISES,
+      JSON.stringify([{ id: 1, name: 123 }]),
+    );
+    localStorage.setItem(
+      STORAGE_KEYS.WORKOUTS,
+      JSON.stringify([{ id: "2", date: "2026-03-16" }]),
+    );
+    localStorage.setItem(
+      STORAGE_KEYS.SETS,
+      JSON.stringify([{ id: 3, set_type: "drop" }]),
+    );
+
+    expect(getAllExercises()).toEqual([]);
+    expect(getAllWorkouts()).toEqual([]);
+    expect(getWorkoutById(2)).toEqual([]);
+  });
+
+  it("defaults malformed historical 1rm map storage when reading exercise detail", () => {
+    localStorage.setItem(
+      STORAGE_KEYS.EXERCISES,
+      JSON.stringify([
+        {
+          id: 1,
+          name: "Bench Press",
+          user_id: "demo-user",
+          created_at: "2026-03-15T10:00:00.000Z",
+          updated_at: "2026-03-15T10:00:00.000Z",
+        },
+      ]),
+    );
+    localStorage.setItem(STORAGE_KEYS.HISTORICAL_1RM, JSON.stringify(null));
+
+    expect(getExerciseById(1)?.name).toBe("Bench Press");
+    expect(getExerciseDetail(1).exercise.historical_1rm).toBeUndefined();
+  });
+
+  it("defaults malformed demo set storage when recomputing historical 1rm", () => {
+    localStorage.setItem(
+      STORAGE_KEYS.SETS,
+      JSON.stringify({
+        id: 3,
+        exercise_id: 1,
+        workout_id: 2,
+        weight: 185,
+        reps: 3,
+        set_type: "working",
+      }),
+    );
+
+    expect(recomputeDemoExerciseHistorical1Rm(1)).toBeNull();
   });
 });

--- a/client/src/lib/demo-data/storage.ts
+++ b/client/src/lib/demo-data/storage.ts
@@ -11,6 +11,7 @@ import type {
   ExerciseRecentSetsResponse,
 } from "./types";
 import { STORAGE_KEYS, DEMO_USER_ID } from "./types";
+import * as v from "valibot";
 import {
   INITIAL_EXERCISES,
   INITIAL_SETS,
@@ -33,17 +34,118 @@ import type { DemoContributionWorkout } from "@/lib/demo-data/contribution-data"
 // localStorage Utilities
 // ===========================
 
-function getFromStorage<T>(key: string, defaultValue: T): T {
+type StorageParser<T> = (input: unknown) => T | null;
+
+const StoredExerciseSchema = v.object({
+  id: v.number(),
+  name: v.string(),
+  user_id: v.string(),
+  created_at: v.string(),
+  updated_at: v.string(),
+});
+
+const StoredWorkoutSchema = v.object({
+  id: v.number(),
+  date: v.string(),
+  notes: v.optional(v.string()),
+  workout_focus: v.optional(v.string()),
+  user_id: v.string(),
+  created_at: v.string(),
+  updated_at: v.string(),
+});
+
+const StoredSetSchema = v.object({
+  id: v.number(),
+  exercise_id: v.number(),
+  workout_id: v.number(),
+  weight: v.optional(v.number()),
+  reps: v.number(),
+  set_type: v.picklist(["warmup", "working"]),
+  exercise_order: v.number(),
+  set_order: v.number(),
+  user_id: v.string(),
+  created_at: v.string(),
+});
+
+function parseWithSchema<
+  TSchema extends v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+>(schema: TSchema, input: unknown): v.InferOutput<TSchema> | null {
+  const result = v.safeParse(schema, input);
+  return result.success ? result.output : null;
+}
+
+function parseStoredExercise(input: unknown): StoredExercise | null {
+  return parseWithSchema(StoredExerciseSchema, input);
+}
+
+function parseStoredWorkout(input: unknown): StoredWorkout | null {
+  return parseWithSchema(StoredWorkoutSchema, input);
+}
+
+function parseStoredSet(input: unknown): StoredSet | null {
+  return parseWithSchema(StoredSetSchema, input);
+}
+
+function parseArray<T>(
+  input: unknown,
+  parseItem: StorageParser<T>,
+): T[] | null {
+  if (!Array.isArray(input)) {
+    return null;
+  }
+
+  const items: T[] = [];
+  for (const itemInput of input) {
+    const item = parseItem(itemInput);
+    if (item === null) {
+      return null;
+    }
+    items.push(item);
+  }
+
+  return items;
+}
+
+function parseStoredExercises(input: unknown): StoredExercise[] | null {
+  return parseArray(input, parseStoredExercise);
+}
+
+function parseStoredWorkouts(input: unknown): StoredWorkout[] | null {
+  return parseArray(input, parseStoredWorkout);
+}
+
+function parseStoredSets(input: unknown): StoredSet[] | null {
+  return parseArray(input, parseStoredSet);
+}
+
+function getFromStorage<T>(
+  key: string,
+  defaultValue: T,
+  parseStoredValue: StorageParser<T>,
+): T {
   if (typeof window === "undefined") return defaultValue;
 
   const stored = localStorage.getItem(key);
   if (!stored) return defaultValue;
 
   try {
-    return JSON.parse(stored) as T;
+    const parsed: unknown = JSON.parse(stored);
+    return parseStoredValue(parsed) ?? defaultValue;
   } catch {
     return defaultValue;
   }
+}
+
+function getStoredExercises(): StoredExercise[] {
+  return getFromStorage(STORAGE_KEYS.EXERCISES, [], parseStoredExercises);
+}
+
+function getStoredWorkouts(): StoredWorkout[] {
+  return getFromStorage(STORAGE_KEYS.WORKOUTS, [], parseStoredWorkouts);
+}
+
+function getStoredSets(): StoredSet[] {
+  return getFromStorage(STORAGE_KEYS.SETS, [], parseStoredSets);
 }
 
 function setInStorage<T>(key: string, value: T): void {
@@ -88,10 +190,7 @@ export function clearDemoData(): void {
 // ===========================
 
 export function getAllExercises(): ExerciseExerciseResponse[] {
-  const exercises = getFromStorage<StoredExercise[]>(
-    STORAGE_KEYS.EXERCISES,
-    [],
-  );
+  const exercises = getStoredExercises();
   return exercises.map((ex) => ({
     id: ex.id,
     name: ex.name,
@@ -102,10 +201,7 @@ export function getAllExercises(): ExerciseExerciseResponse[] {
 }
 
 export function getExerciseById(id: number): ExerciseExerciseResponse | null {
-  const exercises = getFromStorage<StoredExercise[]>(
-    STORAGE_KEYS.EXERCISES,
-    [],
-  );
+  const exercises = getStoredExercises();
   const exercise = exercises.find((ex) => ex.id === id);
 
   if (!exercise) return null;
@@ -120,10 +216,7 @@ export function getExerciseById(id: number): ExerciseExerciseResponse | null {
 }
 
 export function createExercise(name: string): ExerciseExerciseResponse {
-  const exercises = getFromStorage<StoredExercise[]>(
-    STORAGE_KEYS.EXERCISES,
-    [],
-  );
+  const exercises = getStoredExercises();
 
   const newExercise: StoredExercise = {
     id: getNextId(exercises),
@@ -146,10 +239,7 @@ export function createExercise(name: string): ExerciseExerciseResponse {
 }
 
 export function updateExercise(id: number, name: string): boolean {
-  const exercises = getFromStorage<StoredExercise[]>(
-    STORAGE_KEYS.EXERCISES,
-    [],
-  );
+  const exercises = getStoredExercises();
   const exerciseIndex = exercises.findIndex((ex) => ex.id === id);
 
   if (exerciseIndex === -1) return false;
@@ -171,16 +261,13 @@ export function updateExercise(id: number, name: string): boolean {
 }
 
 export function deleteExercise(id: number): boolean {
-  const exercises = getFromStorage<StoredExercise[]>(
-    STORAGE_KEYS.EXERCISES,
-    [],
-  );
+  const exercises = getStoredExercises();
   const filtered = exercises.filter((ex) => ex.id !== id);
 
   if (filtered.length === exercises.length) return false;
 
   // Also delete all sets referencing this exercise
-  const sets = getFromStorage<StoredSet[]>(STORAGE_KEYS.SETS, []);
+  const sets = getStoredSets();
   const filteredSets = sets.filter((set) => set.exercise_id !== id);
   setInStorage(STORAGE_KEYS.SETS, filteredSets);
   handleDemoExerciseDeleted(id);
@@ -193,12 +280,9 @@ export function deleteExercise(id: number): boolean {
 export function getExerciseWithSets(
   exerciseId: number,
 ): ExerciseExerciseWithSetsResponse[] {
-  const sets = getFromStorage<StoredSet[]>(STORAGE_KEYS.SETS, []);
-  const workouts = getFromStorage<StoredWorkout[]>(STORAGE_KEYS.WORKOUTS, []);
-  const exercises = getFromStorage<StoredExercise[]>(
-    STORAGE_KEYS.EXERCISES,
-    [],
-  );
+  const sets = getStoredSets();
+  const workouts = getStoredWorkouts();
+  const exercises = getStoredExercises();
 
   const exerciseSets = sets.filter((set) => set.exercise_id === exerciseId);
 
@@ -242,10 +326,7 @@ function computeBestE1rmFromWorkingSets(
 export function getExerciseDetail(
   exerciseId: number,
 ): ExerciseExerciseDetailResponse {
-  const exercises = getFromStorage<StoredExercise[]>(
-    STORAGE_KEYS.EXERCISES,
-    [],
-  );
+  const exercises = getStoredExercises();
   const exercise = exercises.find((e) => e.id === exerciseId);
   if (!exercise) throw new Error("Exercise not found");
 
@@ -276,8 +357,8 @@ export function getExerciseRecentSets(
   exerciseId: number,
   limit = 10,
 ): ExerciseRecentSetsResponse[] {
-  const sets = getFromStorage<StoredSet[]>(STORAGE_KEYS.SETS, []);
-  const workouts = getFromStorage<StoredWorkout[]>(STORAGE_KEYS.WORKOUTS, []);
+  const sets = getStoredSets();
+  const workouts = getStoredWorkouts();
 
   const exerciseSets = sets
     .filter((set) => set.exercise_id === exerciseId)
@@ -308,7 +389,7 @@ export function getExerciseRecentSets(
 // ===========================
 
 export function getAllWorkouts(): WorkoutWorkoutResponse[] {
-  const workouts = getFromStorage<StoredWorkout[]>(STORAGE_KEYS.WORKOUTS, []);
+  const workouts = getStoredWorkouts();
 
   return workouts
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
@@ -324,8 +405,8 @@ export function getAllWorkouts(): WorkoutWorkoutResponse[] {
 }
 
 export function getAllWorkoutsForContribution(): DemoContributionWorkout[] {
-  const workouts = getFromStorage<StoredWorkout[]>(STORAGE_KEYS.WORKOUTS, []);
-  const sets = getFromStorage<StoredSet[]>(STORAGE_KEYS.SETS, []);
+  const workouts = getStoredWorkouts();
+  const sets = getStoredSets();
 
   return workouts.map((workout) => {
     const workingSets = sets.filter(
@@ -346,12 +427,9 @@ export function getAllWorkoutsForContribution(): DemoContributionWorkout[] {
 }
 
 export function getWorkoutById(id: number): WorkoutWorkoutWithSetsResponse[] {
-  const sets = getFromStorage<StoredSet[]>(STORAGE_KEYS.SETS, []);
-  const workouts = getFromStorage<StoredWorkout[]>(STORAGE_KEYS.WORKOUTS, []);
-  const exercises = getFromStorage<StoredExercise[]>(
-    STORAGE_KEYS.EXERCISES,
-    [],
-  );
+  const sets = getStoredSets();
+  const workouts = getStoredWorkouts();
+  const exercises = getStoredExercises();
 
   const workout = workouts.find((w) => w.id === id);
   if (!workout) return [];
@@ -401,12 +479,9 @@ interface CreateWorkoutInput {
 }
 
 export function createWorkout(input: CreateWorkoutInput): { success: boolean } {
-  const workouts = getFromStorage<StoredWorkout[]>(STORAGE_KEYS.WORKOUTS, []);
-  const sets = getFromStorage<StoredSet[]>(STORAGE_KEYS.SETS, []);
-  const exercises = getFromStorage<StoredExercise[]>(
-    STORAGE_KEYS.EXERCISES,
-    [],
-  );
+  const workouts = getStoredWorkouts();
+  const sets = getStoredSets();
+  const exercises = getStoredExercises();
 
   // Create new workout
   const newWorkout: StoredWorkout = {
@@ -467,12 +542,9 @@ export function updateWorkout(
   id: number,
   input: CreateWorkoutInput,
 ): { success: boolean } {
-  const workouts = getFromStorage<StoredWorkout[]>(STORAGE_KEYS.WORKOUTS, []);
-  const sets = getFromStorage<StoredSet[]>(STORAGE_KEYS.SETS, []);
-  const exercises = getFromStorage<StoredExercise[]>(
-    STORAGE_KEYS.EXERCISES,
-    [],
-  );
+  const workouts = getStoredWorkouts();
+  const sets = getStoredSets();
+  const exercises = getStoredExercises();
 
   const workoutIndex = workouts.findIndex((w) => w.id === id);
   if (workoutIndex === -1) return { success: false };
@@ -534,8 +606,8 @@ export function updateWorkout(
 }
 
 export function deleteWorkout(id: number): boolean {
-  const workouts = getFromStorage<StoredWorkout[]>(STORAGE_KEYS.WORKOUTS, []);
-  const sets = getFromStorage<StoredSet[]>(STORAGE_KEYS.SETS, []);
+  const workouts = getStoredWorkouts();
+  const sets = getStoredSets();
 
   const filtered = workouts.filter((w) => w.id !== id);
   if (filtered.length === workouts.length) return false;
@@ -555,7 +627,7 @@ export function deleteWorkout(id: number): boolean {
 // ===========================
 
 export function getWorkoutFocusValues(): string[] {
-  const workouts = getFromStorage<StoredWorkout[]>(STORAGE_KEYS.WORKOUTS, []);
+  const workouts = getStoredWorkouts();
   const focusValues = workouts
     .map((w) => w.workout_focus)
     .filter((focus): focus is string => !!focus);

--- a/client/src/lib/local-storage.test.ts
+++ b/client/src/lib/local-storage.test.ts
@@ -98,4 +98,52 @@ describe("workoutDraftStorage", () => {
 
     expect(draftStorage.load("user-123")).toBeNull();
   });
+
+  it("returns saved draft data from valid stored JSON", () => {
+    const storage = createMemoryStorage({
+      "workout-entry-form-data-user-123": JSON.stringify({
+        date: "2026-03-24T10:30:00.000Z",
+        notes: "Saved draft",
+        workoutFocus: "Upper",
+        exercises: [
+          {
+            name: "Bench Press",
+            sets: [{ reps: 5, setType: "working", weight: 185 }],
+          },
+        ],
+      }),
+    });
+    const draftStorage = createWorkoutDraftStorage(storage);
+
+    expect(draftStorage.load("user-123")).toEqual({
+      date: new Date("2026-03-24T10:30:00.000Z"),
+      notes: "Saved draft",
+      workoutFocus: "Upper",
+      exercises: [
+        {
+          name: "Bench Press",
+          sets: [{ reps: 5, setType: "working", weight: 185 }],
+        },
+      ],
+    });
+  });
+
+  it("returns null for structurally invalid stored drafts", () => {
+    const storage = createMemoryStorage({
+      "workout-entry-form-data-user-123": JSON.stringify({
+        date: "2026-03-24T10:30:00.000Z",
+        notes: "Bad draft",
+        workoutFocus: "Upper",
+        exercises: [
+          {
+            name: "Bench Press",
+            sets: [{ reps: "5", setType: "working", weight: 185 }],
+          },
+        ],
+      }),
+    });
+    const draftStorage = createWorkoutDraftStorage(storage);
+
+    expect(draftStorage.load("user-123")).toBeNull();
+  });
 });

--- a/client/src/lib/local-storage.ts
+++ b/client/src/lib/local-storage.ts
@@ -1,4 +1,5 @@
 import type { WorkoutCreateWorkoutRequest } from "../client/types.gen";
+import * as v from "valibot";
 
 const STORAGE_KEY = "workout-entry-form-data";
 
@@ -19,6 +20,24 @@ export type WorkoutDraftStorage = {
   clear: (userId?: string) => void;
 };
 
+const WorkoutSetSchema = v.object({
+  reps: v.number(),
+  weight: v.optional(v.number()),
+  setType: v.picklist(["warmup", "working"]),
+});
+
+const WorkoutExerciseSchema = v.object({
+  name: v.string(),
+  sets: v.array(WorkoutSetSchema),
+});
+
+const WorkoutDraftSchema = v.object({
+  date: v.string(),
+  notes: v.optional(v.string()),
+  workoutFocus: v.optional(v.string()),
+  exercises: v.array(WorkoutExerciseSchema),
+});
+
 function serializeDraft(data: FormDataType): WorkoutCreateWorkoutRequest {
   return {
     ...data,
@@ -26,15 +45,35 @@ function serializeDraft(data: FormDataType): WorkoutCreateWorkoutRequest {
   };
 }
 
+function parseWorkoutDraft(input: unknown): WorkoutCreateWorkoutRequest | null {
+  const result = v.safeParse(WorkoutDraftSchema, input);
+
+  if (!result.success) {
+    return null;
+  }
+
+  const date = new Date(result.output.date);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return {
+    // SAFETY: Existing draft consumers expect storage to rehydrate the saved
+    // ISO string into a Date for the date picker, while the generated request
+    // type still represents the submitted JSON payload.
+    date: date as unknown as string,
+    notes: result.output.notes,
+    workoutFocus: result.output.workoutFocus,
+    exercises: result.output.exercises,
+  };
+}
+
 function deserializeDraft(
   rawValue: string,
 ): WorkoutCreateWorkoutRequest | null {
   try {
-    const parsed = JSON.parse(rawValue);
-    if (parsed.date && typeof parsed.date === "string") {
-      parsed.date = new Date(parsed.date);
-    }
-    return parsed as WorkoutCreateWorkoutRequest;
+    const parsed: unknown = JSON.parse(rawValue);
+    return parseWorkoutDraft(parsed);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- add concrete parsers for workout draft, demo data, and exercise-goal localStorage reads
- default/discard malformed persisted browser storage while preserving valid stored data behavior
- add focused storage-boundary tests for valid and corrupt persisted data

## Verification
- bun run test src/lib/local-storage.test.ts src/lib/demo-data/storage.test.ts src/features/exercises/utils/exercise-goals.test.ts src/features/chat/utils/ai-workout-draft.test.ts
- bun run tsc
- bun run lint
- bun run fmt:check
- git diff --check