### PR TITLE
fix: preserve backend lookup failures

### DIFF
--- a/server/internal/exercise/handler_test.go
+++ b/server/internal/exercise/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Andrewy-gh/fittrack/server/internal/testutils"
 	"github.com/Andrewy-gh/fittrack/server/internal/user"
 	"github.com/go-playground/validator/v10"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/joho/godotenv"
@@ -245,7 +246,7 @@ func TestExerciseHandler_GetExerciseWithSets(t *testing.T) {
 			name:       "exercise not found",
 			exerciseID: "999",
 			setupMock: func(m *MockExerciseRepository, id int32) {
-				m.On("GetExerciseDetail", mock.Anything, id, userID).Return(db.GetExerciseDetailRow{}, assert.AnError)
+				m.On("GetExerciseDetail", mock.Anything, id, userID).Return(db.GetExerciseDetailRow{}, pgx.ErrNoRows)
 			},
 			ctx:           context.WithValue(context.Background(), user.UserIDKey, userID),
 			expectedCode:  http.StatusNotFound,
@@ -596,7 +597,7 @@ func TestExerciseHandler_DeleteExercise(t *testing.T) {
 			name:       "exercise not found",
 			exerciseID: "999",
 			setupMock: func(m *MockExerciseRepository, id int32) {
-				m.On("GetExercise", mock.Anything, id, userID).Return(db.Exercise{}, assert.AnError)
+				m.On("GetExercise", mock.Anything, id, userID).Return(db.Exercise{}, pgx.ErrNoRows)
 			},
 			ctx:           context.WithValue(context.Background(), user.UserIDKey, userID),
 			expectedCode:  http.StatusNotFound,
@@ -736,7 +737,7 @@ func TestExerciseHandler_UpdateExerciseName(t *testing.T) {
 			exerciseID:  "999",
 			requestBody: map[string]string{"name": "Updated Exercise"},
 			setupMock: func(m *MockExerciseRepository, id int32) {
-				m.On("GetExercise", mock.Anything, id, userID).Return(db.Exercise{}, assert.AnError)
+				m.On("GetExercise", mock.Anything, id, userID).Return(db.Exercise{}, pgx.ErrNoRows)
 			},
 			ctx:           context.WithValue(context.Background(), user.UserIDKey, userID),
 			expectedCode:  http.StatusNotFound,

--- a/server/internal/exercise/service.go
+++ b/server/internal/exercise/service.go
@@ -2,6 +2,7 @@ package exercise
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -9,6 +10,7 @@ import (
 	db "github.com/Andrewy-gh/fittrack/server/internal/database"
 	apperrors "github.com/Andrewy-gh/fittrack/server/internal/errors"
 	"github.com/Andrewy-gh/fittrack/server/internal/user"
+	"github.com/jackc/pgx/v5"
 )
 
 type ExerciseRepository interface {
@@ -59,8 +61,11 @@ func (es *ExerciseService) GetExerciseWithSets(ctx context.Context, id int32) (*
 	}
 
 	exercise, err := es.repo.GetExerciseDetail(ctx, id, userID)
-	if err != nil {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, &apperrors.NotFound{Resource: "exercise", ID: fmt.Sprintf("%d", id)}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up exercise detail: %w", err)
 	}
 
 	sets, err := es.repo.GetExerciseWithSets(ctx, id, userID)
@@ -145,8 +150,11 @@ func (es *ExerciseService) UpdateExerciseName(ctx context.Context, id int32, nam
 	}
 
 	_, err := es.repo.GetExercise(ctx, id, userID)
-	if err != nil {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return &apperrors.NotFound{Resource: "exercise", ID: fmt.Sprintf("%d", id)}
+	}
+	if err != nil {
+		return fmt.Errorf("failed to look up exercise before update: %w", err)
 	}
 
 	if err := es.repo.UpdateExerciseName(ctx, id, name, userID); err != nil {
@@ -164,8 +172,11 @@ func (es *ExerciseService) DeleteExercise(ctx context.Context, id int32) error {
 	}
 
 	_, err := es.repo.GetExercise(ctx, id, userID)
-	if err != nil {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return &apperrors.NotFound{Resource: "exercise", ID: fmt.Sprintf("%d", id)}
+	}
+	if err != nil {
+		return fmt.Errorf("failed to look up exercise before delete: %w", err)
 	}
 
 	if err := es.repo.DeleteExercise(ctx, id, userID); err != nil {

--- a/server/internal/exercise/service_test.go
+++ b/server/internal/exercise/service_test.go
@@ -7,14 +7,13 @@ import (
 	"log/slog"
 	"testing"
 
-	apperrors "github.com/Andrewy-gh/fittrack/server/internal/errors"
 	db "github.com/Andrewy-gh/fittrack/server/internal/database"
+	apperrors "github.com/Andrewy-gh/fittrack/server/internal/errors"
 	"github.com/Andrewy-gh/fittrack/server/internal/user"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
-
-
 
 func TestExerciseService_GetRecentSetsForExercise(t *testing.T) {
 	mockRepo := new(MockExerciseRepository)
@@ -46,14 +45,66 @@ func TestExerciseService_GetRecentSetsForExercise(t *testing.T) {
 	mockRepo.AssertExpectations(t)
 }
 
+func TestExerciseService_GetExerciseWithSets_LookupErrorClassification(t *testing.T) {
+	userID := "user-123"
+	exerciseID := int32(1)
+
+	tests := []struct {
+		name         string
+		lookupError  error
+		wantNotFound bool
+	}{
+		{
+			name:         "no rows returns not found",
+			lookupError:  pgx.ErrNoRows,
+			wantNotFound: true,
+		},
+		{
+			name:        "database failure is wrapped",
+			lookupError: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := new(MockExerciseRepository)
+			mockRepo.On("GetExerciseDetail", mock.Anything, exerciseID, userID).Return(db.GetExerciseDetailRow{}, tt.lookupError)
+
+			service := NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), mockRepo)
+			ctx := context.WithValue(context.Background(), user.UserIDKey, userID)
+
+			_, err := service.GetExerciseWithSets(ctx, exerciseID)
+			if err == nil {
+				t.Fatal("expected error but got none")
+			}
+
+			var notFoundErr *apperrors.NotFound
+			if tt.wantNotFound {
+				if !errors.As(err, &notFoundErr) {
+					t.Errorf("expected NotFound error but got %T", err)
+				}
+			} else {
+				if errors.As(err, &notFoundErr) {
+					t.Errorf("expected non-NotFound error but got %T", err)
+				}
+				if !errors.Is(err, tt.lookupError) {
+					t.Errorf("expected wrapped lookup error but got %v", err)
+				}
+			}
+
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
 func TestExerciseService_DeleteExercise(t *testing.T) {
 	tests := []struct {
-		name          string
-		exerciseID    int32
-		userID        string
-		setupMock     func(*MockExerciseRepository)
-		expectError   bool
-		errorType     string
+		name        string
+		exerciseID  int32
+		userID      string
+		setupMock   func(*MockExerciseRepository)
+		expectError bool
+		errorType   string
 	}{
 		{
 			name:       "successful deletion",
@@ -70,10 +121,20 @@ func TestExerciseService_DeleteExercise(t *testing.T) {
 			exerciseID: 999,
 			userID:     "user-123",
 			setupMock: func(m *MockExerciseRepository) {
-				m.On("GetExercise", mock.Anything, int32(999), "user-123").Return(db.Exercise{}, assert.AnError)
+				m.On("GetExercise", mock.Anything, int32(999), "user-123").Return(db.Exercise{}, pgx.ErrNoRows)
 			},
 			expectError: true,
 			errorType:   "ErrNotFound",
+		},
+		{
+			name:       "lookup operation fails",
+			exerciseID: 1,
+			userID:     "user-123",
+			setupMock: func(m *MockExerciseRepository) {
+				m.On("GetExercise", mock.Anything, int32(1), "user-123").Return(db.Exercise{}, assert.AnError)
+			},
+			expectError: true,
+			errorType:   "generic",
 		},
 		{
 			name:       "unauthenticated user",
@@ -166,10 +227,21 @@ func TestExerciseService_UpdateExerciseName(t *testing.T) {
 			newName:    "Updated Exercise",
 			userID:     "user-123",
 			setupMock: func(m *MockExerciseRepository) {
-				m.On("GetExercise", mock.Anything, int32(999), "user-123").Return(db.Exercise{}, assert.AnError)
+				m.On("GetExercise", mock.Anything, int32(999), "user-123").Return(db.Exercise{}, pgx.ErrNoRows)
 			},
 			expectError: true,
 			errorType:   "ErrNotFound",
+		},
+		{
+			name:       "lookup operation fails",
+			exerciseID: 1,
+			newName:    "Updated Exercise",
+			userID:     "user-123",
+			setupMock: func(m *MockExerciseRepository) {
+				m.On("GetExercise", mock.Anything, int32(1), "user-123").Return(db.Exercise{}, assert.AnError)
+			},
+			expectError: true,
+			errorType:   "generic",
 		},
 		{
 			name:       "unauthenticated user",
@@ -236,4 +308,3 @@ func TestExerciseService_UpdateExerciseName(t *testing.T) {
 		})
 	}
 }
-

--- a/server/internal/workout/handler_test.go
+++ b/server/internal/workout/handler_test.go
@@ -7,6 +7,7 @@ import (
 	db "github.com/Andrewy-gh/fittrack/server/internal/database"
 	"github.com/Andrewy-gh/fittrack/server/internal/user"
 	"github.com/go-playground/validator/v10"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -421,7 +422,7 @@ func TestWorkoutHandler_DeleteWorkout(t *testing.T) {
 			name:      "workout not found",
 			workoutID: "999",
 			setupMock: func(m *MockWorkoutRepository, id int32) {
-				m.On("GetWorkout", mock.Anything, id, userID).Return(db.Workout{}, assert.AnError)
+				m.On("GetWorkout", mock.Anything, id, userID).Return(db.Workout{}, pgx.ErrNoRows)
 			},
 			ctx:           context.WithValue(context.Background(), user.UserIDKey, userID),
 			expectedCode:  http.StatusNotFound,

--- a/server/internal/workout/service.go
+++ b/server/internal/workout/service.go
@@ -151,8 +151,11 @@ func (ws *WorkoutService) UpdateWorkout(ctx context.Context, id int32, req Updat
 	// First, validate that the workout exists and belongs to the user
 	// This helps provide better error messages (404 vs generic error)
 	_, err := ws.repo.GetWorkout(ctx, id, userID)
-	if err != nil {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return &apperrors.NotFound{Resource: "workout", ID: fmt.Sprintf("%d", id)}
+	}
+	if err != nil {
+		return fmt.Errorf("failed to look up workout before update: %w", err)
 	}
 
 	// Transform the request to our internal format (same as CreateWorkout)
@@ -180,8 +183,11 @@ func (ws *WorkoutService) DeleteWorkout(ctx context.Context, id int32) error {
 	// First, validate that the workout exists and belongs to the user
 	// This helps provide better error messages (404 vs generic error)
 	_, err := ws.repo.GetWorkout(ctx, id, userID)
-	if err != nil {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return &apperrors.NotFound{Resource: "workout", ID: fmt.Sprintf("%d", id)}
+	}
+	if err != nil {
+		return fmt.Errorf("failed to look up workout before delete: %w", err)
 	}
 
 	// Call repository to delete the workout

--- a/server/internal/workout/service_lookup_error_test.go
+++ b/server/internal/workout/service_lookup_error_test.go
@@ -1,0 +1,113 @@
+package workout
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	db "github.com/Andrewy-gh/fittrack/server/internal/database"
+	apperrors "github.com/Andrewy-gh/fittrack/server/internal/errors"
+	"github.com/Andrewy-gh/fittrack/server/internal/user"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkoutService_UpdateWorkout_LookupErrorClassification(t *testing.T) {
+	userID := "user-123"
+	workoutID := int32(1)
+	request := UpdateWorkoutRequest{
+		Date: time.Now().UTC().Format(time.RFC3339),
+		Exercises: []UpdateExercise{{
+			Name: "Bench Press",
+			Sets: []UpdateSet{{Reps: 5, SetType: "working"}},
+		}},
+	}
+
+	tests := []struct {
+		name         string
+		lookupError  error
+		wantNotFound bool
+	}{
+		{
+			name:         "no rows returns not found",
+			lookupError:  pgx.ErrNoRows,
+			wantNotFound: true,
+		},
+		{
+			name:        "database failure is wrapped",
+			lookupError: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := new(MockWorkoutRepository)
+			mockRepo.On("GetWorkout", mock.Anything, workoutID, userID).Return(db.Workout{}, tt.lookupError)
+
+			service := NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), mockRepo)
+			ctx := context.WithValue(context.Background(), user.UserIDKey, userID)
+
+			err := service.UpdateWorkout(ctx, workoutID, request)
+			require.Error(t, err)
+
+			var notFoundErr *apperrors.NotFound
+			if tt.wantNotFound {
+				require.True(t, errors.As(err, &notFoundErr), "expected NotFound but got %T", err)
+			} else {
+				require.False(t, errors.As(err, &notFoundErr), "unexpected NotFound for %v", err)
+				require.ErrorIs(t, err, tt.lookupError)
+			}
+
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestWorkoutService_DeleteWorkout_LookupErrorClassification(t *testing.T) {
+	userID := "user-123"
+	workoutID := int32(1)
+
+	tests := []struct {
+		name         string
+		lookupError  error
+		wantNotFound bool
+	}{
+		{
+			name:         "no rows returns not found",
+			lookupError:  pgx.ErrNoRows,
+			wantNotFound: true,
+		},
+		{
+			name:        "database failure is wrapped",
+			lookupError: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := new(MockWorkoutRepository)
+			mockRepo.On("GetWorkout", mock.Anything, workoutID, userID).Return(db.Workout{}, tt.lookupError)
+
+			service := NewService(slog.New(slog.NewTextHandler(io.Discard, nil)), mockRepo)
+			ctx := context.WithValue(context.Background(), user.UserIDKey, userID)
+
+			err := service.DeleteWorkout(ctx, workoutID)
+			require.Error(t, err)
+
+			var notFoundErr *apperrors.NotFound
+			if tt.wantNotFound {
+				require.True(t, errors.As(err, &notFoundErr), "expected NotFound but got %T", err)
+			} else {
+				require.False(t, errors.As(err, &notFoundErr), "unexpected NotFound for %v", err)
+				require.ErrorIs(t, err, tt.lookupError)
+			}
+
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}

--- a/server/internal/workout/update_workout_test.go
+++ b/server/internal/workout/update_workout_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Andrewy-gh/fittrack/server/internal/exercise"
 	"github.com/Andrewy-gh/fittrack/server/internal/user"
 	"github.com/go-playground/validator/v10"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -236,7 +237,7 @@ func TestWorkoutHandler_UpdateWorkout(t *testing.T) {
 			},
 			setupMock: func(m *MockWorkoutRepository) {
 				// GetWorkout returns error for non-existent workout
-				m.On("GetWorkout", mock.Anything, int32(999), userID).Return(db.Workout{}, fmt.Errorf("workout not found"))
+				m.On("GetWorkout", mock.Anything, int32(999), userID).Return(db.Workout{}, pgx.ErrNoRows)
 				// UpdateWorkout should not be called since GetWorkout returns error
 			},
 			ctx:           context.WithValue(context.Background(), user.UserIDKey, userID),


### PR DESCRIPTION
## Summary
- Return `apperrors.NotFound` only for true `pgx.ErrNoRows` lookup misses in workout/exercise service ownership checks.
- Wrap non-not-found lookup failures so repository/database errors surface as server failures instead of false 404s.
- Tighten handler fixtures and add focused service regression coverage for both true no-row and generic lookup failures.

## Checks
- `go test ./internal/workout -run 'TestWorkoutService_(UpdateWorkout|DeleteWorkout)_LookupErrorClassification|TestWorkoutHandler_(UpdateWorkout|DeleteWorkout)$'`
- `go test ./internal/exercise -run 'TestExerciseService_(GetExerciseWithSets_LookupErrorClassification|DeleteExercise|UpdateExerciseName)$|TestExerciseHandler_(GetExerciseWithSets|DeleteExercise|UpdateExerciseName)$'`
- `$pkgs = go list ./... | Where-Object { $_ -notmatch '/internal/database$' }; go test -short $pkgs`
- `git diff --check`
- `go vet ./...`
- `go build ./cmd/api`

## Notes
- A full non-short `go test ./internal/workout ./internal/exercise` hit local Postgres auth failures in integration tests before the short gate was run.