### PR TITLE
Add user training profile table

### DIFF
--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -143,6 +143,21 @@ type UserFeatureAccess struct {
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 }
 
+type UserTrainingProfile struct {
+	UserID                          string             `json:"user_id"`
+	PrimaryGoal                     pgtype.Text        `json:"primary_goal"`
+	ExperienceLevel                 pgtype.Text        `json:"experience_level"`
+	PreferredSessionDurationMinutes pgtype.Int4        `json:"preferred_session_duration_minutes"`
+	UsualTrainingLocation           pgtype.Text        `json:"usual_training_location"`
+	AvailableEquipment              []byte             `json:"available_equipment"`
+	AvoidedExercises                []byte             `json:"avoided_exercises"`
+	MovementLimitations             []byte             `json:"movement_limitations"`
+	SourceConversationID            pgtype.Int4        `json:"source_conversation_id"`
+	SourceMessageID                 pgtype.Int4        `json:"source_message_id"`
+	CreatedAt                       pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt                       pgtype.Timestamptz `json:"updated_at"`
+}
+
 type Users struct {
 	ID        int32              `json:"id"`
 	UserID    string             `json:"user_id"`

--- a/server/internal/database/user_training_profile_schema_test.go
+++ b/server/internal/database/user_training_profile_schema_test.go
@@ -1,0 +1,187 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Andrewy-gh/fittrack/server/internal/testutils"
+)
+
+func TestUserTrainingProfileSchemaAndRLS(t *testing.T) {
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, getTestDatabaseURL())
+	require.NoError(t, err)
+	defer pool.Close()
+
+	require.NoError(t, pool.Ping(ctx))
+	requireUserTrainingProfileTable(t, pool)
+
+	cleanupUserTrainingProfileTestData(t, pool)
+	defer cleanupUserTrainingProfileTestData(t, pool)
+
+	requireUserTrainingProfilePolicies(t, pool)
+
+	userA := "training-profile-test-user-a"
+	userB := "training-profile-test-user-b"
+	seedUserTrainingProfileTestUser(t, pool, userA)
+	seedUserTrainingProfileTestUser(t, pool, userB)
+
+	connA, err := pool.Acquire(ctx)
+	require.NoError(t, err)
+	defer connA.Release()
+	ctxA := testutils.SetTestUserContext(ctx, t, connA, userA)
+
+	_, err = connA.Exec(ctxA, `
+		INSERT INTO user_training_profile (
+			user_id,
+			primary_goal,
+			experience_level,
+			preferred_session_duration_minutes,
+			usual_training_location,
+			available_equipment,
+			avoided_exercises,
+			movement_limitations
+		) VALUES (
+			$1,
+			'strength',
+			'intermediate',
+			60,
+			'gym',
+			'["barbell", "dumbbells"]'::jsonb,
+			'["burpees"]'::jsonb,
+			'["sensitive knee"]'::jsonb
+		)
+	`, userA)
+	require.NoError(t, err)
+
+	var visibleToOwner int
+	err = connA.QueryRow(ctxA, "SELECT COUNT(*) FROM user_training_profile WHERE user_id = $1", userA).Scan(&visibleToOwner)
+	require.NoError(t, err)
+	require.Equal(t, 1, visibleToOwner)
+
+	assertUserTrainingProfileConstraintRejects(t, connA, ctxA, "unsupported primary goal", `
+		UPDATE user_training_profile
+		SET primary_goal = 'unsupported_goal'
+		WHERE user_id = $1
+	`, userA)
+	assertUserTrainingProfileConstraintRejects(t, connA, ctxA, "unsupported experience level", `
+		UPDATE user_training_profile
+		SET experience_level = 'expert'
+		WHERE user_id = $1
+	`, userA)
+	assertUserTrainingProfileConstraintRejects(t, connA, ctxA, "too-short duration", `
+		UPDATE user_training_profile
+		SET preferred_session_duration_minutes = 5
+		WHERE user_id = $1
+	`, userA)
+	assertUserTrainingProfileConstraintRejects(t, connA, ctxA, "non-array equipment", `
+		UPDATE user_training_profile
+		SET available_equipment = '{}'::jsonb
+		WHERE user_id = $1
+	`, userA)
+
+	if isCurrentDatabaseUserSuperuser(t, pool) {
+		t.Log("Skipping cross-user visibility assertion because PostgreSQL superusers bypass RLS")
+		return
+	}
+
+	connB, err := pool.Acquire(ctx)
+	require.NoError(t, err)
+	defer connB.Release()
+	ctxB := testutils.SetTestUserContext(ctx, t, connB, userB)
+
+	var visibleToOtherUser int
+	err = connB.QueryRow(ctxB, "SELECT COUNT(*) FROM user_training_profile WHERE user_id = $1", userA).Scan(&visibleToOtherUser)
+	require.NoError(t, err)
+	require.Equal(t, 0, visibleToOtherUser)
+}
+
+func requireUserTrainingProfileTable(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+
+	var exists bool
+	err := pool.QueryRow(context.Background(), "SELECT to_regclass('public.user_training_profile') IS NOT NULL").Scan(&exists)
+	require.NoError(t, err)
+	require.True(t, exists, "run database migrations before executing this test")
+}
+
+func requireUserTrainingProfilePolicies(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+
+	var rlsEnabled bool
+	err := pool.QueryRow(context.Background(), `
+		SELECT relrowsecurity
+		FROM pg_class
+		WHERE relname = 'user_training_profile'
+	`).Scan(&rlsEnabled)
+	require.NoError(t, err)
+	require.True(t, rlsEnabled)
+
+	var policyCount int
+	err = pool.QueryRow(context.Background(), `
+		SELECT COUNT(*)
+		FROM pg_policies
+		WHERE tablename = 'user_training_profile'
+		  AND policyname IN (
+			'user_training_profile_select_policy',
+			'user_training_profile_insert_policy',
+			'user_training_profile_update_policy',
+			'user_training_profile_delete_policy'
+		  )
+	`).Scan(&policyCount)
+	require.NoError(t, err)
+	require.Equal(t, 4, policyCount)
+}
+
+func seedUserTrainingProfileTestUser(t *testing.T, pool *pgxpool.Pool, userID string) {
+	t.Helper()
+
+	ctx := context.Background()
+	conn, err := pool.Acquire(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	ctx = testutils.SetTestUserContext(ctx, t, conn, userID)
+
+	_, err = conn.Exec(ctx, "INSERT INTO users (user_id) VALUES ($1) ON CONFLICT (user_id) DO NOTHING", userID)
+	require.NoError(t, err)
+}
+
+func assertUserTrainingProfileConstraintRejects(t *testing.T, db testutils.DBTX, ctx context.Context, name string, query string, userID string) {
+	t.Helper()
+
+	_, err := db.Exec(ctx, query, userID)
+	require.Error(t, err, name)
+}
+
+func isCurrentDatabaseUserSuperuser(t *testing.T, pool *pgxpool.Pool) bool {
+	t.Helper()
+
+	var isSuperuser bool
+	err := pool.QueryRow(context.Background(), "SELECT usesuper FROM pg_user WHERE usename = current_user").Scan(&isSuperuser)
+	require.NoError(t, err)
+	return isSuperuser
+}
+
+func cleanupUserTrainingProfileTestData(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+
+	for _, userID := range []string{"training-profile-test-user-a", "training-profile-test-user-b"} {
+		ctx := context.Background()
+		conn, err := pool.Acquire(ctx)
+		require.NoError(t, err)
+
+		ctx = testutils.SetTestUserContext(ctx, t, conn, userID)
+
+		_, err = conn.Exec(ctx, "DELETE FROM user_training_profile WHERE user_id = $1", userID)
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "DELETE FROM users WHERE user_id = $1", userID)
+		require.NoError(t, err)
+
+		conn.Release()
+	}
+}

