### PR TITLE
refactor: type workout form seam

### DIFF
--- a/client/src/features/workouts/components/form/__tests__/workout-form-sections.test.tsx
+++ b/client/src/features/workouts/components/form/__tests__/workout-form-sections.test.tsx
@@ -82,6 +82,7 @@ vi.mock("@/components/ui/card", () => ({
 
 import {
   WorkoutExerciseCards,
+  type WorkoutExerciseArrayField,
   type WorkoutExerciseCard,
 } from "../workout-form-sections";
 import { useExerciseReorder } from "../use-exercise-reorder";
@@ -116,10 +117,12 @@ function WorkoutExerciseCardsHarness() {
   );
 }
 
-function WorkoutExerciseCardsField({ field }: { field: any }) {
-  const exerciseReorder = useExerciseReorder(
-    field.state.value as WorkoutExerciseCard[],
-  );
+function WorkoutExerciseCardsField({
+  field,
+}: {
+  field: WorkoutExerciseArrayField;
+}) {
+  const exerciseReorder = useExerciseReorder(field.state.value);
 
   return (
     <>

--- a/client/src/features/workouts/components/form/workout-form-sections.tsx
+++ b/client/src/features/workouts/components/form/workout-form-sections.tsx
@@ -1,5 +1,16 @@
-import type { ComponentType, CSSProperties, ReactNode } from "react";
+import type {
+  CSSProperties,
+  LazyExoticComponent,
+  ReactElement,
+  ReactNode,
+} from "react";
 import { Link, useRouter } from "@tanstack/react-router";
+import type { AppFieldExtendedReactFormApi } from "@tanstack/react-form";
+import type {
+  FormAsyncValidateOrFn,
+  FormValidateOrFn,
+  Updater,
+} from "@tanstack/form-core";
 import {
   DndContext,
   KeyboardSensor,
@@ -21,8 +32,13 @@ import { CSS } from "@dnd-kit/utilities";
 import { PencilLine, Plus, Save, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import type { WorkoutExerciseInput } from "@/client";
+import type {
+  WorkoutCreateWorkoutRequest,
+  WorkoutExerciseInput,
+  WorkoutUpdateWorkoutRequest,
+} from "@/client";
 import type { WorkoutFocus } from "@/features/workouts/api/workouts";
+import type { DbExercise } from "@/features/exercises/api/exercises";
 import { cn } from "@/lib/utils";
 import type { ReorderableExercise } from "./use-exercise-reorder";
 
@@ -30,13 +46,72 @@ export type WorkoutExerciseCard = Pick<WorkoutExerciseInput, "name" | "sets">;
 type SortableHandleAttributes = ReturnType<typeof useSortable>["attributes"];
 type SortableHandleListeners = ReturnType<typeof useSortable>["listeners"];
 type SortableHandleRef = ReturnType<typeof useSortable>["setActivatorNodeRef"];
-type WorkoutFormSectionApi = {
-  AppField: ComponentType<any>;
-  Subscribe: ComponentType<any>;
+
+type WorkoutFormValues =
+  | WorkoutCreateWorkoutRequest
+  | WorkoutUpdateWorkoutRequest;
+type WorkoutFormSyncValidator<TFormValues> =
+  | FormValidateOrFn<TFormValues>
+  | undefined;
+type WorkoutFormAsyncValidator<TFormValues> =
+  | FormAsyncValidateOrFn<TFormValues>
+  | undefined;
+type LazyFieldComponent<TProps extends object = Record<string, never>> =
+  LazyExoticComponent<(props: TProps) => ReactElement>;
+type LazyEmptyFieldComponent = LazyExoticComponent<() => ReactElement>;
+type WorkoutFormFieldComponents = {
+  DatePicker: LazyEmptyFieldComponent;
+  NotesTextarea: LazyEmptyFieldComponent;
+  SetTypeSelect: LazyFieldComponent<{ className?: string }>;
+  InputField: LazyFieldComponent<{
+    label: string;
+    placeholder?: string;
+    type?: "text" | "number";
+    className?: string;
+    step?: string;
+    min?: string;
+  }>;
+  AddExerciseField: LazyFieldComponent<{
+    exercises: DbExercise[];
+    onAddExercise: (exerciseIndex: number, exerciseId?: number) => void;
+  }>;
+  WorkoutFocusCombobox: LazyFieldComponent<{
+    workoutsFocus: WorkoutFocus[];
+  }>;
+};
+type WorkoutFormApi<TFormValues extends WorkoutFormValues> =
+  AppFieldExtendedReactFormApi<
+    TFormValues,
+    WorkoutFormSyncValidator<TFormValues>,
+    WorkoutFormSyncValidator<TFormValues>,
+    WorkoutFormAsyncValidator<TFormValues>,
+    WorkoutFormSyncValidator<TFormValues>,
+    WorkoutFormAsyncValidator<TFormValues>,
+    WorkoutFormSyncValidator<TFormValues>,
+    WorkoutFormAsyncValidator<TFormValues>,
+    WorkoutFormSyncValidator<TFormValues>,
+    WorkoutFormAsyncValidator<TFormValues>,
+    WorkoutFormAsyncValidator<TFormValues>,
+    unknown,
+    WorkoutFormFieldComponents,
+    Record<string, never>
+  >;
+
+export type WorkoutFormSectionApi<
+  TFormValues extends WorkoutFormValues = WorkoutFormValues,
+> = Pick<WorkoutFormApi<TFormValues>, "AppField" | "Subscribe">;
+export type WorkoutExerciseArrayField = {
+  readonly state: {
+    readonly value: WorkoutExerciseCard[];
+  };
+  readonly removeValue: (index: number) => void;
+  readonly handleChange: (updater: Updater<WorkoutExerciseCard[]>) => void;
 };
 
-type WorkoutMetadataFieldsProps = {
-  form: WorkoutFormSectionApi;
+type WorkoutMetadataFieldsProps<
+  TFormValues extends WorkoutFormValues = WorkoutFormValues,
+> = {
+  form: WorkoutFormSectionApi<TFormValues>;
   workoutsFocus: WorkoutFocus[];
 };
 
@@ -56,8 +131,10 @@ type WorkoutExerciseCardsProps = {
   renderMetrics?: (exercise: WorkoutExerciseCard) => ReactNode;
 };
 
-type WorkoutFormActionsProps = {
-  form: WorkoutFormSectionApi;
+type WorkoutFormActionsProps<
+  TFormValues extends WorkoutFormValues = WorkoutFormValues,
+> = {
+  form: WorkoutFormSectionApi<TFormValues>;
   isReorderMode: boolean;
 };
 
@@ -68,26 +145,25 @@ function getExerciseVolume(exercise: WorkoutExerciseCard): number {
   );
 }
 
-export function WorkoutMetadataFields({
-  form,
-  workoutsFocus,
-}: WorkoutMetadataFieldsProps) {
+export function WorkoutMetadataFields<
+  TFormValues extends WorkoutFormValues = WorkoutFormValues,
+>({ form, workoutsFocus }: WorkoutMetadataFieldsProps<TFormValues>) {
   return (
     <div className="grid grid-cols-2 gap-4 mb-4">
       <form.AppField
         name="date"
-        children={(field: any) => <field.DatePicker />}
+        children={(field) => <field.DatePicker />}
       />
       <form.AppField
         name="workoutFocus"
-        children={(field: any) => (
+        children={(field) => (
           <field.WorkoutFocusCombobox workoutsFocus={workoutsFocus} />
         )}
       />
       <div className="col-span-2">
         <form.AppField
           name="notes"
-          children={(field: any) => <field.NotesTextarea />}
+          children={(field) => <field.NotesTextarea />}
         />
       </div>
     </div>
@@ -464,10 +540,9 @@ function SortableWorkoutExerciseCard({
   );
 }
 
-export function WorkoutFormActions({
-  form,
-  isReorderMode,
-}: WorkoutFormActionsProps) {
+export function WorkoutFormActions<
+  TFormValues extends WorkoutFormValues = WorkoutFormValues,
+>({ form, isReorderMode }: WorkoutFormActionsProps<TFormValues>) {
   return (
     <>
       <div className="py-6">
@@ -501,9 +576,9 @@ export function WorkoutFormActions({
         )}
       </div>
       <div className="mt-8">
-        <form.Subscribe
-          selector={(state: any) => [state.canSubmit, state.isSubmitting]}
-          children={([canSubmit, isSubmitting]: [boolean, boolean]) => (
+        <form.Subscribe<readonly [boolean, boolean]>
+          selector={(state) => [state.canSubmit, state.isSubmitting] as const}
+          children={([canSubmit, isSubmitting]) => (
             <Button
               type="submit"
               disabled={!canSubmit || isReorderMode}

--- a/client/src/features/workouts/pages/edit-workout-page.tsx
+++ b/client/src/features/workouts/pages/edit-workout-page.tsx
@@ -28,15 +28,23 @@ import {
 import { formatWeight } from "@/lib/utils";
 import {
   WorkoutExerciseCards,
+  type WorkoutExerciseArrayField,
   type WorkoutExerciseCard,
   WorkoutFormActions,
+  type WorkoutFormSectionApi,
   WorkoutMetadataFields,
 } from "@/features/workouts/components/form/workout-form-sections";
 import { useExerciseReorder } from "@/features/workouts/components/form/use-exercise-reorder";
 
-function WorkoutExerciseSection({ field, form }: { field: any; form: any }) {
+function WorkoutExerciseSection({
+  field,
+  form,
+}: {
+  field: WorkoutExerciseArrayField;
+  form: WorkoutFormSectionApi<WorkoutUpdateWorkoutRequest>;
+}) {
   const exerciseReorder = useExerciseReorder<WorkoutExerciseCard>(
-    field.state.value as WorkoutExerciseCard[],
+    field.state.value,
   );
 
   return (

--- a/client/src/features/workouts/pages/new-workout-page.tsx
+++ b/client/src/features/workouts/pages/new-workout-page.tsx
@@ -19,7 +19,10 @@ import {
 } from "@/components/error-boundary";
 import { ExerciseContextPanel } from "@/features/workouts/components/form/exercise-context-panel";
 import { LastWorkoutNoteSection } from "@/features/workouts/components/last-workout-note-section";
-import type { WorkoutNewWorkoutContextResponse } from "@/client";
+import type {
+  WorkoutCreateWorkoutRequest,
+  WorkoutNewWorkoutContextResponse,
+} from "@/client";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -48,8 +51,10 @@ import { RecentSets } from "@/features/workouts/components/form/recent-sets-disp
 import { shouldShowRecentFocusAreaCard } from "@/features/workouts/components/form/workout-form-helpers";
 import {
   WorkoutExerciseCards,
+  type WorkoutExerciseArrayField,
   type WorkoutExerciseCard,
   WorkoutFormActions,
+  type WorkoutFormSectionApi,
   WorkoutMetadataFields,
 } from "@/features/workouts/components/form/workout-form-sections";
 import { useExerciseReorder } from "@/features/workouts/components/form/use-exercise-reorder";
@@ -61,13 +66,13 @@ function WorkoutExerciseSection({
   formatVolume,
   renderExerciseGoalSummary,
 }: {
-  field: any;
-  form: any;
+  field: WorkoutExerciseArrayField;
+  form: WorkoutFormSectionApi<WorkoutCreateWorkoutRequest>;
   formatVolume: (value: number) => string;
   renderExerciseGoalSummary: (exercise: { name: string }) => ReactNode;
 }) {
   const exerciseReorder = useExerciseReorder<WorkoutExerciseCard>(
-    field.state.value as WorkoutExerciseCard[],
+    field.state.value,
   );
 
   return (


### PR DESCRIPTION
## Summary
- replace broad workout form seam any types with local TanStack form API aliases
- type the shared exercises array field used by new/edit workout reorder flows
- update the focused workout form test harness to use the typed seam

## Verification
- bun run test src/features/workouts/components/form/__tests__/workout-form-sections.test.tsx
- bun run tsc
- bun run lint
- bun run fmt:check