### PR TITLE
fix: sanitize backend error logs

### DIFF
--- a/server/cmd/api/routes.go
+++ b/server/cmd/api/routes.go
@@ -94,8 +94,9 @@ func (api *api) handleStaticFiles() http.HandlerFunc {
 	fs := http.FileServer(http.Dir("./dist"))
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		_, err := http.Dir("./dist").Open(r.URL.Path)
+		file, err := http.Dir("./dist").Open(r.URL.Path)
 		if err == nil {
+			_ = file.Close()
 			setStaticCacheHeader(w, r.URL.Path)
 			fs.ServeHTTP(w, r)
 			return

--- a/server/cmd/api/routes_test.go
+++ b/server/cmd/api/routes_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Andrewy-gh/fittrack/server/internal/account"
 	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
@@ -252,6 +251,19 @@ func TestRoutes_RegistersAccountDeletion(t *testing.T) {
 }
 
 func TestStaticFiles_SetCacheHeadersForPWAUpdates(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatalf("switch to temporary static file directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("restore working directory: %v", err)
+		}
+	})
+
 	writeStaticTestFile(t, "index.html", "<!doctype html>")
 	writeStaticTestFile(t, "sw.js", "self.skipWaiting()")
 	writeStaticTestFile(t, "manifest.webmanifest", "{}")
@@ -330,12 +342,4 @@ func writeStaticTestFile(t *testing.T, relativePath string, contents string) {
 	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 		t.Fatalf("write static test file: %v", err)
 	}
-	t.Cleanup(func() {
-		for range 10 {
-			if err := os.RemoveAll("dist"); err == nil || os.IsNotExist(err) {
-				return
-			}
-			time.Sleep(50 * time.Millisecond)
-		}
-	})
 }

--- a/server/internal/aichat/handler.go
+++ b/server/internal/aichat/handler.go
@@ -121,7 +121,7 @@ func (h *Handler) StreamValidate(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		if !h.writeStreamError(sse, r, 0, 0, 0, "failed to generate ai chat validation", err) {
-			h.logger.Error("failed to stream ai chat validation response", "error", err, "path", r.URL.Path, "request_id", request.GetRequestID(r.Context()))
+			h.logServiceFailure("failed to stream ai chat validation response", r, err)
 		}
 		return
 	}