--- a/server/internal/database/user_training_profile_schema_test.go
+++ b/server/internal/database/user_training_profile_schema_test.go
@@ -34,6 +34,19 @@ func TestUserTrainingProfileSchemaAndRLS(t *testing.T) {
 	defer connA.Release()
 	ctxA := testutils.SetTestUserContext(ctx, t, connA, userA)
 
+	sourceConversationA := insertUserTrainingProfileTestConversation(t, connA, ctxA, userA)
+	sourceMessageA := insertUserTrainingProfileTestMessage(t, connA, ctxA, userA, sourceConversationA)
+	otherConversationA := insertUserTrainingProfileTestConversation(t, connA, ctxA, userA)
+	otherMessageA := insertUserTrainingProfileTestMessage(t, connA, ctxA, userA, otherConversationA)
+
+	connB, err := pool.Acquire(ctx)
+	require.NoError(t, err)
+	defer connB.Release()
+	ctxB := testutils.SetTestUserContext(ctx, t, connB, userB)
+
+	sourceConversationB := insertUserTrainingProfileTestConversation(t, connB, ctxB, userB)
+	sourceMessageB := insertUserTrainingProfileTestMessage(t, connB, ctxB, userB, sourceConversationB)
+
 	_, err = connA.Exec(ctxA, `
 		INSERT INTO user_training_profile (
 			user_id,
@@ -43,7 +56,9 @@ func TestUserTrainingProfileSchemaAndRLS(t *testing.T) {
 			usual_training_location,
 			available_equipment,
 			avoided_exercises,
-			movement_limitations
+			movement_limitations,
+			source_conversation_id,
+			source_message_id
 		) VALUES (
 			$1,
 			'strength',
@@ -52,9 +67,11 @@ func TestUserTrainingProfileSchemaAndRLS(t *testing.T) {
 			'gym',
 			'["barbell", "dumbbells"]'::jsonb,
 			'["burpees"]'::jsonb,
-			'["sensitive knee"]'::jsonb
+			'["sensitive knee"]'::jsonb,
+			$2,
+			$3
 		)
-	`, userA)
+	`, userA, sourceConversationA, sourceMessageA)
 	require.NoError(t, err)
 
 	var visibleToOwner int
@@ -82,16 +99,29 @@ func TestUserTrainingProfileSchemaAndRLS(t *testing.T) {
 		SET available_equipment = '{}'::jsonb
 		WHERE user_id = $1
 	`, userA)
