### PR TITLE
refactor: clarify account deletion failure boundary

### DIFF
--- a/server/internal/account/service.go
+++ b/server/internal/account/service.go
@@ -33,16 +33,35 @@ func (s *Service) DeleteCurrentUser(ctx context.Context) error {
 		return apperrors.NewUnauthorized("account", "")
 	}
 
-	if s.billing != nil {
-		if err := s.billing.CancelCurrentSubscriptionImmediately(ctx); err != nil {
-			return fmt.Errorf("cancel subscription before account deletion: %w", err)
-		}
+	subscriptionCancellationAttempted, err := s.cancelSubscriptionBeforeLocalAccountDeletion(ctx)
+	if err != nil {
+		return err
 	}
 
-	if err := s.repo.DeleteUser(ctx, userID); err != nil {
-		return fmt.Errorf("delete current user account: %w", err)
+	if err := s.deleteLocalAccountData(ctx, userID, subscriptionCancellationAttempted); err != nil {
+		return err
 	}
 
 	s.logger.Info("deleted fittrack user account data", "user_id", userID)
+	return nil
+}
+
+func (s *Service) cancelSubscriptionBeforeLocalAccountDeletion(ctx context.Context) (bool, error) {
+	if s.billing != nil {
+		if err := s.billing.CancelCurrentSubscriptionImmediately(ctx); err != nil {
+			return true, fmt.Errorf("cancel subscription before local account deletion: %w", err)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func (s *Service) deleteLocalAccountData(ctx context.Context, userID string, subscriptionCancellationAttempted bool) error {
+	if err := s.repo.DeleteUser(ctx, userID); err != nil {
+		if subscriptionCancellationAttempted {
+			return fmt.Errorf("delete local account data after subscription cancellation: %w", err)
+		}
+		return fmt.Errorf("delete current user account: %w", err)
+	}
 	return nil
 }

--- a/server/internal/account/service_test.go
+++ b/server/internal/account/service_test.go
@@ -14,10 +14,12 @@ import (
 
 type stubRepository struct {
 	deleteErr     error
+	deleteCalled  bool
 	deletedUserID string
 }
 
 func (s *stubRepository) DeleteUser(ctx context.Context, userID string) error {
+	s.deleteCalled = true
 	s.deletedUserID = userID
 	return s.deleteErr
 }
@@ -87,5 +89,23 @@ func TestServiceDeleteCurrentUser_DoesNotDeleteWhenSubscriptionCancellationFails
 	err := service.DeleteCurrentUser(ctx)
 
 	require.ErrorIs(t, err, expectedErr)
+	assert.True(t, billing.called)
+	assert.False(t, repo.deleteCalled)
 	assert.Empty(t, repo.deletedUserID)
+}
+
+func TestServiceDeleteCurrentUser_ReturnsLocalDeletionFailureAfterSubscriptionCancellation(t *testing.T) {
+	expectedErr := errors.New("delete failed")
+	repo := &stubRepository{deleteErr: expectedErr}
+	billing := &stubBillingCanceler{}
+	service := NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), repo, billing)
+	ctx := user.WithContext(context.Background(), "user-123")
+
+	err := service.DeleteCurrentUser(ctx)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.ErrorContains(t, err, "delete local account data after subscription cancellation")
+	assert.True(t, billing.called)
+	assert.True(t, repo.deleteCalled)
+	assert.Equal(t, "user-123", repo.deletedUserID)
 }


### PR DESCRIPTION
## Product impact

This makes the account deletion failure boundary explicit without intentionally changing behavior. Account deletion still cancels the Stripe subscription before deleting local account data, and now the service/test names make the two-step policy clear.

The important locked-in failure modes are:

- If Stripe cancellation fails, local account deletion does not run.
- If Stripe cancellation succeeds but local deletion fails, the returned error explicitly says the local deletion failed after subscription cancellation.

## Verification

- `go test -short ./internal/account`
- `$pkgs = go list ./... | Where-Object { $_ -notmatch '/internal/database$' }; go test -short $pkgs`
- `go vet ./...`
- pre-push hook: `make test-short` (`go test -short ./...` with local DB/migrations)