@@ -354,7 +354,7 @@ func (h *Handler) StreamMessage(w http.ResponseWriter, r *http.Request) {
 	sse, err := h.startSSE(w)
 	if err != nil {
 		if abortErr := h.service.AbortPreparedMessageStream(r.Context(), prepared, ErrStreamNotStarted); abortErr != nil {
-			h.logger.Error("failed to abort ai chat run after stream preflight error", "error", abortErr, "conversation_id", prepared.Conversation.ID, "run_id", prepared.Run.ID)
+			h.logServiceFailure("failed to abort ai chat run after stream preflight error", r, abortErr, "conversation_id", prepared.Conversation.ID, "run_id", prepared.Run.ID)
 		}
 		response.ErrorJSON(w, r, h.logger, http.StatusInternalServerError, "failed to start ai chat stream", err)
 		return
@@ -371,7 +371,7 @@ func (h *Handler) StreamMessage(w http.ResponseWriter, r *http.Request) {
 		// If the initial SSE start event never reaches the client, treat the run
 		// as never started. Recovery only applies after streaming has begun.
 		if abortErr := h.service.AbortPreparedMessageStream(r.Context(), prepared, ErrStreamNotStarted); abortErr != nil {
-			h.logger.Error("failed to abort ai chat run after start event write failure", "error", abortErr, "conversation_id", prepared.Conversation.ID, "run_id", prepared.Run.ID)
+			h.logServiceFailure("failed to abort ai chat run after start event write failure", r, abortErr, "conversation_id", prepared.Conversation.ID, "run_id", prepared.Run.ID)
 		}
 		h.logStreamWriteFailure("failed to start ai chat stream", r, err)
 		return
@@ -387,7 +387,7 @@ func (h *Handler) StreamMessage(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.service.StartMessageGeneration(r.Context(), prepared); err != nil {
 		if !h.writeStreamError(sse, r, prepared.Conversation.ID, prepared.Run.ID, prepared.AssistantMessage.ID, "failed to start ai chat generation", err) {
-			h.logger.Error("failed to start ai chat generation", "error", err, "path", r.URL.Path, "request_id", request.GetRequestID(r.Context()))
+			h.logServiceFailure("failed to start ai chat generation", r, err)
 		}
 		return
 	}
@@ -426,7 +426,7 @@ func (h *Handler) StreamMessage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !h.writeStreamError(sse, r, prepared.Conversation.ID, prepared.Run.ID, prepared.AssistantMessage.ID, "failed to generate ai chat response", err) {
-			h.logger.Error("failed to stream ai chat response", "error", err, "path", r.URL.Path, "request_id", request.GetRequestID(r.Context()))
+			h.logServiceFailure("failed to stream ai chat response", r, err)
 		}
 		return
 	}
@@ -520,7 +520,7 @@ func (h *Handler) ResumeMessageStream(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !h.writeStreamError(sse, r, prepared.Conversation.ID, prepared.Run.ID, prepared.AssistantMessage.ID, "failed to resume ai chat response", err) {
-			h.logger.Error("failed to resume ai chat response", "error", err, "path", r.URL.Path, "request_id", request.GetRequestID(r.Context()))
+			h.logServiceFailure("failed to resume ai chat response", r, err)
 		}
 		return
 	}

--- a/server/internal/aichat/handler_helpers.go
+++ b/server/internal/aichat/handler_helpers.go
@@ -3,6 +3,7 @@ package aichat
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -162,5 +163,24 @@ func (h *Handler) writeStreamError(sse *sseWriter, r *http.Request, conversation
 }
 
 func (h *Handler) logStreamWriteFailure(message string, r *http.Request, err error) {
-	h.logger.Error(message, "error", err, "path", r.URL.Path, "request_id", request.GetRequestID(r.Context()))
+	h.logger.Error(message,
+		"path", r.URL.Path,
+		"method", r.Method,
+		"request_id", request.GetRequestID(r.Context()),
+		"error_category", "stream_write",
+		"error_present", err != nil,
+		"error_type", fmt.Sprintf("%T", err))
+}
+
+func (h *Handler) logServiceFailure(message string, r *http.Request, err error, attrs ...any) {
+	logAttrs := []any{
+		"path", r.URL.Path,
+		"method", r.Method,
+		"request_id", request.GetRequestID(r.Context()),
+		"error_category", "service",
+		"error_present", err != nil,
+		"error_type", fmt.Sprintf("%T", err),
+	}
+	logAttrs = append(logAttrs, attrs...)
+	h.logger.Error(message, logAttrs...)
 }

--- a/server/internal/aichat/handler_test.go
+++ b/server/internal/aichat/handler_test.go
@@ -1,6 +1,7 @@
 package aichat
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -667,11 +668,13 @@ func TestHandlerStreamMessage(t *testing.T) {
 	})
 
 	t.Run("aborts prepared run when start event write disconnects", func(t *testing.T) {
+		var logs bytes.Buffer
+		logger := slog.New(slog.NewJSONHandler(&logs, nil))
 		service := new(mockChatService)
 		handler := NewHandler(logger, service)
 		prepared := preparedStreamFixture()
 		service.On("PrepareMessageStream", mock.Anything, int32(41), "prove streaming", "req-123").Return(prepared, nil).Once()
-		service.On("AbortPreparedMessageStream", mock.Anything, prepared, ErrStreamNotStarted).Return(nil).Once()
+		service.On("AbortPreparedMessageStream", mock.Anything, prepared, ErrStreamNotStarted).Return(errors.New("provider cleanup failed with secret api-key-123 and SQLSTATE 23505")).Once()
 
 		req := httptest.NewRequest(http.MethodPost, "/api/ai/conversations/41/messages/stream", strings.NewReader(`{"prompt":"prove streaming"}`))
 		req = req.WithContext(request.WithRequestID(req.Context(), "req-123"))
@@ -681,6 +684,22 @@ func TestHandlerStreamMessage(t *testing.T) {
 		handler.StreamMessage(rr, req)
 
 		service.AssertNotCalled(t, "StreamMessage", mock.Anything, mock.Anything, mock.Anything)
+		logOutput := logs.String()
+		assert.Contains(t, logOutput, `"error_category":"service"`)
+		assert.Contains(t, logOutput, `"error_category":"stream_write"`)
+		assert.Contains(t, logOutput, `"error_present":true`)
+		assert.Contains(t, logOutput, `"error_type":"*errors.errorString"`)
+		for _, forbidden := range []string{
+			"provider cleanup failed",
+			"secret api-key-123",
+			"broken pipe",
+			"SQLSTATE",
+			"23505",
+		} {
+			if strings.Contains(logOutput, forbidden) {
+				t.Fatalf("ai chat stream log contains sensitive raw error detail %q: %s", forbidden, logOutput)
+			}
+		}
 		service.AssertExpectations(t)
 	})
 }

--- a/server/internal/auth/middleware.go
+++ b/server/internal/auth/middleware.go
@@ -73,15 +73,16 @@ func (a *Authenticator) setSessionUserID(ctx context.Context, userID string) err
 		// Check if this is an RLS context error
 		if db.IsRLSContextError(err) {
 			a.logger.Error("RLS context setup failed",
-				"error", err,
 				"userID", userID,
-				"error_type", "rls_context")
-			a.logger.Debug("raw RLS context error details", "error", err.Error(), "error_type", fmt.Sprintf("%T", err), "userID", userID)
+				"error_category", "rls_context",
+				"error_present", true,
+				"error_type", fmt.Sprintf("%T", err))
 		} else {
 			a.logger.Error("failed to set session variable",
-				"error", err,
-				"userID", userID)
-			a.logger.Debug("raw session variable error details", "error", err.Error(), "error_type", fmt.Sprintf("%T", err), "userID", userID)
+				"userID", userID,
+				"error_category", "database",
+				"error_present", true,
+				"error_type", fmt.Sprintf("%T", err))
 		}
 		return fmt.Errorf("failed to set user context: %w", err)
 	}