+	assertUserTrainingProfileConstraintRejects(t, connA, ctxA, "cross-user source conversation", `
+		UPDATE user_training_profile
+		SET source_conversation_id = $1,
+			source_message_id = NULL
+		WHERE user_id = $2
+	`, sourceConversationB, userA)
+	assertUserTrainingProfileConstraintRejects(t, connA, ctxA, "cross-user source message", `
+		UPDATE user_training_profile
+		SET source_conversation_id = $1,
+			source_message_id = $2
+		WHERE user_id = $3
+	`, sourceConversationA, sourceMessageB, userA)
+	assertUserTrainingProfileConstraintRejects(t, connA, ctxA, "same-user mismatched conversation and message", `
+		UPDATE user_training_profile
+		SET source_conversation_id = $1,
+			source_message_id = $2
+		WHERE user_id = $3
+	`, sourceConversationA, otherMessageA, userA)
 
 	if isCurrentDatabaseUserSuperuser(t, pool) {
 		t.Log("Skipping cross-user visibility assertion because PostgreSQL superusers bypass RLS")
 		return
 	}
-
-	connB, err := pool.Acquire(ctx)
-	require.NoError(t, err)
-	defer connB.Release()
-	ctxB := testutils.SetTestUserContext(ctx, t, connB, userB)
 
 	var visibleToOtherUser int
 	err = connB.QueryRow(ctxB, "SELECT COUNT(*) FROM user_training_profile WHERE user_id = $1", userA).Scan(&visibleToOtherUser)
@@ -150,10 +180,47 @@ func seedUserTrainingProfileTestUser(t *testing.T, pool *pgxpool.Pool, userID st
 	require.NoError(t, err)
 }
 
