### PR TITLE
fix: serialize stripe billing webhook writes

### DIFF
--- a/server/internal/billing/repository.go
+++ b/server/internal/billing/repository.go
@@ -75,7 +75,7 @@ func (r *repository) UpsertStripeCustomer(ctx context.Context, userID string, st
 	}
 
 	qtx := r.queries.WithTx(tx)
-	_, err = qtx.GetUserByUserID(ctx, userID)
+	_, err = qtx.GetBillingUserForUpdate(ctx, userID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		r.logger.Info("ignored stripe customer event for deleted user", "user_id", userID, "stripe_customer_id", stripeCustomerID)
 		return db.StripeCustomers{}, ErrBillingAccountDeleted
@@ -121,7 +121,7 @@ func (r *repository) UpsertSubscriptionFromWebhook(ctx context.Context, snapshot
 	}
 
 	qtx := r.queries.WithTx(tx)
-	_, err = qtx.GetUserByUserID(ctx, snapshot.UserID)
+	_, err = qtx.GetBillingUserForUpdate(ctx, snapshot.UserID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		r.logger.Info("ignored stripe subscription event for deleted user", "user_id", snapshot.UserID, "stripe_subscription_id", snapshot.StripeSubscriptionID)
 		return db.StripeSubscriptions{}, ErrBillingAccountDeleted

--- a/server/internal/database/query.sql.go
+++ b/server/internal/database/query.sql.go
@@ -849,6 +849,20 @@ func (q *Queries) GetActiveAIChatRunForConversation(ctx context.Context, arg Get
 	return i, err
 }
 
+const getBillingUserForUpdate = `-- name: GetBillingUserForUpdate :one
+SELECT id, user_id, created_at
+FROM users
+WHERE user_id = $1
+FOR UPDATE
+`
+
+func (q *Queries) GetBillingUserForUpdate(ctx context.Context, userID string) (Users, error) {
+	row := q.db.QueryRow(ctx, getBillingUserForUpdate, userID)
+	var i Users
+	err := row.Scan(&i.ID, &i.UserID, &i.CreatedAt)
+	return i, err
+}
+
 const getContributionData = `-- name: GetContributionData :many
 WITH workout_totals AS (
     SELECT
@@ -2592,7 +2606,7 @@ func (q *Queries) MarkStripeWebhookEventProcessed(ctx context.Context, arg MarkS
 
 const revokeStripeFeatureAccess = `-- name: RevokeStripeFeatureAccess :exec
 UPDATE user_feature_access
-SET revoked_at = CURRENT_TIMESTAMP
+SET revoked_at = GREATEST(CURRENT_TIMESTAMP, starts_at)
 WHERE user_id = $1
   AND feature_key = $2
   AND source = 'stripe'

--- a/server/query.sql
+++ b/server/query.sql
@@ -490,6 +490,12 @@ SELECT user_id, stripe_customer_id, created_at, updated_at
 FROM stripe_customers
 WHERE stripe_customer_id = $1;
 
+-- name: GetBillingUserForUpdate :one
+SELECT id, user_id, created_at
+FROM users
+WHERE user_id = $1
+FOR UPDATE;
+
 -- name: UpsertStripeCustomer :one
 INSERT INTO stripe_customers (
     user_id,
@@ -608,7 +614,7 @@ ON CONFLICT (stripe_event_id) DO NOTHING;
 
 -- name: RevokeStripeFeatureAccess :exec
 UPDATE user_feature_access
-SET revoked_at = CURRENT_TIMESTAMP
+SET revoked_at = GREATEST(CURRENT_TIMESTAMP, starts_at)
 WHERE user_id = $1
   AND feature_key = $2
   AND source = 'stripe'


### PR DESCRIPTION
## Summary
- serialize Stripe billing writes per user before customer/subscription/grant updates
- keep Stripe feature revocation timestamps within the user_feature_access table invariant under concurrent webhooks
- regenerate sqlc query output for the new lock query and revoke timestamp update

## Why
PR 214 merged while the backend CI job was failing in TestServiceHandleWebhook_ConcurrentSameEventLeavesOneActiveStripeGrant. The PR diff was frontend-only, but the backend test exposed a race in duplicate Stripe webhook handling.

## Verification
- DATABASE_URL=postgresql://user:password@127.0.0.1:5432/postgres?sslmode=disable go test ./internal/billing -run TestServiceHandleWebhook_ConcurrentSameEventLeavesOneActiveStripeGrant -count=20 -v
- DATABASE_URL=postgresql://user:password@127.0.0.1:5432/postgres?sslmode=disable go test ./internal/billing -count=1
- DATABASE_URL=postgresql://user:password@127.0.0.1:5432/postgres?sslmode=disable go test -short ./...
- go vet ./...
- go build ./cmd/api
- DATABASE_URL=postgresql://user:password@127.0.0.1:5432/postgres?sslmode=disable go test ./... -count=1