@@ -118,7 +119,14 @@ func (a *Authenticator) Middleware(next http.Handler) http.Handler {
 
 		userID, err := a.jwkCache.GetUserIDFromToken(accessToken)
 		if err != nil {
-			a.logger.Error("invalid access token", "error", err, "path", r.URL.Path, "request_id", request.GetRequestID(r.Context()))
+			a.logger.Error("invalid access token",
+				"path", r.URL.Path,
+				"method", r.Method,
+				"status", http.StatusUnauthorized,
+				"request_id", request.GetRequestID(r.Context()),
+				"error_category", "jwt",
+				"error_present", true,
+				"error_type", fmt.Sprintf("%T", err))
 			response.ErrorJSON(w, r, a.logger, http.StatusUnauthorized, "invalid access token", err)
 			return
 		}
@@ -130,7 +138,15 @@ func (a *Authenticator) Middleware(next http.Handler) http.Handler {
 func (a *Authenticator) authenticateUser(w http.ResponseWriter, r *http.Request, next http.Handler, userID string) bool {
 	dbUser, err := a.userService.EnsureUser(r.Context(), userID)
 	if err != nil {
-		a.logger.Error("failed to ensure user", "error", err, "userID", userID, "request_id", request.GetRequestID(r.Context()))
+		a.logger.Error("failed to ensure user",
+			"userID", userID,
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", http.StatusInternalServerError,
+			"request_id", request.GetRequestID(r.Context()),
+			"error_category", "database",
+			"error_present", true,
+			"error_type", fmt.Sprintf("%T", err))
 		response.ErrorJSON(w, r, a.logger, http.StatusInternalServerError, "failed to ensure user", err)
 		return false
 	}
@@ -139,10 +155,14 @@ func (a *Authenticator) authenticateUser(w http.ResponseWriter, r *http.Request,
 	if a.dbPool != nil {
 		if err := a.setSessionUserID(r.Context(), userID); err != nil {
 			a.logger.Error("failed to set user context",
-				"error", err,
 				"userID", userID,
 				"path", r.URL.Path,
-				"request_id", request.GetRequestID(r.Context()))
+				"method", r.Method,
+				"status", http.StatusInternalServerError,
+				"request_id", request.GetRequestID(r.Context()),
+				"error_category", "database",
+				"error_present", true,
+				"error_type", fmt.Sprintf("%T", err))
 			response.ErrorJSON(w, r, a.logger,
 				http.StatusInternalServerError,
 				"failed to set user context",

--- a/server/internal/auth/middleware_test.go
+++ b/server/internal/auth/middleware_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -9,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -320,6 +322,110 @@ func TestAuthenticator_Middleware_NilDBPool(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	mockJWKSCache.AssertExpectations(t)
 	mockUserService.AssertExpectations(t)
+}
+
+func TestAuthenticator_Middleware_LogsSafeErrorSummaries(t *testing.T) {
+	tests := []struct {
+		name         string
+		setup        func(*MockJWKSCache, *MockUserService, *MockDBTX)
+		wantStatus   int
+		wantCategory string
+		forbidden    []string
+	}{
+		{
+			name: "invalid access token",
+			setup: func(jwkCache *MockJWKSCache, userService *MockUserService, dbPool *MockDBTX) {
+				jwkCache.On("GetUserIDFromToken", "invalid-token").Return("", fmt.Errorf("failed to parse token for project secret-project-id: SQLSTATE 42501"))
+			},
+			wantStatus:   http.StatusUnauthorized,
+			wantCategory: `"error_category":"jwt"`,
+			forbidden: []string{
+				"secret-project-id",
+				"SQLSTATE",
+				"42501",
+				"failed to parse token for project",
+			},
+		},
+		{
+			name: "ensure user database error",
+			setup: func(jwkCache *MockJWKSCache, userService *MockUserService, dbPool *MockDBTX) {
+				jwkCache.On("GetUserIDFromToken", "valid-token").Return("user-123", nil)
+				userService.On("EnsureUser", mock.Anything, "user-123").Return(db.Users{}, fmt.Errorf("pq: duplicate key value violates unique constraint \"users_email_key\" DETAIL: Key (email)=(andy@example.com) already exists. SQLSTATE 23505"))
+			},
+			wantStatus:   http.StatusInternalServerError,
+			wantCategory: `"error_category":"database"`,
+			forbidden: []string{
+				"pq:",
+				"users_email_key",
+				"andy@example.com",
+				"SQLSTATE",
+				"23505",
+			},
+		},
+		{
+			name: "session user database error",
+			setup: func(jwkCache *MockJWKSCache, userService *MockUserService, dbPool *MockDBTX) {
+				jwkCache.On("GetUserIDFromToken", "valid-token").Return("user-123", nil)
+				userService.On("EnsureUser", mock.Anything, "user-123").Return(db.Users{UserID: "user-123"}, nil)
+				tag := pgconn.NewCommandTag("SET")
+				dbPool.On("Exec", mock.Anything, setUserIDQuery, "user-123").Return(tag, fmt.Errorf("pq: permission denied for relation users SQLSTATE 42501"))
+			},
+			wantStatus:   http.StatusInternalServerError,
+			wantCategory: `"error_category":"database"`,
+			forbidden: []string{
+				"pq:",
+				"permission denied",
+				"relation users",
+				"SQLSTATE",
+				"42501",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logs bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&logs, nil))
+			mockJWKSCache := &MockJWKSCache{}
+			mockUserService := &MockUserService{}
+			mockDB := &MockDBTX{}
+			tt.setup(mockJWKSCache, mockUserService, mockDB)
+
+			auth := &Authenticator{
+				logger:      logger,
+				jwkCache:    mockJWKSCache,
+				userService: mockUserService,
+				dbPool:      mockDB,
+			}
+
+			nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+			req.Header.Set("x-stack-access-token", "valid-token")
+			if tt.name == "invalid access token" {
+				req.Header.Set("x-stack-access-token", "invalid-token")
+			}
+			w := httptest.NewRecorder()
+
+			auth.Middleware(nextHandler).ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+			logOutput := logs.String()
+			assert.Contains(t, logOutput, tt.wantCategory)
+			assert.Contains(t, logOutput, `"error_present":true`)
+			assert.Contains(t, logOutput, `"error_type":`)
+			for _, forbidden := range tt.forbidden {
+				if strings.Contains(logOutput, forbidden) {
+					t.Fatalf("auth log contains sensitive raw error detail %q: %s", forbidden, logOutput)
+				}
+			}
+
+			mockJWKSCache.AssertExpectations(t)
+			mockUserService.AssertExpectations(t)
+			mockDB.AssertExpectations(t)
+		})
+	}
 }
 
 func TestJWKSCache_GetUserIDFromToken(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace raw auth middleware error logs with safe structured fields for token, user ensure, and session-user failures
- replace AI chat stream fallback raw error logs with safe type/category/presence summaries while preserving request and stream IDs
- close the static file existence-check handle and isolate static route test assets in a temp directory so backend tests do not leave placeholder dist files

## Verification
- go test -short ./internal/auth ./internal/aichat ./internal/response
- go test -short ./cmd/api ./internal/auth ./internal/aichat ./internal/response
- $pkgs = go list ./... | Where-Object { $_ -notmatch '/internal/database$' }; go test -short $pkgs
- go vet ./...
- git diff --check
- python C:\Users\lenny\.codex\skills\autoreview\scripts\autoreview --mode local --thinking codex=medium