### PR TITLE
refactor: migrate route search validation to valibot

### DIFF
--- a/client/bun.lock
+++ b/client/bun.lock
@@ -28,6 +28,7 @@
         "@tanstack/react-router": "1.169.2",
         "@tanstack/react-router-devtools": "1.166.13",
         "@tanstack/router-plugin": "1.167.34",
+        "@tanstack/valibot-adapter": "^1.167.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -42,8 +43,8 @@
         "tailwind-merge": "3.5.0",
         "tailwindcss": "4.2.4",
         "tailwindcss-animate": "^1.0.7",
+        "valibot": "^1.4.1",
         "vaul": "^1.1.2",
-        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@hey-api/openapi-ts": "0.97.1",
@@ -975,6 +976,8 @@
     "@tanstack/store": ["@tanstack/store@0.9.2", "", {}, "sha512-K013lUJEFJK2ofFQ/hZKJUmCnpcV00ebLyOyFOWQvyQHUOZp/iYO84BM6aOGiV81JzwbX0APTVmW8YI7yiG5oA=="],
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+
+    "@tanstack/valibot-adapter": ["@tanstack/valibot-adapter@1.167.0", "", { "peerDependencies": { "@tanstack/react-router": ">=1.43.2", "valibot": "^1.0.0 || ^1.0.0-beta.5 || ^1.0.0-rc" } }, "sha512-W/sN+BnRrMeW3QEtSBf6hUhNFaa/QMs4XnPgSnme5RFt+hDRTQYs/K9aW+TOy92u8VsnQ82uJ2HX/vmntTeqIQ=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
 
@@ -1955,6 +1958,8 @@
     "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "uzip": ["uzip@0.20201231.0", "", {}, "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="],
+
+    "valibot": ["valibot@1.4.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g=="],
 
     "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -45,6 +45,7 @@
     "@tanstack/react-router": "1.169.2",
     "@tanstack/react-router-devtools": "1.166.13",
     "@tanstack/router-plugin": "1.167.34",
+    "@tanstack/valibot-adapter": "^1.167.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -59,8 +60,8 @@
     "tailwind-merge": "3.5.0",
     "tailwindcss": "4.2.4",
     "tailwindcss-animate": "^1.0.7",
-    "vaul": "^1.1.2",
-    "zod": "^4.4.3"
+    "valibot": "^1.4.1",
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "0.97.1",

--- a/client/src/lib/route-search-validation.ts
+++ b/client/src/lib/route-search-validation.ts
@@ -1,0 +1,47 @@
+import { valibotValidator } from "@tanstack/valibot-adapter";
+import * as v from "valibot";
+
+const optionalIntegerSearchParam = v.optional(
+  v.pipe(v.unknown(), v.toNumber(), v.number(), v.integer()),
+);
+
+const optionalPositiveIntegerSearchParam = v.optional(
+  v.pipe(v.unknown(), v.toNumber(), v.number(), v.integer(), v.minValue(1)),
+);
+
+const optionalSortOrderSearchParam = v.optional(v.picklist(["asc", "desc"]));
+
+/** Search validator for workout creation and editing routes. */
+export const workoutEditorSearchValidator = valibotValidator(
+  v.object({
+    addExercise: v.optional(v.boolean()),
+    exerciseIndex: optionalIntegerSearchParam,
+    newExercise: v.optional(v.boolean()),
+  }),
+);
+
+/** Search validator for the workouts list route. */
+export const workoutsSearchValidator = valibotValidator(
+  v.object({
+    focusArea: v.optional(v.string()),
+    sortOrder: optionalSortOrderSearchParam,
+    itemsPerPage: optionalPositiveIntegerSearchParam,
+    page: optionalPositiveIntegerSearchParam,
+  }),
+);
+
+/** Search validator for the exercise detail route. */
+export const exerciseDetailSearchValidator = valibotValidator(
+  v.object({
+    sortOrder: optionalSortOrderSearchParam,
+    itemsPerPage: optionalPositiveIntegerSearchParam,
+    page: optionalPositiveIntegerSearchParam,
+  }),
+);
+
+/** Search validator for the analytics route. */
+export const analyticsSearchValidator = valibotValidator(
+  v.object({
+    exerciseId: optionalPositiveIntegerSearchParam,
+  }),
+);

--- a/client/src/routes/_layout/analytics.tsx
+++ b/client/src/routes/_layout/analytics.tsx
@@ -1,19 +1,15 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
 import { AnalyticsPage } from "@/features/analytics/pages/analytics-page";
 import { getExerciseListQueryOptions } from "@/features/exercises/api/exercise-query-options";
 import {
   getWorkoutContributionQueryOptions,
   getWorkoutsFocusQueryOptions,
 } from "@/features/workouts/api/workout-query-options";
+import { analyticsSearchValidator } from "@/lib/route-search-validation";
 import { clearDemoData, initializeDemoData } from "@/lib/demo-data/storage";
 
-const analyticsSearchSchema = z.object({
-  exerciseId: z.coerce.number().int().positive().optional(),
-});
-
 export const Route = createFileRoute("/_layout/analytics")({
-  validateSearch: analyticsSearchSchema,
+  validateSearch: analyticsSearchValidator,
   loader: async ({ context }) => {
     const user = context.user;
 

--- a/client/src/routes/_layout/exercises/$exerciseId.tsx
+++ b/client/src/routes/_layout/exercises/$exerciseId.tsx
@@ -1,17 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
 import { getExerciseDetailQueryOptions } from "@/features/exercises/api/exercise-query-options";
 import { ExerciseDetailPage } from "@/features/exercises/pages/exercise-detail-page";
+import { exerciseDetailSearchValidator } from "@/lib/route-search-validation";
 import { initializeDemoData, clearDemoData } from "@/lib/demo-data/storage";
 
-const exerciseSearchSchema = z.object({
-  sortOrder: z.enum(["asc", "desc"]).optional(),
-  itemsPerPage: z.coerce.number().int().positive().optional(),
-  page: z.coerce.number().int().positive().optional(),
-});
-
 export const Route = createFileRoute("/_layout/exercises/$exerciseId")({
-  validateSearch: exerciseSearchSchema,
+  validateSearch: exerciseDetailSearchValidator,
   params: {
     parse: (params) => {
       const exerciseId = parseInt(params.exerciseId, 10);

--- a/client/src/routes/_layout/workouts/$workoutId/edit.tsx
+++ b/client/src/routes/_layout/workouts/$workoutId/edit.tsx
@@ -1,18 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
 import {
   EditWorkoutRouteComposition,
   preloadEditWorkoutRouteData,
 } from "@/features/workouts/pages/workout-route-composition";
-
-const workoutSearchSchema = z.object({
-  addExercise: z.boolean().optional(),
-  exerciseIndex: z.coerce.number().int().optional(),
-  newExercise: z.boolean().optional(),
-});
+import { workoutEditorSearchValidator } from "@/lib/route-search-validation";
 
 export const Route = createFileRoute("/_layout/workouts/$workoutId/edit")({
-  validateSearch: workoutSearchSchema,
+  validateSearch: workoutEditorSearchValidator,
   params: {
     parse: (params) => {
       const workoutId = parseInt(params.workoutId, 10);

--- a/client/src/routes/_layout/workouts/index.tsx
+++ b/client/src/routes/_layout/workouts/index.tsx
@@ -1,19 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
 import { contributionDataQueryOptions } from "@/features/workouts/api/workouts";
 import { getWorkoutListQueryOptions } from "@/features/workouts/api/workout-query-options";
 import { WorkoutsPage } from "@/features/workouts/pages/workouts-page";
+import { workoutsSearchValidator } from "@/lib/route-search-validation";
 import { clearDemoData, initializeDemoData } from "@/lib/demo-data/storage";
 
-const workoutsSearchSchema = z.object({
-  focusArea: z.string().optional(),
-  sortOrder: z.enum(["asc", "desc"]).optional(),
-  itemsPerPage: z.coerce.number().int().positive().optional(),
-  page: z.coerce.number().int().positive().optional(),
-});
-
 export const Route = createFileRoute("/_layout/workouts/")({
-  validateSearch: workoutsSearchSchema,
+  validateSearch: workoutsSearchValidator,
   loader: async ({ context }) => {
     const user = context.user;
 

--- a/client/src/routes/_layout/workouts/new.tsx
+++ b/client/src/routes/_layout/workouts/new.tsx
@@ -1,18 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
 import {
   NewWorkoutRouteComposition,
   preloadNewWorkoutRouteData,
 } from "@/features/workouts/pages/workout-route-composition";
-
-const workoutSearchSchema = z.object({
-  addExercise: z.boolean().optional(),
-  exerciseIndex: z.coerce.number().int().optional(),
-  newExercise: z.boolean().optional(),
-});
+import { workoutEditorSearchValidator } from "@/lib/route-search-validation";
 
 export const Route = createFileRoute("/_layout/workouts/new")({
-  validateSearch: workoutSearchSchema,
+  validateSearch: workoutEditorSearchValidator,
   loader: ({ context }) => {
     preloadNewWorkoutRouteData(context);
   },

--- a/client/src/test/routes/search-validation.test.ts
+++ b/client/src/test/routes/search-validation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyticsSearchValidator,
+  exerciseDetailSearchValidator,
+  workoutEditorSearchValidator,
+  workoutsSearchValidator,
+} from "@/lib/route-search-validation";
+
+describe("route search validation", () => {
+  it("coerces optional numeric workout list search params and strips unknown keys", () => {
+    expect(
+      workoutsSearchValidator.parse({
+        focusArea: "push",
+        sortOrder: "desc",
+        itemsPerPage: "25",
+        page: "2",
+        ignored: "value",
+      }),
+    ).toEqual({
+      focusArea: "push",
+      sortOrder: "desc",
+      itemsPerPage: 25,
+      page: 2,
+    });
+  });
+
+  it("keeps omitted optional search params absent", () => {
+    expect(workoutsSearchValidator.parse({})).toEqual({});
+    expect(exerciseDetailSearchValidator.parse({ sortOrder: "asc" })).toEqual({
+      sortOrder: "asc",
+    });
+  });
+
+  it("preserves workout editor boolean params and coerces exercise indexes", () => {
+    expect(
+      workoutEditorSearchValidator.parse({
+        addExercise: true,
+        exerciseIndex: "0",
+        newExercise: false,
+      }),
+    ).toEqual({
+      addExercise: true,
+      exerciseIndex: 0,
+      newExercise: false,
+    });
+  });
+
+  it("coerces analytics exercise ids to positive integers", () => {
+    expect(analyticsSearchValidator.parse({ exerciseId: "12" })).toEqual({
+      exerciseId: 12,
+    });
+  });
+
+  it("rejects invalid numeric and enum query values", () => {
+    expect(() => workoutsSearchValidator.parse({ page: "0" })).toThrow();
+    expect(() => workoutsSearchValidator.parse({ page: "2.5" })).toThrow();
+    expect(() =>
+      exerciseDetailSearchValidator.parse({ sortOrder: "newest" }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- replace client route search Zod schemas with Valibot validators via @tanstack/valibot-adapter
- preserve optional search params, numeric coercion, enum validation, and unknown-key stripping
- remove the direct client zod dependency and add focused route-search regression coverage

## Checks
- bun run test src/test/routes/search-validation.test.ts
- bun run tsc
- bun run lint
- bun run test src/test/routes
- bun run fmt:check
- bun run knip
- bun run build

## Notes
- Build still reports the existing large chunk warning; build exits successfully.