-func assertUserTrainingProfileConstraintRejects(t *testing.T, db testutils.DBTX, ctx context.Context, name string, query string, userID string) {
+func insertUserTrainingProfileTestConversation(t *testing.T, db testutils.DBTX, ctx context.Context, userID string) int32 {
 	t.Helper()
 
-	_, err := db.Exec(ctx, query, userID)
+	var conversationID int32
+	err := db.QueryRow(ctx, `
+		INSERT INTO ai_chat_conversation (user_id, title)
+		VALUES ($1, 'Training profile source test')
+		RETURNING id
+	`, userID).Scan(&conversationID)
+	require.NoError(t, err)
+	return conversationID
+}
+
+func insertUserTrainingProfileTestMessage(t *testing.T, db testutils.DBTX, ctx context.Context, userID string, conversationID int32) int32 {
+	t.Helper()
+
+	var messageID int32
+	err := db.QueryRow(ctx, `
+		INSERT INTO ai_chat_message (
+			conversation_id,
+			user_id,
+			role,
+			content,
+			status
+		) VALUES (
+			$1,
+			$2,
+			'user',
+			'Use this as durable training profile source context.',
+			'completed'
+		)
+		RETURNING id
+	`, conversationID, userID).Scan(&messageID)
+	require.NoError(t, err)
+	return messageID
+}
+
+func assertUserTrainingProfileConstraintRejects(t *testing.T, db testutils.DBTX, ctx context.Context, name string, query string, args ...interface{}) {
+	t.Helper()
+
+	_, err := db.Exec(ctx, query, args...)
 	require.Error(t, err, name)
 }
 

--- a/server/migrations/00024_create_user_training_profile.sql
+++ b/server/migrations/00024_create_user_training_profile.sql
@@ -1,5 +1,11 @@
 -- +goose Up
 -- +goose StatementBegin
+ALTER TABLE ai_chat_conversation
+ADD CONSTRAINT ai_chat_conversation_user_id_id_unique UNIQUE (user_id, id);
+
+ALTER TABLE ai_chat_message
+ADD CONSTRAINT ai_chat_message_user_conversation_id_unique UNIQUE (user_id, conversation_id, id);
+
 CREATE TABLE user_training_profile (
     user_id VARCHAR(256) PRIMARY KEY REFERENCES users(user_id) ON DELETE CASCADE,
     primary_goal VARCHAR(64),
@@ -9,8 +15,8 @@ CREATE TABLE user_training_profile (
     available_equipment JSONB NOT NULL DEFAULT '[]'::jsonb,
     avoided_exercises JSONB NOT NULL DEFAULT '[]'::jsonb,
     movement_limitations JSONB NOT NULL DEFAULT '[]'::jsonb,
-    source_conversation_id INTEGER REFERENCES ai_chat_conversation(id) ON DELETE SET NULL,
-    source_message_id INTEGER REFERENCES ai_chat_message(id) ON DELETE SET NULL,
+    source_conversation_id INTEGER,
+    source_message_id INTEGER,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT user_training_profile_primary_goal_valid CHECK (
@@ -53,7 +59,23 @@ CREATE TABLE user_training_profile (
     ),
     CONSTRAINT user_training_profile_source_message_requires_conversation CHECK (
         source_message_id IS NULL OR source_conversation_id IS NOT NULL
-    )
+    ),
+    CONSTRAINT user_training_profile_source_conversation_owner_fk FOREIGN KEY (
+        user_id,
+        source_conversation_id
+    ) REFERENCES ai_chat_conversation (
+        user_id,
+        id
+    ) ON DELETE SET NULL (source_conversation_id),
+    CONSTRAINT user_training_profile_source_message_owner_conversation_fk FOREIGN KEY (
+        user_id,
+        source_conversation_id,
+        source_message_id
+    ) REFERENCES ai_chat_message (
+        user_id,
+        conversation_id,
+        id
+    ) ON DELETE SET NULL (source_message_id)
 );
 
 ALTER TABLE user_training_profile ENABLE ROW LEVEL SECURITY;
@@ -90,4 +112,10 @@ ALTER TABLE user_training_profile DISABLE ROW LEVEL SECURITY;
 REVOKE ALL ON user_training_profile FROM PUBLIC;
 
 DROP TABLE IF EXISTS user_training_profile;
+
+ALTER TABLE ai_chat_message
+DROP CONSTRAINT IF EXISTS ai_chat_message_user_conversation_id_unique;
+
+ALTER TABLE ai_chat_conversation
+DROP CONSTRAINT IF EXISTS ai_chat_conversation_user_id_id_unique;
 -- +goose StatementEnd

--- a/server/migrations/00024_create_user_training_profile.sql
+++ b/server/migrations/00024_create_user_training_profile.sql
@@ -6,6 +6,8 @@ ADD CONSTRAINT ai_chat_conversation_user_id_id_unique UNIQUE (user_id, id);
 ALTER TABLE ai_chat_message
 ADD CONSTRAINT ai_chat_message_user_conversation_id_unique UNIQUE (user_id, conversation_id, id);
 
+DROP INDEX IF EXISTS idx_ai_chat_message_user_conversation;
+
 CREATE TABLE user_training_profile (
     user_id VARCHAR(256) PRIMARY KEY REFERENCES users(user_id) ON DELETE CASCADE,
     primary_goal VARCHAR(64),
@@ -115,6 +117,9 @@ DROP TABLE IF EXISTS user_training_profile;
 
 ALTER TABLE ai_chat_message
 DROP CONSTRAINT IF EXISTS ai_chat_message_user_conversation_id_unique;
+
+CREATE INDEX IF NOT EXISTS idx_ai_chat_message_user_conversation
+    ON ai_chat_message (user_id, conversation_id, id ASC);
 
 ALTER TABLE ai_chat_conversation
 DROP CONSTRAINT IF EXISTS ai_chat_conversation_user_id_id_unique;

--- a/server/migrations/00024_create_user_training_profile.sql
+++ b/server/migrations/00024_create_user_training_profile.sql
@@ -1,0 +1,93 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE user_training_profile (
+    user_id VARCHAR(256) PRIMARY KEY REFERENCES users(user_id) ON DELETE CASCADE,
+    primary_goal VARCHAR(64),
+    experience_level VARCHAR(32),
+    preferred_session_duration_minutes INTEGER,
+    usual_training_location VARCHAR(64),
+    available_equipment JSONB NOT NULL DEFAULT '[]'::jsonb,
+    avoided_exercises JSONB NOT NULL DEFAULT '[]'::jsonb,
+    movement_limitations JSONB NOT NULL DEFAULT '[]'::jsonb,
+    source_conversation_id INTEGER REFERENCES ai_chat_conversation(id) ON DELETE SET NULL,
+    source_message_id INTEGER REFERENCES ai_chat_message(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT user_training_profile_primary_goal_valid CHECK (
+        primary_goal IS NULL OR primary_goal IN (
+            'strength',
+            'hypertrophy',
+            'endurance',
+            'general_fitness',
+            'weight_loss',
+            'mobility'
+        )
+    ),
+    CONSTRAINT user_training_profile_experience_level_valid CHECK (
+        experience_level IS NULL OR experience_level IN (
+            'beginner',
+            'intermediate',
+            'advanced'
+        )
+    ),
+    CONSTRAINT user_training_profile_duration_bounds CHECK (
+        preferred_session_duration_minutes IS NULL
+        OR preferred_session_duration_minutes BETWEEN 10 AND 240
+    ),
+    CONSTRAINT user_training_profile_location_valid CHECK (
+        usual_training_location IS NULL OR usual_training_location IN (
+            'gym',
+            'home',
+            'outdoor',
+            'travel'
+        )
+    ),
+    CONSTRAINT user_training_profile_available_equipment_array CHECK (
+        jsonb_typeof(available_equipment) = 'array'
+    ),
+    CONSTRAINT user_training_profile_avoided_exercises_array CHECK (
+        jsonb_typeof(avoided_exercises) = 'array'
+    ),
+    CONSTRAINT user_training_profile_movement_limitations_array CHECK (
+        jsonb_typeof(movement_limitations) = 'array'
+    ),
+    CONSTRAINT user_training_profile_source_message_requires_conversation CHECK (
+        source_message_id IS NULL OR source_conversation_id IS NOT NULL
+    )
+);
+
+ALTER TABLE user_training_profile ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY user_training_profile_select_policy ON user_training_profile
+    FOR SELECT TO PUBLIC
+    USING (user_id = current_user_id());
+
+CREATE POLICY user_training_profile_insert_policy ON user_training_profile
+    FOR INSERT TO PUBLIC
+    WITH CHECK (user_id = current_user_id());
+
+CREATE POLICY user_training_profile_update_policy ON user_training_profile
+    FOR UPDATE TO PUBLIC
+    USING (user_id = current_user_id())
+    WITH CHECK (user_id = current_user_id());
+
+CREATE POLICY user_training_profile_delete_policy ON user_training_profile
+    FOR DELETE TO PUBLIC
+    USING (user_id = current_user_id());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON user_training_profile TO PUBLIC;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP POLICY IF EXISTS user_training_profile_delete_policy ON user_training_profile;
+DROP POLICY IF EXISTS user_training_profile_update_policy ON user_training_profile;
+DROP POLICY IF EXISTS user_training_profile_insert_policy ON user_training_profile;
+DROP POLICY IF EXISTS user_training_profile_select_policy ON user_training_profile;
+
+ALTER TABLE user_training_profile DISABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON user_training_profile FROM PUBLIC;
+
+DROP TABLE IF EXISTS user_training_profile;
+-- +goose StatementEnd

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -172,6 +172,62 @@ CREATE TABLE ai_chat_stream_chunk (
     CONSTRAINT ai_chat_stream_chunk_delta_not_empty CHECK (btrim(delta_text) <> '')
 );
 
+CREATE TABLE user_training_profile (
+    user_id VARCHAR(256) PRIMARY KEY REFERENCES users(user_id) ON DELETE CASCADE,
+    primary_goal VARCHAR(64),
+    experience_level VARCHAR(32),
+    preferred_session_duration_minutes INTEGER,
+    usual_training_location VARCHAR(64),
+    available_equipment JSONB NOT NULL DEFAULT '[]'::jsonb,
+    avoided_exercises JSONB NOT NULL DEFAULT '[]'::jsonb,
+    movement_limitations JSONB NOT NULL DEFAULT '[]'::jsonb,
+    source_conversation_id INTEGER REFERENCES ai_chat_conversation(id) ON DELETE SET NULL,
+    source_message_id INTEGER REFERENCES ai_chat_message(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT user_training_profile_primary_goal_valid CHECK (
+        primary_goal IS NULL OR primary_goal IN (
+            'strength',
+            'hypertrophy',
+            'endurance',
+            'general_fitness',
+            'weight_loss',
+            'mobility'
+        )
+    ),
+    CONSTRAINT user_training_profile_experience_level_valid CHECK (
+        experience_level IS NULL OR experience_level IN (
+            'beginner',
+            'intermediate',
+            'advanced'
+        )
+    ),
+    CONSTRAINT user_training_profile_duration_bounds CHECK (
+        preferred_session_duration_minutes IS NULL
+        OR preferred_session_duration_minutes BETWEEN 10 AND 240
+    ),
+    CONSTRAINT user_training_profile_location_valid CHECK (
+        usual_training_location IS NULL OR usual_training_location IN (
+            'gym',
+            'home',
+            'outdoor',
+            'travel'
+        )
+    ),
+    CONSTRAINT user_training_profile_available_equipment_array CHECK (
+        jsonb_typeof(available_equipment) = 'array'
+    ),
+    CONSTRAINT user_training_profile_avoided_exercises_array CHECK (
+        jsonb_typeof(avoided_exercises) = 'array'
+    ),
+    CONSTRAINT user_training_profile_movement_limitations_array CHECK (
+        jsonb_typeof(movement_limitations) = 'array'
+    ),
+    CONSTRAINT user_training_profile_source_message_requires_conversation CHECK (
+        source_message_id IS NULL OR source_conversation_id IS NOT NULL
+    )
+);
+
 -- Workouts table
 CREATE TABLE workout (
     id SERIAL PRIMARY KEY,

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -302,7 +302,6 @@ CREATE INDEX idx_stripe_subscriptions_user_updated ON stripe_subscriptions(user_
 CREATE INDEX idx_stripe_subscriptions_customer ON stripe_subscriptions(stripe_customer_id);
 CREATE INDEX idx_ai_chat_conversation_user_updated ON ai_chat_conversation(user_id, updated_at DESC, id DESC);
 CREATE INDEX idx_ai_chat_message_conversation ON ai_chat_message(conversation_id, id ASC);
-CREATE INDEX idx_ai_chat_message_user_conversation ON ai_chat_message(user_id, conversation_id, id ASC);
 CREATE INDEX idx_ai_chat_run_conversation_created ON ai_chat_run(conversation_id, created_at DESC, id DESC);
 CREATE UNIQUE INDEX idx_ai_chat_run_active_conversation ON ai_chat_run(conversation_id) WHERE status = 'streaming';
 CREATE INDEX idx_ai_chat_stream_chunk_user_run_sequence ON ai_chat_stream_chunk(user_id, run_id, sequence ASC);

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -86,7 +86,8 @@ CREATE TABLE ai_chat_conversation (
     last_message_at TIMESTAMPTZ,
     CONSTRAINT ai_chat_conversation_title_not_empty CHECK (
         title IS NULL OR btrim(title) <> ''
-    )
+    ),
+    CONSTRAINT ai_chat_conversation_user_id_id_unique UNIQUE (user_id, id)
 );
 
 -- AI chat messages table
@@ -109,7 +110,8 @@ CREATE TABLE ai_chat_message (
     ),
     CONSTRAINT ai_chat_message_error_not_empty CHECK (
         error_message IS NULL OR btrim(error_message) <> ''
-    )
+    ),
+    CONSTRAINT ai_chat_message_user_conversation_id_unique UNIQUE (user_id, conversation_id, id)
 );
 
 -- AI chat runs table
@@ -181,8 +183,8 @@ CREATE TABLE user_training_profile (
     available_equipment JSONB NOT NULL DEFAULT '[]'::jsonb,
     avoided_exercises JSONB NOT NULL DEFAULT '[]'::jsonb,
     movement_limitations JSONB NOT NULL DEFAULT '[]'::jsonb,
-    source_conversation_id INTEGER REFERENCES ai_chat_conversation(id) ON DELETE SET NULL,
-    source_message_id INTEGER REFERENCES ai_chat_message(id) ON DELETE SET NULL,
+    source_conversation_id INTEGER,
+    source_message_id INTEGER,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT user_training_profile_primary_goal_valid CHECK (
@@ -225,7 +227,23 @@ CREATE TABLE user_training_profile (
     ),
     CONSTRAINT user_training_profile_source_message_requires_conversation CHECK (
         source_message_id IS NULL OR source_conversation_id IS NOT NULL
-    )
+    ),
+    CONSTRAINT user_training_profile_source_conversation_owner_fk FOREIGN KEY (
+        user_id,
+        source_conversation_id
+    ) REFERENCES ai_chat_conversation (
+        user_id,
+        id
+    ) ON DELETE SET NULL (source_conversation_id),
+    CONSTRAINT user_training_profile_source_message_owner_conversation_fk FOREIGN KEY (
+        user_id,
+        source_conversation_id,
+        source_message_id
+    ) REFERENCES ai_chat_message (
+        user_id,
+        conversation_id,
+        id
+    ) ON DELETE SET NULL (source_message_id)
 );
 
 -- Workouts table


### PR DESCRIPTION
## Summary
- add user_training_profile as a one-row-per-user table for durable AI training preferences
- constrain known profile values, session duration bounds, JSONB array fields, and optional source message metadata
- add user-owned RLS policies and sqlc model plumbing
- add a focused DB regression for schema constraints and RLS visibility

## Tests
- goose -dir migrations validate
- goose -dir migrations postgres "$env:DATABASE_URL" up
- go test ./internal/database -run TestUserTrainingProfileSchemaAndRLS -count=1
- go test -short ./...
- go vet ./...
- go build ./cmd/api
- git push pre-push hook: make test-short

## Reviewer Notes
- No API endpoints are included in this slice; this only adds the durable storage primitive and generated DB model.
- Existing unrelated local changes in AGENTS.md, .codex/, and server/cmd/api/dist/ were left out of the commit.
