### PR TITLE
fix: cap JSON request bodies

### DIFF
--- a/server/internal/exercise/handler.go
+++ b/server/internal/exercise/handler.go
@@ -124,7 +124,7 @@ func (h *ExerciseHandler) GetExerciseWithSets(w http.ResponseWriter, r *http.Req
 // @Router /exercises [post]
 func (h *ExerciseHandler) GetOrCreateExercise(w http.ResponseWriter, r *http.Request) {
 	var req CreateExerciseRequest
-	if err := decodeStrictJSON(r, &req); err != nil {
+	if err := decodeStrictJSON(w, r, &req); err != nil {
 		response.ErrorJSON(w, r, h.logger, http.StatusBadRequest, "Failed to decode request body", err)
 		return
 	}
@@ -280,7 +280,7 @@ func (h *ExerciseHandler) UpdateExerciseName(w http.ResponseWriter, r *http.Requ
 	}
 
 	var req UpdateExerciseNameRequest
-	if err := decodeStrictJSON(r, &req); err != nil {
+	if err := decodeStrictJSON(w, r, &req); err != nil {
 		response.ErrorJSON(w, r, h.logger, http.StatusBadRequest, "Failed to decode request body", err)
 		return
 	}

--- a/server/internal/exercise/handler_helpers.go
+++ b/server/internal/exercise/handler_helpers.go
@@ -1,15 +1,15 @@
 package exercise
 
 import (
-	"encoding/json"
-	"errors"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/Andrewy-gh/fittrack/server/internal/request"
 	"github.com/Andrewy-gh/fittrack/server/internal/response"
 )
+
+const maxExerciseJSONBodyBytes = 32 << 10
 
 func (h *ExerciseHandler) decodeExerciseID(w http.ResponseWriter, r *http.Request) (int32, bool) {
 	raw := strings.TrimSpace(r.PathValue("id"))
@@ -27,20 +27,6 @@ func (h *ExerciseHandler) decodeExerciseID(w http.ResponseWriter, r *http.Reques
 	return int32(parsed), true
 }
 
-func decodeStrictJSON(r *http.Request, dst any) error {
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(dst); err != nil {
-		return err
-	}
-
-	var extra any
-	if err := decoder.Decode(&extra); err != io.EOF {
-		if err != nil {
-			return err
-		}
-		return errors.New("request body must contain a single JSON value")
-	}
-
-	return nil
+func decodeStrictJSON(w http.ResponseWriter, r *http.Request, dst any) error {
+	return request.DecodeStrictJSON(w, r, dst, maxExerciseJSONBodyBytes)
 }

--- a/server/internal/exercise/handler_helpers_test.go
+++ b/server/internal/exercise/handler_helpers_test.go
@@ -2,6 +2,7 @@ package exercise
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -74,14 +75,47 @@ func TestExerciseHandler_decodeExerciseIDRejectsInvalidBoundaryValues(t *testing
 
 func TestDecodeStrictJSONRejectsTrailingJSON(t *testing.T) {
 	var req CreateExerciseRequest
+	w := httptest.NewRecorder()
 	httpReq := httptest.NewRequest(
 		http.MethodPost,
 		"/api/exercises",
 		strings.NewReader(`{"name":"Bench Press"}{"unexpected":true}`),
 	)
 
-	err := decodeStrictJSON(httpReq, &req)
+	err := decodeStrictJSON(w, httpReq, &req)
 
 	require.Error(t, err)
 	assert.Equal(t, CreateExerciseRequest{Name: "Bench Press"}, req)
+}
+
+func TestDecodeStrictJSONRejectsUnknownExerciseFields(t *testing.T) {
+	var req CreateExerciseRequest
+	w := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/exercises",
+		strings.NewReader(`{"name":"Bench Press","unexpected":true}`),
+	)
+
+	err := decodeStrictJSON(w, httpReq, &req)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown field "unexpected"`)
+}
+
+func TestDecodeStrictJSONRejectsOversizedExerciseJSON(t *testing.T) {
+	var req CreateExerciseRequest
+	w := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/exercises",
+		strings.NewReader(`{"name":"`+strings.Repeat("x", maxExerciseJSONBodyBytes)+`"}`),
+	)
+
+	err := decodeStrictJSON(w, httpReq, &req)
+
+	require.Error(t, err)
+	var maxBytesErr *http.MaxBytesError
+	assert.True(t, errors.As(err, &maxBytesErr))
+	assert.Equal(t, int64(maxExerciseJSONBodyBytes), maxBytesErr.Limit)
 }

--- a/server/internal/exercise/historical_1rm_http.go
+++ b/server/internal/exercise/historical_1rm_http.go
@@ -31,7 +31,7 @@ func (h *ExerciseHandler) UpdateExerciseHistorical1RM(w http.ResponseWriter, r *
 	}
 
 	var req UpdateExerciseHistorical1RMRequest
-	if err := decodeStrictJSON(r, &req); err != nil {
+	if err := decodeStrictJSON(w, r, &req); err != nil {
 		response.ErrorJSON(w, r, h.logger, http.StatusBadRequest, "Failed to decode request body", err)
 		return
 	}

--- a/server/internal/request/json.go
+++ b/server/internal/request/json.go
@@ -1,0 +1,27 @@
+package request
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+)
+
+// DecodeStrictJSON decodes a single app-owned JSON request body with a byte cap.
+func DecodeStrictJSON(w http.ResponseWriter, r *http.Request, dst any, maxBytes int64) error {
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err != nil {
+			return err
+		}
+		return errors.New("request body must contain a single JSON value")
+	}
+
+	return nil
+}

--- a/server/internal/workout/handler.go
+++ b/server/internal/workout/handler.go
@@ -203,7 +203,7 @@ func (h *WorkoutHandler) GetWorkoutWithSets(w http.ResponseWriter, r *http.Reque
 // @Router /workouts [post]
 func (h *WorkoutHandler) CreateWorkout(w http.ResponseWriter, r *http.Request) {
 	var req CreateWorkoutRequest
-	if err := decodeStrictJSON(r, &req); err != nil {
+	if err := decodeStrictJSON(w, r, &req); err != nil {
 		response.ErrorJSON(w, r, h.logger, http.StatusBadRequest, "failed to decode request body", err)
 		return
 	}
@@ -252,7 +252,7 @@ func (h *WorkoutHandler) UpdateWorkout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req UpdateWorkoutRequest
-	if err := decodeStrictJSON(r, &req); err != nil {
+	if err := decodeStrictJSON(w, r, &req); err != nil {
 		response.ErrorJSON(w, r, h.logger, http.StatusBadRequest, "failed to decode request body", err)
 		return
 	}

--- a/server/internal/workout/handler_helpers.go
+++ b/server/internal/workout/handler_helpers.go
@@ -1,15 +1,15 @@
 package workout
 
 import (
-	"encoding/json"
-	"errors"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/Andrewy-gh/fittrack/server/internal/request"
 	"github.com/Andrewy-gh/fittrack/server/internal/response"
 )
+
+const maxWorkoutJSONBodyBytes = 256 << 10
 
 func (h *WorkoutHandler) decodeWorkoutID(w http.ResponseWriter, r *http.Request) (int32, bool) {
 	raw := strings.TrimSpace(r.PathValue("id"))
@@ -27,20 +27,6 @@ func (h *WorkoutHandler) decodeWorkoutID(w http.ResponseWriter, r *http.Request)
 	return int32(parsed), true
 }
 
-func decodeStrictJSON(r *http.Request, dst any) error {
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(dst); err != nil {
-		return err
-	}
-
-	var extra any
-	if err := decoder.Decode(&extra); err != io.EOF {
-		if err != nil {
-			return err
-		}
-		return errors.New("request body must contain a single JSON value")
-	}
-
-	return nil
+func decodeStrictJSON(w http.ResponseWriter, r *http.Request, dst any) error {
+	return request.DecodeStrictJSON(w, r, dst, maxWorkoutJSONBodyBytes)
 }

--- a/server/internal/workout/handler_helpers_test.go
+++ b/server/internal/workout/handler_helpers_test.go
@@ -2,6 +2,7 @@ package workout
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -74,14 +75,47 @@ func TestWorkoutHandler_decodeWorkoutIDRejectsInvalidBoundaryValues(t *testing.T
 
 func TestDecodeStrictJSONRejectsTrailingJSON(t *testing.T) {
 	var req CreateWorkoutRequest
+	w := httptest.NewRecorder()
 	httpReq := httptest.NewRequest(
 		http.MethodPost,
 		"/api/workouts",
 		strings.NewReader(`{"date":"2023-01-15T10:00:00Z","exercises":[{"name":"Bench Press","sets":[{"reps":10,"setType":"working"}]}]}{"unexpected":true}`),
 	)
 
-	err := decodeStrictJSON(httpReq, &req)
+	err := decodeStrictJSON(w, httpReq, &req)
 
 	require.Error(t, err)
 	assert.Equal(t, "2023-01-15T10:00:00Z", req.Date)
+}
+
+func TestDecodeStrictJSONRejectsUnknownWorkoutFields(t *testing.T) {
+	var req CreateWorkoutRequest
+	w := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/workouts",
+		strings.NewReader(`{"date":"2023-01-15T10:00:00Z","exercises":[{"name":"Bench Press","sets":[{"reps":10,"setType":"working"}]}],"unexpected":true}`),
+	)
+
+	err := decodeStrictJSON(w, httpReq, &req)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown field "unexpected"`)
+}
+
+func TestDecodeStrictJSONRejectsOversizedWorkoutJSON(t *testing.T) {
+	var req CreateWorkoutRequest
+	w := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/workouts",
+		strings.NewReader(`{"date":"2023-01-15T10:00:00Z","notes":"`+strings.Repeat("x", maxWorkoutJSONBodyBytes)+`","exercises":[{"name":"Bench Press","sets":[{"reps":10,"setType":"working"}]}]}`),
+	)
+
+	err := decodeStrictJSON(w, httpReq, &req)
+
+	require.Error(t, err)
+	var maxBytesErr *http.MaxBytesError
+	assert.True(t, errors.As(err, &maxBytesErr))
+	assert.Equal(t, int64(maxWorkoutJSONBodyBytes), maxBytesErr.Limit)
 }


### PR DESCRIPTION
## Summary
- Add a shared strict JSON decoder for app-owned request bodies using http.MaxBytesReader.
- Route exercise JSON through a 32 KiB cap and workout JSON through a 256 KiB cap.
- Preserve unknown-field rejection and trailing JSON value rejection.

## Notes
- Stripe webhook handling remains separate because it verifies signed raw payload bytes and keeps its existing 1 MiB raw-body limit.
- AI chat request decoding is unchanged.

## Tests
- go test -short ./internal/exercise ./internal/workout ./internal/request ./internal/response
- go vet ./...
- git diff --check
- commit hook Go package tests passed

## Not run
- make test-short / pre-push hook: Docker Desktop was not listening, so the hook could not start postgres:16.2.