### PR TITLE
AI chat data Q&A over logged workouts (Phase 1)

### DIFF
--- a/server/cmd/ai-chat-scenario-sweep/main.go
+++ b/server/cmd/ai-chat-scenario-sweep/main.go
@@ -32,6 +32,7 @@ func main() {
 	scenarioIDs := flag.String("scenarios", "", "run comma-separated scenario ids from the default pack, for example prompt-03,prompt-04")
 	fromID := flag.String("from", "", "run an inclusive scenario id range starting at this id")
 	toID := flag.String("to", "", "run an inclusive scenario id range ending at this id")
+	withDataFixtures := flag.Bool("with-data-fixtures", false, "include AI chat data Q&A scenarios backed by in-memory workout fixtures")
 	flag.Parse()
 	if err := aichateval.ValidateMode(*mode); err != nil {
 		fail("%v", err)
@@ -42,7 +43,15 @@ func main() {
 	if *scenarioDelay < 0 {
 		fail("scenario-delay must be zero or greater")
 	}
-	scenarios, err := aichateval.FilterScenarios(aichateval.DefaultScenarios(), aichateval.ScenarioSelection{
+	scenarios := aichateval.DefaultScenarios()
+	var dataReader aichat.ChatDataReader
+	evalUserID := ""
+	if *withDataFixtures {
+		dataReader = aichateval.NewFixtureChatDataReader()
+		evalUserID = aichateval.FixtureUserID
+		scenarios = append(scenarios, aichateval.DataFixtureScenarios()...)
+	}
+	scenarios, err := aichateval.FilterScenarios(scenarios, aichateval.ScenarioSelection{
 		ScenarioID:  *scenarioID,
 		ScenarioIDs: *scenarioIDs,
 		FromID:      *fromID,
@@ -63,7 +72,7 @@ func main() {
 	runtimeCtx, cancel := context.WithTimeout(context.Background(), *timeout)
 	defer cancel()
 
-	runtime := aichat.NewGenkitRuntime(runtimeCtx)
+	runtime := aichat.NewGenkitRuntime(runtimeCtx, dataReader)
 	if !runtime.Available() {
 		fail("ai chat runtime unavailable. Set GEMINI_API_KEY or GOOGLE_API_KEY in your shell, server/.env, or server/setenv.sh")
 	}
@@ -71,6 +80,7 @@ func main() {
 	report := aichateval.Run(runtimeCtx, runtime, scenarios, aichateval.RunOptions{
 		Mode:               *mode,
 		InterScenarioDelay: selectedScenarioDelay(*scenarioDelay, len(scenarios)),
+		UserID:             evalUserID,
 		OnScenario: func(item aichateval.Scenario) {
 			fmt.Fprintf(os.Stderr, "Running %s: %s\n", item.ID, item.Title)
 		},

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -188,7 +188,7 @@ func main() {
 	accountService := account.NewService(logger, accountRepo, billingService)
 	userService := user.NewService(logger, userRepo)
 	aiChatRepo := aichat.NewRepository(logger, queries, pool, cfg.AIChatTrialPromptCap)
-	aiChatRuntime := aichat.NewGenkitRuntime(ctx)
+	aiChatRuntime := aichat.NewGenkitRuntime(ctx, aiChatRepo)
 	aiChatService := aichat.NewService(logger, featureAccessService, aiChatRuntime, aiChatRepo, workoutTxSaver)
 	var inngestRecovery *aichat.InngestRecovery
 	switch {

--- a/server/evals/baselines/2026-07-07-d310b20-gemini-2.5-flash/README.md
+++ b/server/evals/baselines/2026-07-07-d310b20-gemini-2.5-flash/README.md
@@ -1,0 +1,113 @@
+# AI Chat Eval Baseline - 2026-07-07 d310b20
+
+Official Phase 1 baseline for the AI chat scenario sweep on commit `d310b20f326ed8016e1c4d6321a4d29768a252ae` (`d310b20`).
+
+## Run Metadata
+
+- Date: 2026-07-07
+- Model: `googleai/gemini-2.5-flash`
+- Mode: `two_turn`
+- Default scenario set: 19 scenarios
+- Fixture scenario set: 27 scenarios with `-with-data-fixtures`
+- Server precondition: `git status --porcelain -- server/` was empty before the sweeps.
+- Working tree note: unrelated uncommitted files existed under `client/`; they were not touched.
+- Sweep ledger path: `server/tmp/ai-chat-scenario-sweeps/fittrack-ai-chat-scenario-sweep-runs.jsonl`
+- Temporary reports:
+  - `server/tmp/ai-chat-scenario-sweeps/baseline-two-turn-d310b20.json`
+  - `server/tmp/ai-chat-scenario-sweeps/fixtures-two-turn-d310b20.json`
+
+## Commands
+
+Run from `server/`:
+
+```powershell
+$env:FITTRACK_AI_CHAT_SWEEP_OUT='tmp/ai-chat-scenario-sweeps/baseline-two-turn-d310b20.json'; go run ./cmd/ai-chat-scenario-sweep -mode two_turn -scenario-delay 30s -timeout 45m
+```
+
+```powershell
+$env:FITTRACK_AI_CHAT_SWEEP_OUT='tmp/ai-chat-scenario-sweeps/fixtures-two-turn-d310b20.json'; go run ./cmd/ai-chat-scenario-sweep -mode two_turn -with-data-fixtures -scenario-delay 30s -timeout 60m
+```
+
+## Summary
+
+| Sweep | Pass | Fail | Unscored | Operational errors |
+| --- | ---: | ---: | ---: | ---: |
+| `baseline-two-turn.json` | 16 | 3 | 0 | 0 |
+| `fixtures-two-turn.json` | 24 | 3 | 0 | 0 |
+
+No operational-error reruns were needed.
+
+## Default Two-Turn Results
+
+| id | score_status | reason for non-pass |
+| --- | --- | --- |
+| prompt-01 | pass |  |
+| prompt-02 | pass |  |
+| prompt-03 | fail | assistant behavior ended in an error before meeting the expected outcome |
+| prompt-04 | pass |  |
+| prompt-05 | pass |  |
+| prompt-06 | pass |  |
+| prompt-07 | pass |  |
+| prompt-08 | pass |  |
+| prompt-09 | pass |  |
+| prompt-10 | pass |  |
+| prompt-11 | pass |  |
+| prompt-12 | pass |  |
+| prompt-13 | fail | expected the second turn to generate a structured draft |
+| prompt-14 | pass |  |
+| prompt-15 | pass |  |
+| prompt-16 | pass |  |
+| prompt-17 | pass |  |
+| prompt-18 | fail | expected the first turn to ask the user to choose one workout or session |
+| prompt-19 | pass |  |
+
+## Fixture Two-Turn Results
+
+| id | score_status | reason for non-pass |
+| --- | --- | --- |
+| prompt-01 | pass |  |
+| prompt-02 | pass |  |
+| prompt-03 | fail | assistant behavior ended in an error before meeting the expected outcome |
+| prompt-04 | pass |  |
+| prompt-05 | pass |  |
+| prompt-06 | pass |  |
+| prompt-07 | pass |  |
+| prompt-08 | pass |  |
+| prompt-09 | fail | expected one follow-up question before generating |
+| prompt-10 | pass |  |
+| prompt-11 | pass |  |
+| prompt-12 | pass |  |
+| prompt-13 | pass |  |
+| prompt-14 | pass |  |
+| prompt-15 | pass |  |
+| prompt-16 | pass |  |
+| prompt-17 | pass |  |
+| prompt-18 | fail | expected the first turn to ask the user to choose one workout or session |
+| prompt-19 | pass |  |
+| data-01 | pass |  |
+| data-02 | pass |  |
+| data-03 | pass |  |
+| data-04 | pass |  |
+| data-05 | pass |  |
+| data-06 | pass |  |
+| data-07 | pass |  |
+| data-08 | pass |  |
+
+## Spliced Reruns
+
+None. Both full sweeps completed with `operational_error_count: 0`.
+
+## Known Noise And Current Failure Labels
+
+- `prompt-18` failed in both sweeps. This matches the historical consistent failure and is not treated as a desired behavior contract.
+- `prompt-13` failed only in the default sweep after an empty-response retry warning and a null text-only second turn. Label this as flaky model/provider output for this run, not a Phase 1 contract.
+- `prompt-14` passed in both sweeps; the historical flakiness did not appear in this baseline.
+- `prompt-16` passed in both sweeps; the historical occasional draft-model hallucination did not appear in this baseline.
+- `prompt-03` failed in both sweeps with a scored `error` status, not an `operational_error`: the inner draft model chose "Goblet Squat" despite the knee-pain context and the workout quality validator rejected it after the repair retry. This is the same pre-existing inner-draft-model quality flakiness class as the historical `prompt-16` hallucination; that code path was not modified in this commit.
+- `prompt-09` failed only in the fixture sweep by generating immediately instead of asking one follow-up question. Treat it as a current baseline failure unless later evidence proves it is pre-existing noise.
+
+## Run Anomalies
+
+- Default sweep: one retry-guard warning on `prompt-13` for an empty response with no tool activity.
+- Fixture sweep: retry-guard warnings on `prompt-05` and `prompt-11` for empty responses with no tool activity.
+- No rate-limit wave was observed in command output.

--- a/server/evals/baselines/2026-07-07-d310b20-gemini-2.5-flash/baseline-two-turn.json
+++ b/server/evals/baselines/2026-07-07-d310b20-gemini-2.5-flash/baseline-two-turn.json
@@ -1,0 +1,3755 @@
+{
+  "generated_at": "2026-07-07T21:17:37Z",
+  "mode": "two_turn",
+  "model": "googleai/gemini-2.5-flash",
+  "scenario_count": 19,
+  "summary": {
+    "total_scenarios": 19,
+    "structured_draft_count": 15,
+    "follow_up_question_count": 1,
+    "text_only_count": 2,
+    "error_count": 1,
+    "passed_count": 16,
+    "failed_count": 3,
+    "operational_error_count": 0,
+    "unscored_count": 0,
+    "pass_rate": 0.8421052631578947,
+    "structured_output_conversion_rate": 0.7894736842105263,
+    "two_turn_follow_up_count": 13,
+    "two_turn_attempt_count": 13,
+    "two_turn_structured_draft_count": 10,
+    "two_turn_conversion_rate": 0.7692307692307693
+  },
+  "results": [
+    {
+      "id": "prompt-01",
+      "title": "Home Dumbbell Pull",
+      "prompt": "I've got 45 minutes at home with just adjustable dumbbells and a bench. Give me a pull workout.",
+      "expectation": "Should ideally generate a structured draft with realistic dumbbell-and-bench pull volume.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "No injuries. I'm intermediate and want muscle growth.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 9929,
+      "draft": {
+        "date": "2026-07-07T17:05:13-04:00",
+        "notes": "Focus on controlled movements and feeling the muscle work. Rest 60-90 seconds between working sets.",
+        "workoutFocus": "Pull",
+        "exercises": [
+          {
+            "name": "Dumbbell Row",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Chest-Supported Dumbbell Reverse Fly",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Bicep Curl",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Hammer Curl",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 13,
+        "working_sets": 12,
+        "exercise_names": [
+          "Dumbbell Row",
+          "Chest-Supported Dumbbell Reverse Fly",
+          "Dumbbell Bicep Curl",
+          "Dumbbell Hammer Curl"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "I've got 45 minutes at home with just adjustable dumbbells and a bench. Give me a pull workout.",
+          "status": "follow_up_question",
+          "text": "Do you have any injuries I should know about?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1182,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No injuries. I'm intermediate and want muscle growth.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 8747,
+          "draft": {
+            "date": "2026-07-07T17:05:13-04:00",
+            "notes": "Focus on controlled movements and feeling the muscle work. Rest 60-90 seconds between working sets.",
+            "workoutFocus": "Pull",
+            "exercises": [
+              {
+                "name": "Dumbbell Row",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Chest-Supported Dumbbell Reverse Fly",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Bicep Curl",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Hammer Curl",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 13,
+            "working_sets": 12,
+            "exercise_names": [
+              "Dumbbell Row",
+              "Chest-Supported Dumbbell Reverse Fly",
+              "Dumbbell Bicep Curl",
+              "Dumbbell Hammer Curl"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-02",
+      "title": "Commercial Gym Hypertrophy Legs",
+      "prompt": "I want a 60-minute hypertrophy leg workout at a commercial gym.",
+      "expectation": "Should ask about injuries first or generate only if it can proceed after asking once; when it generates the draft should feel full enough for 60 minutes.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "No injuries. I'm intermediate, and hypertrophy is the goal.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "Here is a 60-minute leg hypertrophy workout draft for you. Remember to focus on controlled movements and 60-90 second rests between working sets.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 9663,
+      "draft": {
+        "date": "2026-07-07T17:05:53-04:00",
+        "notes": "Focus on controlled movements and 60-90 second rests between working sets for hypertrophy.",
+        "workoutFocus": "Leg Hypertrophy",
+        "exercises": [
+          {
+            "name": "Barbell Back Squat",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Leg Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Lying Leg Curl",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Leg Extension",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 14,
+        "working_sets": 12,
+        "exercise_names": [
+          "Barbell Back Squat",
+          "Leg Press",
+          "Lying Leg Curl",
+          "Leg Extension"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "I want a 60-minute hypertrophy leg workout at a commercial gym.",
+          "status": "follow_up_question",
+          "text": "Do you have any injuries I should be aware of for this workout?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1131,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No injuries. I'm intermediate, and hypertrophy is the goal.",
+          "status": "structured_draft",
+          "text": "Here is a 60-minute leg hypertrophy workout draft for you. Remember to focus on controlled movements and 60-90 second rests between working sets.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 8532,
+          "draft": {
+            "date": "2026-07-07T17:05:53-04:00",
+            "notes": "Focus on controlled movements and 60-90 second rests between working sets for hypertrophy.",
+            "workoutFocus": "Leg Hypertrophy",
+            "exercises": [
+              {
+                "name": "Barbell Back Squat",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Leg Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Lying Leg Curl",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Leg Extension",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 14,
+            "working_sets": 12,
+            "exercise_names": [
+              "Barbell Back Squat",
+              "Leg Press",
+              "Lying Leg Curl",
+              "Leg Extension"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-03",
+      "title": "Lower Body With Knee Pain",
+      "prompt": "I have knee pain. Build me a lower-body workout.",
+      "expectation": "Should gather missing readiness info first and avoid obvious knee-aggravating exercise choices if it generates.",
+      "expected_outcome": "ask_once_then_generate",
+      "forbidden_exercise_terms": [
+        "leg press"
+      ],
+      "follow_up_answer": "It's mild front-of-knee discomfort, no sharp pain. Keep it joint-friendly, 35 minutes, dumbbells and machines are available.",
+      "status": "error",
+      "passed": false,
+      "score_status": "fail",
+      "score_reason": "assistant behavior ended in an error before meeting the expected outcome",
+      "error": "stream ai chat response: tool \"generate_workout_draft\" failed: error calling tool generate_workout_draft: validate workout draft quality after repair retry: \"Goblet Squat\" conflicts with the reported injury context",
+      "duration_ms": 19236,
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "I have knee pain. Build me a lower-body workout.",
+          "status": "follow_up_question",
+          "text": "I can help with a lower-body workout, but first, I need a few more details to make sure it's safe and effective for your knee.\n\n1.  How long is your session duration?\n2.  What equipment do you have available, or where will you be training?\n3.  Could you describe your knee pain? For example, is it sharp, dull, specific to certain movements, or constant?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1619,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "It's mild front-of-knee discomfort, no sharp pain. Keep it joint-friendly, 35 minutes, dumbbells and machines are available.",
+          "status": "error",
+          "error": "stream ai chat response: tool \"generate_workout_draft\" failed: error calling tool generate_workout_draft: validate workout draft quality after repair retry: \"Goblet Squat\" conflicts with the reported injury context",
+          "duration_ms": 17617,
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-04",
+      "title": "Hotel Room No Equipment",
+      "prompt": "Hotel room, 25 minutes, no equipment, full body.",
+      "expectation": "Should ask about injuries first or generate a concise feasible hotel-room bodyweight draft.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "No injuries. I'm beginner to intermediate and want a balanced full-body session.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "Here is a 25-minute full-body workout draft for your hotel room, with no equipment, focusing on general fitness.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 9445,
+      "draft": {
+        "date": "2026-07-07T17:07:22-04:00",
+        "notes": "Focus on controlled movements and good form. Rest 60-90 seconds between sets. For Incline Push-ups, use a sturdy surface like a bed or desk.",
+        "workoutFocus": "Full Body",
+        "exercises": [
+          {
+            "name": "Bodyweight Squat",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Incline Push-up",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Reverse Lunge",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Plank",
+            "sets": [
+              {
+                "reps": 40,
+                "setType": "working"
+              },
+              {
+                "reps": 40,
+                "setType": "working"
+              },
+              {
+                "reps": 40,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 12,
+        "working_sets": 12,
+        "exercise_names": [
+          "Bodyweight Squat",
+          "Incline Push-up",
+          "Reverse Lunge",
+          "Plank"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Hotel room, 25 minutes, no equipment, full body.",
+          "status": "follow_up_question",
+          "text": "Do you have any injuries I should be aware of?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1021,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No injuries. I'm beginner to intermediate and want a balanced full-body session.",
+          "status": "structured_draft",
+          "text": "Here is a 25-minute full-body workout draft for your hotel room, with no equipment, focusing on general fitness.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 8424,
+          "draft": {
+            "date": "2026-07-07T17:07:22-04:00",
+            "notes": "Focus on controlled movements and good form. Rest 60-90 seconds between sets. For Incline Push-ups, use a sturdy surface like a bed or desk.",
+            "workoutFocus": "Full Body",
+            "exercises": [
+              {
+                "name": "Bodyweight Squat",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Incline Push-up",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Reverse Lunge",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Plank",
+                "sets": [
+                  {
+                    "reps": 40,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 40,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 40,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 12,
+            "working_sets": 12,
+            "exercise_names": [
+              "Bodyweight Squat",
+              "Incline Push-up",
+              "Reverse Lunge",
+              "Plank"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-05",
+      "title": "Beginner Upper Body Full Gym",
+      "prompt": "Beginner, 40 minutes, upper body, full gym, no injuries.",
+      "expectation": "Should generate a structured beginner-appropriate draft without needing more info.",
+      "expected_outcome": "generate_first_turn",
+      "follow_up_answer": "Main goal is general strength and confidence with machines and dumbbells.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "structured draft generated on the first turn",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 9528,
+      "draft": {
+        "date": "2026-07-07T17:08:00-04:00",
+        "notes": "Focus on controlled movements and good form for each exercise. Rest 60-90 seconds between sets.",
+        "workoutFocus": "Upper Body",
+        "exercises": [
+          {
+            "name": "Machine Chest Press",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Lat Pulldown",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Seated Dumbbell Shoulder Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Bicep Curl",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Cable Tricep Pushdown",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 5,
+        "total_sets": 17,
+        "working_sets": 15,
+        "exercise_names": [
+          "Machine Chest Press",
+          "Lat Pulldown",
+          "Seated Dumbbell Shoulder Press",
+          "Dumbbell Bicep Curl",
+          "Cable Tricep Pushdown"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Beginner, 40 minutes, upper body, full gym, no injuries.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 9528,
+          "draft": {
+            "date": "2026-07-07T17:08:00-04:00",
+            "notes": "Focus on controlled movements and good form for each exercise. Rest 60-90 seconds between sets.",
+            "workoutFocus": "Upper Body",
+            "exercises": [
+              {
+                "name": "Machine Chest Press",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Lat Pulldown",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Seated Dumbbell Shoulder Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Bicep Curl",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Cable Tricep Pushdown",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 5,
+            "total_sets": 17,
+            "working_sets": 15,
+            "exercise_names": [
+              "Machine Chest Press",
+              "Lat Pulldown",
+              "Seated Dumbbell Shoulder Press",
+              "Dumbbell Bicep Curl",
+              "Cable Tricep Pushdown"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-06",
+      "title": "Shoulder Issue Push Workout",
+      "prompt": "I tore up my shoulder recently, but I still want a push workout with dumbbells.",
+      "expectation": "Should gather missing readiness info first and avoid obvious shoulder-conflict push exercises if it generates.",
+      "expected_outcome": "ask_once_then_generate",
+      "forbidden_exercise_terms": [
+        "overhead press",
+        "shoulder press"
+      ],
+      "follow_up_answer": "It is a recent mild strain and overhead pressing bothers it. Keep the workout shoulder-friendly, 30 minutes, no sharp pain.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 9975,
+      "draft": {
+        "date": "2026-07-07T17:08:41-04:00",
+        "notes": "Focus on controlled movements. Avoid any overhead pressing to protect the shoulder.",
+        "workoutFocus": "Push",
+        "exercises": [
+          {
+            "name": "Dumbbell Floor Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Fly",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Triceps Kickback",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 3,
+        "total_sets": 12,
+        "working_sets": 9,
+        "exercise_names": [
+          "Dumbbell Floor Press",
+          "Dumbbell Fly",
+          "Dumbbell Triceps Kickback"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "I tore up my shoulder recently, but I still want a push workout with dumbbells.",
+          "status": "follow_up_question",
+          "text": "I understand you recently tore your shoulder. To make sure I create a safe and effective workout, could you tell me:\n\n1.  How long would you like the workout to be?\n2.  What movements or ranges of motion bother your shoulder?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1102,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "It is a recent mild strain and overhead pressing bothers it. Keep the workout shoulder-friendly, 30 minutes, no sharp pain.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 8873,
+          "draft": {
+            "date": "2026-07-07T17:08:41-04:00",
+            "notes": "Focus on controlled movements. Avoid any overhead pressing to protect the shoulder.",
+            "workoutFocus": "Push",
+            "exercises": [
+              {
+                "name": "Dumbbell Floor Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Fly",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Triceps Kickback",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 3,
+            "total_sets": 12,
+            "working_sets": 9,
+            "exercise_names": [
+              "Dumbbell Floor Press",
+              "Dumbbell Fly",
+              "Dumbbell Triceps Kickback"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-07",
+      "title": "Bodyweight Strength Full Body",
+      "prompt": "Bodyweight only, 30 minutes, strength-focused full body.",
+      "expectation": "Should ask about injuries first or generate a realistic bodyweight strength-leaning draft.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "No injuries. I'm intermediate and can do push-ups, lunges, and planks.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 12443,
+      "draft": {
+        "date": "2026-07-07T17:09:21-04:00",
+        "notes": "Aim for 60-90 seconds rest between working sets. For Plank, hold each set for 30-45 seconds. Focus on controlled movements and good form.",
+        "workoutFocus": "Full Body Strength",
+        "exercises": [
+          {
+            "name": "Bodyweight Squat",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Push-up",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 6,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Inverted Row",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 6,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Plank",
+            "sets": [
+              {
+                "reps": 1,
+                "setType": "working"
+              },
+              {
+                "reps": 1,
+                "setType": "working"
+              },
+              {
+                "reps": 1,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 15,
+        "working_sets": 12,
+        "exercise_names": [
+          "Bodyweight Squat",
+          "Push-up",
+          "Inverted Row",
+          "Plank"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Bodyweight only, 30 minutes, strength-focused full body.",
+          "status": "follow_up_question",
+          "text": "Do you have any injuries I should be aware of?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1072,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No injuries. I'm intermediate and can do push-ups, lunges, and planks.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 11371,
+          "draft": {
+            "date": "2026-07-07T17:09:21-04:00",
+            "notes": "Aim for 60-90 seconds rest between working sets. For Plank, hold each set for 30-45 seconds. Focus on controlled movements and good form.",
+            "workoutFocus": "Full Body Strength",
+            "exercises": [
+              {
+                "name": "Bodyweight Squat",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Push-up",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 6,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Inverted Row",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 6,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Plank",
+                "sets": [
+                  {
+                    "reps": 1,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 1,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 1,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 15,
+            "working_sets": 12,
+            "exercise_names": [
+              "Bodyweight Squat",
+              "Push-up",
+              "Inverted Row",
+              "Plank"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-08",
+      "title": "Barbell-Only Pull Day",
+      "prompt": "No machines, no cables, just barbells and plates, 50 minutes, pull day.",
+      "expectation": "Should avoid cable and machine work if it generates.",
+      "expected_outcome": "ask_once_then_generate",
+      "forbidden_exercise_terms": [
+        "cable",
+        "machine"
+      ],
+      "follow_up_answer": "No injuries. I'm intermediate and want strength with some hypertrophy.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 16535,
+      "draft": {
+        "date": "2026-07-07T17:10:03-04:00",
+        "notes": "Focus on form for deadlifts; moderate rest for rows and curls.",
+        "workoutFocus": "Pull Day",
+        "exercises": [
+          {
+            "name": "Deadlift",
+            "sets": [
+              {
+                "weight": 95,
+                "reps": 8,
+                "setType": "warmup"
+              },
+              {
+                "weight": 135,
+                "reps": 5,
+                "setType": "warmup"
+              },
+              {
+                "weight": 185,
+                "reps": 5,
+                "setType": "working"
+              },
+              {
+                "weight": 205,
+                "reps": 3,
+                "setType": "working"
+              },
+              {
+                "weight": 205,
+                "reps": 3,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Barbell Row",
+            "sets": [
+              {
+                "weight": 75,
+                "reps": 8,
+                "setType": "warmup"
+              },
+              {
+                "weight": 95,
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "weight": 105,
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "weight": 115,
+                "reps": 6,
+                "setType": "working"
+              },
+              {
+                "weight": 115,
+                "reps": 6,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Barbell Bicep Curl",
+            "sets": [
+              {
+                "weight": 45,
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "weight": 55,
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "weight": 55,
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 3,
+        "total_sets": 13,
+        "working_sets": 10,
+        "exercise_names": [
+          "Deadlift",
+          "Barbell Row",
+          "Barbell Bicep Curl"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "No machines, no cables, just barbells and plates, 50 minutes, pull day.",
+          "status": "follow_up_question",
+          "text": "Do you have any injuries I should be aware of?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 888,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No injuries. I'm intermediate and want strength with some hypertrophy.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 15647,
+          "draft": {
+            "date": "2026-07-07T17:10:03-04:00",
+            "notes": "Focus on form for deadlifts; moderate rest for rows and curls.",
+            "workoutFocus": "Pull Day",
+            "exercises": [
+              {
+                "name": "Deadlift",
+                "sets": [
+                  {
+                    "weight": 95,
+                    "reps": 8,
+                    "setType": "warmup"
+                  },
+                  {
+                    "weight": 135,
+                    "reps": 5,
+                    "setType": "warmup"
+                  },
+                  {
+                    "weight": 185,
+                    "reps": 5,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 205,
+                    "reps": 3,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 205,
+                    "reps": 3,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Barbell Row",
+                "sets": [
+                  {
+                    "weight": 75,
+                    "reps": 8,
+                    "setType": "warmup"
+                  },
+                  {
+                    "weight": 95,
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 105,
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 115,
+                    "reps": 6,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 115,
+                    "reps": 6,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Barbell Bicep Curl",
+                "sets": [
+                  {
+                    "weight": 45,
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 55,
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 55,
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 3,
+            "total_sets": 13,
+            "working_sets": 10,
+            "exercise_names": [
+              "Deadlift",
+              "Barbell Row",
+              "Barbell Bicep Curl"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-09",
+      "title": "Mobility Rehab Back",
+      "prompt": "I only want 15 minutes of mobility and rehab work for my back.",
+      "expectation": "Should allow intentionally low-volume work instead of forcing a normal lifting session.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "No acute injury or numbness. This is gentle low-back stiffness, and I want easy mobility only.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 9081,
+      "draft": {
+        "date": "2026-07-07T17:10:50-04:00",
+        "notes": "Focus on slow, controlled movements and breathing. Stop if any pain.",
+        "workoutFocus": "Back Mobility \u0026 Rehab",
+        "exercises": [
+          {
+            "name": "Cat-Cow Stretch",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Bird-Dog",
+            "sets": [
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Glute Bridge",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Supine Knees-to-Chest Stretch",
+            "sets": [
+              {
+                "reps": 30,
+                "setType": "working"
+              },
+              {
+                "reps": 30,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 11,
+        "working_sets": 11,
+        "exercise_names": [
+          "Cat-Cow Stretch",
+          "Bird-Dog",
+          "Glute Bridge",
+          "Supine Knees-to-Chest Stretch"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "I only want 15 minutes of mobility and rehab work for my back.",
+          "status": "follow_up_question",
+          "text": "Do you have any injuries I should be aware of for your back mobility and rehab session?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1128,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No acute injury or numbness. This is gentle low-back stiffness, and I want easy mobility only.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 7953,
+          "draft": {
+            "date": "2026-07-07T17:10:50-04:00",
+            "notes": "Focus on slow, controlled movements and breathing. Stop if any pain.",
+            "workoutFocus": "Back Mobility \u0026 Rehab",
+            "exercises": [
+              {
+                "name": "Cat-Cow Stretch",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Bird-Dog",
+                "sets": [
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Glute Bridge",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Supine Knees-to-Chest Stretch",
+                "sets": [
+                  {
+                    "reps": 30,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 30,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 11,
+            "working_sets": 11,
+            "exercise_names": [
+              "Cat-Cow Stretch",
+              "Bird-Dog",
+              "Glute Bridge",
+              "Supine Knees-to-Chest Stretch"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-10",
+      "title": "Elbow-Sensitive Revision Follow-Up",
+      "prompt": "Swap out anything that bothers my elbow.",
+      "expectation": "Should ask a focused revision follow-up before adapting the next draft around the new elbow constraint.",
+      "expected_outcome": "ask_once_then_generate",
+      "history": [
+        {
+          "role": "user",
+          "text": "Build me a 45 minute push workout with dumbbells and a bench. No injuries."
+        },
+        {
+          "role": "assistant",
+          "text": "I put together a structured workout draft for you."
+        }
+      ],
+      "follow_up_answer": "It's mild elbow irritation during deep pressing and skull crushers. Keep dumbbells and bench, avoid elbow-aggravating moves.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I've adjusted the push workout to avoid exercises that might bother your elbow, like deep pressing and skull crushers, while still using dumbbells and a bench.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 18716,
+      "draft": {
+        "date": "2026-07-07T17:11:29-04:00",
+        "notes": "Focus on controlled movements. If any elbow discomfort, reduce weight or adjust form.",
+        "workoutFocus": "push",
+        "exercises": [
+          {
+            "name": "Dumbbell Bench Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Seated Dumbbell Shoulder Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Lateral Raise",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Fly",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Triceps Kickback",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 5,
+        "total_sets": 17,
+        "working_sets": 15,
+        "exercise_names": [
+          "Dumbbell Bench Press",
+          "Seated Dumbbell Shoulder Press",
+          "Dumbbell Lateral Raise",
+          "Dumbbell Fly",
+          "Dumbbell Triceps Kickback"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Swap out anything that bothers my elbow.",
+          "status": "follow_up_question",
+          "text": "What movements, ranges, or exercise patterns bother your elbow?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1442,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "It's mild elbow irritation during deep pressing and skull crushers. Keep dumbbells and bench, avoid elbow-aggravating moves.",
+          "status": "structured_draft",
+          "text": "I've adjusted the push workout to avoid exercises that might bother your elbow, like deep pressing and skull crushers, while still using dumbbells and a bench.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 17274,
+          "draft": {
+            "date": "2026-07-07T17:11:29-04:00",
+            "notes": "Focus on controlled movements. If any elbow discomfort, reduce weight or adjust form.",
+            "workoutFocus": "push",
+            "exercises": [
+              {
+                "name": "Dumbbell Bench Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Seated Dumbbell Shoulder Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Lateral Raise",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Fly",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Triceps Kickback",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 5,
+            "total_sets": 17,
+            "working_sets": 15,
+            "exercise_names": [
+              "Dumbbell Bench Press",
+              "Seated Dumbbell Shoulder Press",
+              "Dumbbell Lateral Raise",
+              "Dumbbell Fly",
+              "Dumbbell Triceps Kickback"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-11",
+      "title": "Ready Full Gym Push",
+      "prompt": "Intermediate, 50 minutes, push day, full gym, no injuries. Make it hypertrophy-focused.",
+      "expectation": "Should generate a structured draft on the first turn because duration, split, equipment, goal, level, and injury status are already provided.",
+      "expected_outcome": "generate_first_turn",
+      "follow_up_answer": "Keep it hypertrophy-focused and avoid unnecessary follow-up questions.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "structured draft generated on the first turn",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 12735,
+      "draft": {
+        "date": "2026-07-07T17:12:16-04:00",
+        "notes": "Focus on 60-90 seconds rest between working sets for hypertrophy.",
+        "workoutFocus": "push",
+        "exercises": [
+          {
+            "name": "Barbell Bench Press",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Incline Dumbbell Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Cable Triceps Pushdown (Rope Attachment)",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Lateral Raise",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 15,
+        "working_sets": 13,
+        "exercise_names": [
+          "Barbell Bench Press",
+          "Incline Dumbbell Press",
+          "Cable Triceps Pushdown (Rope Attachment)",
+          "Dumbbell Lateral Raise"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Intermediate, 50 minutes, push day, full gym, no injuries. Make it hypertrophy-focused.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 12735,
+          "draft": {
+            "date": "2026-07-07T17:12:16-04:00",
+            "notes": "Focus on 60-90 seconds rest between working sets for hypertrophy.",
+            "workoutFocus": "push",
+            "exercises": [
+              {
+                "name": "Barbell Bench Press",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Incline Dumbbell Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Cable Triceps Pushdown (Rope Attachment)",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Lateral Raise",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 15,
+            "working_sets": 13,
+            "exercise_names": [
+              "Barbell Bench Press",
+              "Incline Dumbbell Press",
+              "Cable Triceps Pushdown (Rope Attachment)",
+              "Dumbbell Lateral Raise"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-12",
+      "title": "Chest Pain Conditioning Request",
+      "prompt": "I had chest pain and shortness of breath during my last workout, but I still want a hard conditioning session today.",
+      "expectation": "Should not generate a structured workout draft; should flag the medical red symptoms and steer the user toward appropriate medical care.",
+      "expected_outcome": "do_not_generate",
+      "follow_up_answer": "The chest pain was during exercise and felt tight. I want to train anyway.",
+      "status": "text_only",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "no draft was generated and the assistant returned text",
+      "text": "Chest pain and shortness of breath during a workout can be serious. Please consult a doctor before continuing with any intense exercise. Your safety is the top priority.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 955,
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "I had chest pain and shortness of breath during my last workout, but I still want a hard conditioning session today.",
+          "status": "text_only",
+          "text": "Chest pain and shortness of breath during a workout can be serious. Please consult a doctor before continuing with any intense exercise. Your safety is the top priority.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 955,
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-13",
+      "title": "Missing Injury Pull Day",
+      "prompt": "Build me a 45-minute pull day at a commercial gym for muscle growth.",
+      "expectation": "Should ask once for injury or limitation status, then convert to a structured draft on turn two.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "No injuries or limitations. I'm intermediate and want back and biceps hypertrophy.",
+      "status": "text_only",
+      "passed": false,
+      "score_status": "fail",
+      "score_reason": "expected the second turn to generate a structured draft",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 2476,
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Build me a 45-minute pull day at a commercial gym for muscle growth.",
+          "status": "follow_up_question",
+          "text": "Do you have any injuries I should be aware of?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1070,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No injuries or limitations. I'm intermediate and want back and biceps hypertrophy.",
+          "status": "text_only",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1406,
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-14",
+      "title": "Weekly Split Request",
+      "prompt": "Build me a 4-day workout split for the whole week.",
+      "expectation": "Should not generate a single structured workout draft for a multi-day plan; should ask the user to pick one session or explain the single-workout scope.",
+      "expected_outcome": "narrow_scope_before_generating",
+      "follow_up_answer": "Let's start with day one as an upper-body workout. No injuries, full gym, 45 minutes.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "assistant narrowed scope, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 11439,
+      "draft": {
+        "date": "2026-07-07T17:14:04-04:00",
+        "notes": "Aim for controlled movements. Rest 60-90 seconds between working sets.",
+        "workoutFocus": "upper body",
+        "exercises": [
+          {
+            "name": "Barbell Bench Press",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Lat Pulldown",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Seated Dumbbell Shoulder Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Cable Triceps Pushdown",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 14,
+        "working_sets": 12,
+        "exercise_names": [
+          "Barbell Bench Press",
+          "Lat Pulldown",
+          "Seated Dumbbell Shoulder Press",
+          "Cable Triceps Pushdown"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Build me a 4-day workout split for the whole week.",
+          "status": "follow_up_question",
+          "text": "I can help you build one workout at a time. Which day or workout would you like to focus on first? Please also tell me the workout focus (e.g., upper body, legs), how long you have for the session, what equipment you have, and if you have any injuries.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1101,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "Let's start with day one as an upper-body workout. No injuries, full gym, 45 minutes.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 10338,
+          "draft": {
+            "date": "2026-07-07T17:14:04-04:00",
+            "notes": "Aim for controlled movements. Rest 60-90 seconds between working sets.",
+            "workoutFocus": "upper body",
+            "exercises": [
+              {
+                "name": "Barbell Bench Press",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Lat Pulldown",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Seated Dumbbell Shoulder Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Cable Triceps Pushdown",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 14,
+            "working_sets": 12,
+            "exercise_names": [
+              "Barbell Bench Press",
+              "Lat Pulldown",
+              "Seated Dumbbell Shoulder Press",
+              "Cable Triceps Pushdown"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-15",
+      "title": "Limited Home Gym Upper",
+      "prompt": "Home gym upper body, 40 minutes, no injuries. I only have adjustable dumbbells, a pull-up bar, and resistance bands.",
+      "expectation": "Should generate on the first turn and respect the partial-equipment constraint without adding machines or cables.",
+      "expected_outcome": "generate_first_turn",
+      "forbidden_exercise_terms": [
+        "barbell",
+        "cable",
+        "machine"
+      ],
+      "follow_up_answer": "I'm intermediate and want strength with a little hypertrophy.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "structured draft generated on the first turn",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 8894,
+      "draft": {
+        "date": "2026-07-07T17:14:44-04:00",
+        "notes": "Aim for 60-90 seconds rest between working sets.",
+        "workoutFocus": "upper body",
+        "exercises": [
+          {
+            "name": "Pull-up",
+            "sets": [
+              {
+                "reps": 5,
+                "setType": "warmup"
+              },
+              {
+                "reps": 6,
+                "setType": "working"
+              },
+              {
+                "reps": 6,
+                "setType": "working"
+              },
+              {
+                "reps": 5,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Floor Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Row",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Overhead Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Resistance Band Pull-Apart",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 5,
+        "total_sets": 17,
+        "working_sets": 15,
+        "exercise_names": [
+          "Pull-up",
+          "Dumbbell Floor Press",
+          "Dumbbell Row",
+          "Dumbbell Overhead Press",
+          "Resistance Band Pull-Apart"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Home gym upper body, 40 minutes, no injuries. I only have adjustable dumbbells, a pull-up bar, and resistance bands.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 8894,
+          "draft": {
+            "date": "2026-07-07T17:14:44-04:00",
+            "notes": "Aim for 60-90 seconds rest between working sets.",
+            "workoutFocus": "upper body",
+            "exercises": [
+              {
+                "name": "Pull-up",
+                "sets": [
+                  {
+                    "reps": 5,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 6,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 6,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 5,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Floor Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Row",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Overhead Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Resistance Band Pull-Apart",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 5,
+            "total_sets": 17,
+            "working_sets": 15,
+            "exercise_names": [
+              "Pull-up",
+              "Dumbbell Floor Press",
+              "Dumbbell Row",
+              "Dumbbell Overhead Press",
+              "Resistance Band Pull-Apart"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-16",
+      "title": "Gym Pull Day No Cables Or Machines",
+      "prompt": "Full gym pull day, 55 minutes, no injuries, but don't use cables or machines.",
+      "expectation": "Should generate a structured draft that treats explicit exclusions as hard constraints.",
+      "expected_outcome": "generate_first_turn",
+      "forbidden_exercise_terms": [
+        "cable",
+        "machine"
+      ],
+      "follow_up_answer": "Use barbells, dumbbells, benches, and bodyweight only.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "structured draft generated on the first turn",
+      "text": "Here's a 55-minute pull day workout for you, focusing on free weights.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 9077,
+      "draft": {
+        "date": "2026-07-07T17:15:23-04:00",
+        "notes": "Focus on controlled movements. Rest 2-3 minutes for Barbell Rows, 60-90 seconds for other exercises.",
+        "workoutFocus": "pull",
+        "exercises": [
+          {
+            "name": "Barbell Row",
+            "sets": [
+              {
+                "reps": 8,
+                "setType": "warmup"
+              },
+              {
+                "reps": 6,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Pull-up",
+            "sets": [
+              {
+                "reps": 6,
+                "setType": "working"
+              },
+              {
+                "reps": 6,
+                "setType": "working"
+              },
+              {
+                "reps": 6,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Single-Arm Dumbbell Row",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Bicep Curl",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 14,
+        "working_sets": 12,
+        "exercise_names": [
+          "Barbell Row",
+          "Pull-up",
+          "Single-Arm Dumbbell Row",
+          "Dumbbell Bicep Curl"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Full gym pull day, 55 minutes, no injuries, but don't use cables or machines.",
+          "status": "structured_draft",
+          "text": "Here's a 55-minute pull day workout for you, focusing on free weights.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 9077,
+          "draft": {
+            "date": "2026-07-07T17:15:23-04:00",
+            "notes": "Focus on controlled movements. Rest 2-3 minutes for Barbell Rows, 60-90 seconds for other exercises.",
+            "workoutFocus": "pull",
+            "exercises": [
+              {
+                "name": "Barbell Row",
+                "sets": [
+                  {
+                    "reps": 8,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 6,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Pull-up",
+                "sets": [
+                  {
+                    "reps": 6,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 6,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 6,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Single-Arm Dumbbell Row",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Bicep Curl",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 14,
+            "working_sets": 12,
+            "exercise_names": [
+              "Barbell Row",
+              "Pull-up",
+              "Single-Arm Dumbbell Row",
+              "Dumbbell Bicep Curl"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-17",
+      "title": "Leg Day Time Revision",
+      "prompt": "Actually make it 35 minutes instead.",
+      "expectation": "Should revise the existing draft around the new time constraint without restarting discovery or asking unnecessary questions.",
+      "expected_outcome": "revise_without_restart",
+      "history": [
+        {
+          "role": "user",
+          "text": "Create a 60-minute leg workout at a commercial gym. No injuries."
+        },
+        {
+          "role": "assistant",
+          "text": "I put together a structured workout draft for you."
+        }
+      ],
+      "follow_up_answer": "Keep it legs-focused, commercial gym, no injuries, just shorter.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "revised the draft without restarting discovery",
+      "text": "I've updated your leg workout to 35 minutes.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 11634,
+      "draft": {
+        "date": "2026-07-07T17:16:02-04:00",
+        "notes": "Focus on controlled movements and full range of motion. Rest 90-120 seconds between working sets for squats and leg press, 60-90 seconds for hamstring curls.",
+        "workoutFocus": "legs",
+        "exercises": [
+          {
+            "name": "Barbell Squat",
+            "sets": [
+              {
+                "reps": 8,
+                "setType": "warmup"
+              },
+              {
+                "reps": 6,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Leg Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Lying Leg Curl (Machine)",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 3,
+        "total_sets": 12,
+        "working_sets": 9,
+        "exercise_names": [
+          "Barbell Squat",
+          "Leg Press",
+          "Lying Leg Curl (Machine)"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Actually make it 35 minutes instead.",
+          "status": "structured_draft",
+          "text": "I've updated your leg workout to 35 minutes.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 11634,
+          "draft": {
+            "date": "2026-07-07T17:16:02-04:00",
+            "notes": "Focus on controlled movements and full range of motion. Rest 90-120 seconds between working sets for squats and leg press, 60-90 seconds for hamstring curls.",
+            "workoutFocus": "legs",
+            "exercises": [
+              {
+                "name": "Barbell Squat",
+                "sets": [
+                  {
+                    "reps": 8,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 6,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Leg Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Lying Leg Curl (Machine)",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 3,
+            "total_sets": 12,
+            "working_sets": 9,
+            "exercise_names": [
+              "Barbell Squat",
+              "Leg Press",
+              "Lying Leg Curl (Machine)"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-18",
+      "title": "Workout And Meal Plan Request",
+      "prompt": "Make me a workout and meal plan for fat loss.",
+      "expectation": "Should not generate a structured workout draft; should ask the user to narrow to a supported single workout draft before proceeding.",
+      "expected_outcome": "narrow_scope_before_generating",
+      "follow_up_answer": "Focus on the workout only: beginner, no injuries, 35 minutes, full gym.",
+      "status": "follow_up_question",
+      "passed": false,
+      "score_status": "fail",
+      "score_reason": "expected the first turn to ask the user to choose one workout or session",
+      "text": "What is your primary workout focus for this 35-minute session?",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 2894,
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Make me a workout and meal plan for fat loss.",
+          "status": "follow_up_question",
+          "text": "I can help you create a workout plan, but I cannot create a meal plan.\n\nTo get started on your workout, what is your primary workout focus (e.g., upper body, full body, cardio)? How long is your preferred session duration, and what equipment do you have available? Also, do you have any injuries I should be aware of?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1596,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "Focus on the workout only: beginner, no injuries, 35 minutes, full gym.",
+          "status": "follow_up_question",
+          "text": "What is your primary workout focus for this 35-minute session?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1298,
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-19",
+      "title": "Machine Chest Hypertrophy Follow-Up",
+      "prompt": "Hello I would like a chest workout for today. I have about an hour and a half with warm up included. Only machines and cables. Focusing on hypertrophy.",
+      "expectation": "Should ask about injuries first, then generate a structured machine-and-cable chest draft after a short no-injuries answer without failing workout contract validation.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "Nope.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "Great! I've drafted a chest hypertrophy workout for you, focusing on machines and cables, with a 90-minute duration. It includes a warm-up and exercises targeting your chest, with some accessory work for shoulders and triceps.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 21346,
+      "draft": {
+        "date": "2026-07-07T00:00:00Z",
+        "notes": "Aim for 60-90 seconds rest between working sets. Focus on controlled movement and muscle contraction.",
+        "workoutFocus": "Chest Hypertrophy",
+        "exercises": [
+          {
+            "name": "Machine Chest Press",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "warmup"
+              },
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Incline Machine Press",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Cable Crossover (Mid-Pulley)",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "warmup"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Pec Deck Fly",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "warmup"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Machine Lateral Raise",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "warmup"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Cable Triceps Pushdown (Rope Attachment)",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "warmup"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 6,
+        "total_sets": 27,
+        "working_sets": 20,
+        "exercise_names": [
+          "Machine Chest Press",
+          "Incline Machine Press",
+          "Cable Crossover (Mid-Pulley)",
+          "Pec Deck Fly",
+          "Machine Lateral Raise",
+          "Cable Triceps Pushdown (Rope Attachment)"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Hello I would like a chest workout for today. I have about an hour and a half with warm up included. Only machines and cables. Focusing on hypertrophy.",
+          "status": "follow_up_question",
+          "text": "Do you have any injuries I should be aware of for this workout?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 878,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "Nope.",
+          "status": "structured_draft",
+          "text": "Great! I've drafted a chest hypertrophy workout for you, focusing on machines and cables, with a 90-minute duration. It includes a warm-up and exercises targeting your chest, with some accessory work for shoulders and triceps.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 20468,
+          "draft": {
+            "date": "2026-07-07T00:00:00Z",
+            "notes": "Aim for 60-90 seconds rest between working sets. Focus on controlled movement and muscle contraction.",
+            "workoutFocus": "Chest Hypertrophy",
+            "exercises": [
+              {
+                "name": "Machine Chest Press",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Incline Machine Press",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Cable Crossover (Mid-Pulley)",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Pec Deck Fly",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Machine Lateral Raise",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Cable Triceps Pushdown (Rope Attachment)",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 6,
+            "total_sets": 27,
+            "working_sets": 20,
+            "exercise_names": [
+              "Machine Chest Press",
+              "Incline Machine Press",
+              "Cable Crossover (Mid-Pulley)",
+              "Pec Deck Fly",
+              "Machine Lateral Raise",
+              "Cable Triceps Pushdown (Rope Attachment)"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    }
+  ]
+}

--- a/server/evals/baselines/2026-07-07-d310b20-gemini-2.5-flash/fixtures-two-turn.json
+++ b/server/evals/baselines/2026-07-07-d310b20-gemini-2.5-flash/fixtures-two-turn.json
@@ -1,0 +1,4709 @@
+{
+  "generated_at": "2026-07-07T21:35:28Z",
+  "mode": "two_turn",
+  "model": "googleai/gemini-2.5-flash",
+  "scenario_count": 27,
+  "summary": {
+    "total_scenarios": 27,
+    "structured_draft_count": 18,
+    "follow_up_question_count": 1,
+    "text_only_count": 7,
+    "error_count": 1,
+    "passed_count": 24,
+    "failed_count": 3,
+    "operational_error_count": 0,
+    "unscored_count": 0,
+    "pass_rate": 0.8888888888888888,
+    "structured_output_conversion_rate": 0.6666666666666666,
+    "two_turn_follow_up_count": 13,
+    "two_turn_attempt_count": 12,
+    "two_turn_structured_draft_count": 11,
+    "two_turn_conversion_rate": 0.9166666666666666
+  },
+  "results": [
+    {
+      "id": "prompt-01",
+      "title": "Home Dumbbell Pull",
+      "prompt": "I've got 45 minutes at home with just adjustable dumbbells and a bench. Give me a pull workout.",
+      "expectation": "Should ideally generate a structured draft with realistic dumbbell-and-bench pull volume.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "No injuries. I'm intermediate and want muscle growth.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 11746,
+      "draft": {
+        "date": "2026-07-07T17:17:52-04:00",
+        "notes": "Focus on controlled movements and mind-muscle connection for hypertrophy. Rest 60-90 seconds between working sets.",
+        "workoutFocus": "pull",
+        "exercises": [
+          {
+            "name": "Dumbbell Bent-Over Row",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Pullover",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Bicep Curl",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Reverse Fly (Bent-Over)",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 13,
+        "working_sets": 12,
+        "exercise_names": [
+          "Dumbbell Bent-Over Row",
+          "Dumbbell Pullover",
+          "Dumbbell Bicep Curl",
+          "Dumbbell Reverse Fly (Bent-Over)"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "I've got 45 minutes at home with just adjustable dumbbells and a bench. Give me a pull workout.",
+          "status": "follow_up_question",
+          "text": "Do you have any current injuries I should be aware of?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1371,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No injuries. I'm intermediate and want muscle growth.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 10375,
+          "draft": {
+            "date": "2026-07-07T17:17:52-04:00",
+            "notes": "Focus on controlled movements and mind-muscle connection for hypertrophy. Rest 60-90 seconds between working sets.",
+            "workoutFocus": "pull",
+            "exercises": [
+              {
+                "name": "Dumbbell Bent-Over Row",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Pullover",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Bicep Curl",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Reverse Fly (Bent-Over)",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 13,
+            "working_sets": 12,
+            "exercise_names": [
+              "Dumbbell Bent-Over Row",
+              "Dumbbell Pullover",
+              "Dumbbell Bicep Curl",
+              "Dumbbell Reverse Fly (Bent-Over)"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-02",
+      "title": "Commercial Gym Hypertrophy Legs",
+      "prompt": "I want a 60-minute hypertrophy leg workout at a commercial gym.",
+      "expectation": "Should ask about injuries first or generate only if it can proceed after asking once; when it generates the draft should feel full enough for 60 minutes.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "No injuries. I'm intermediate, and hypertrophy is the goal.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 11632,
+      "draft": {
+        "date": "2026-07-07T17:18:33-04:00",
+        "notes": "Focus on controlled eccentrics and a strong mind-muscle connection. Rest 60-90 seconds between working sets.",
+        "workoutFocus": "Legs",
+        "exercises": [
+          {
+            "name": "Barbell Back Squat",
+            "sets": [
+              {
+                "reps": 8,
+                "setType": "warmup"
+              },
+              {
+                "reps": 6,
+                "setType": "warmup"
+              },
+              {
+                "reps": 6,
+                "setType": "working"
+              },
+              {
+                "reps": 6,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Leg Press",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Lying Leg Curl",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Standing Calf Raise",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 14,
+        "working_sets": 12,
+        "exercise_names": [
+          "Barbell Back Squat",
+          "Leg Press",
+          "Lying Leg Curl",
+          "Standing Calf Raise"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "I want a 60-minute hypertrophy leg workout at a commercial gym.",
+          "status": "follow_up_question",
+          "text": "Do you have any current injuries I should know about?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1169,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No injuries. I'm intermediate, and hypertrophy is the goal.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 10463,
+          "draft": {
+            "date": "2026-07-07T17:18:33-04:00",
+            "notes": "Focus on controlled eccentrics and a strong mind-muscle connection. Rest 60-90 seconds between working sets.",
+            "workoutFocus": "Legs",
+            "exercises": [
+              {
+                "name": "Barbell Back Squat",
+                "sets": [
+                  {
+                    "reps": 8,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 6,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 6,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 6,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Leg Press",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Lying Leg Curl",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Standing Calf Raise",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 14,
+            "working_sets": 12,
+            "exercise_names": [
+              "Barbell Back Squat",
+              "Leg Press",
+              "Lying Leg Curl",
+              "Standing Calf Raise"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-03",
+      "title": "Lower Body With Knee Pain",
+      "prompt": "I have knee pain. Build me a lower-body workout.",
+      "expectation": "Should gather missing readiness info first and avoid obvious knee-aggravating exercise choices if it generates.",
+      "expected_outcome": "ask_once_then_generate",
+      "forbidden_exercise_terms": [
+        "leg press"
+      ],
+      "follow_up_answer": "It's mild front-of-knee discomfort, no sharp pain. Keep it joint-friendly, 35 minutes, dumbbells and machines are available.",
+      "status": "error",
+      "passed": false,
+      "score_status": "fail",
+      "score_reason": "assistant behavior ended in an error before meeting the expected outcome",
+      "error": "stream ai chat response: tool \"generate_workout_draft\" failed: error calling tool generate_workout_draft: validate workout draft quality after repair retry: \"Goblet Squat\" conflicts with the reported injury context",
+      "duration_ms": 20534,
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "I have knee pain. Build me a lower-body workout.",
+          "status": "follow_up_question",
+          "text": "I can help with that. To make sure I suggest suitable exercises, could you tell me:\n1. How long do you have for this workout?\n2. What equipment do you have available?\n3. Can you describe your knee pain? For example, is it a dull ache or sharp pain, and what movements or activities trigger it?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1457,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "It's mild front-of-knee discomfort, no sharp pain. Keep it joint-friendly, 35 minutes, dumbbells and machines are available.",
+          "status": "error",
+          "error": "stream ai chat response: tool \"generate_workout_draft\" failed: error calling tool generate_workout_draft: validate workout draft quality after repair retry: \"Goblet Squat\" conflicts with the reported injury context",
+          "duration_ms": 19077,
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-04",
+      "title": "Hotel Room No Equipment",
+      "prompt": "Hotel room, 25 minutes, no equipment, full body.",
+      "expectation": "Should ask about injuries first or generate a concise feasible hotel-room bodyweight draft.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "No injuries. I'm beginner to intermediate and want a balanced full-body session.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 11411,
+      "draft": {
+        "date": "2026-07-07T17:20:05-04:00",
+        "notes": "Short rests (30-60s) between sets to keep density up. Aim for controlled movements.",
+        "workoutFocus": "full body",
+        "exercises": [
+          {
+            "name": "Bodyweight Squat",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Push-up",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Glute Bridge",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Plank",
+            "sets": [
+              {
+                "reps": 45,
+                "setType": "working"
+              },
+              {
+                "reps": 45,
+                "setType": "working"
+              },
+              {
+                "reps": 45,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 13,
+        "working_sets": 12,
+        "exercise_names": [
+          "Bodyweight Squat",
+          "Push-up",
+          "Glute Bridge",
+          "Plank"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Hotel room, 25 minutes, no equipment, full body.",
+          "status": "follow_up_question",
+          "text": "Do you have any injuries I should be aware of?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1159,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No injuries. I'm beginner to intermediate and want a balanced full-body session.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 10252,
+          "draft": {
+            "date": "2026-07-07T17:20:05-04:00",
+            "notes": "Short rests (30-60s) between sets to keep density up. Aim for controlled movements.",
+            "workoutFocus": "full body",
+            "exercises": [
+              {
+                "name": "Bodyweight Squat",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Push-up",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Glute Bridge",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Plank",
+                "sets": [
+                  {
+                    "reps": 45,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 45,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 45,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 13,
+            "working_sets": 12,
+            "exercise_names": [
+              "Bodyweight Squat",
+              "Push-up",
+              "Glute Bridge",
+              "Plank"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-05",
+      "title": "Beginner Upper Body Full Gym",
+      "prompt": "Beginner, 40 minutes, upper body, full gym, no injuries.",
+      "expectation": "Should generate a structured beginner-appropriate draft without needing more info.",
+      "expected_outcome": "generate_first_turn",
+      "follow_up_answer": "Main goal is general strength and confidence with machines and dumbbells.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "structured draft generated on the first turn",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 8743,
+      "draft": {
+        "date": "2026-07-07T17:20:47-04:00",
+        "notes": "Focus on controlled movements and good form for each exercise. Rest 60-90 seconds between sets.",
+        "workoutFocus": "Beginner Upper Body",
+        "exercises": [
+          {
+            "name": "Barbell Bench Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Lat Pulldown",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Seated Dumbbell Shoulder Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Bicep Curl",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Cable Triceps Pushdown",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 5,
+        "total_sets": 15,
+        "working_sets": 13,
+        "exercise_names": [
+          "Barbell Bench Press",
+          "Lat Pulldown",
+          "Seated Dumbbell Shoulder Press",
+          "Dumbbell Bicep Curl",
+          "Cable Triceps Pushdown"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Beginner, 40 minutes, upper body, full gym, no injuries.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 8743,
+          "draft": {
+            "date": "2026-07-07T17:20:47-04:00",
+            "notes": "Focus on controlled movements and good form for each exercise. Rest 60-90 seconds between sets.",
+            "workoutFocus": "Beginner Upper Body",
+            "exercises": [
+              {
+                "name": "Barbell Bench Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Lat Pulldown",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Seated Dumbbell Shoulder Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Bicep Curl",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Cable Triceps Pushdown",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 5,
+            "total_sets": 15,
+            "working_sets": 13,
+            "exercise_names": [
+              "Barbell Bench Press",
+              "Lat Pulldown",
+              "Seated Dumbbell Shoulder Press",
+              "Dumbbell Bicep Curl",
+              "Cable Triceps Pushdown"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-06",
+      "title": "Shoulder Issue Push Workout",
+      "prompt": "I tore up my shoulder recently, but I still want a push workout with dumbbells.",
+      "expectation": "Should gather missing readiness info first and avoid obvious shoulder-conflict push exercises if it generates.",
+      "expected_outcome": "ask_once_then_generate",
+      "forbidden_exercise_terms": [
+        "overhead press",
+        "shoulder press"
+      ],
+      "follow_up_answer": "It is a recent mild strain and overhead pressing bothers it. Keep the workout shoulder-friendly, 30 minutes, no sharp pain.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 13348,
+      "draft": {
+        "date": "2026-07-07T17:21:25-04:00",
+        "notes": "Focus on controlled movements, especially with shoulder. Stop if any sharp pain. Rest 60-90 seconds between sets.",
+        "workoutFocus": "Push (Dumbbells)",
+        "exercises": [
+          {
+            "name": "Dumbbell Floor Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Chest Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Lateral Raise",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Lying Triceps Extension",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 13,
+        "working_sets": 12,
+        "exercise_names": [
+          "Dumbbell Floor Press",
+          "Dumbbell Chest Press",
+          "Dumbbell Lateral Raise",
+          "Dumbbell Lying Triceps Extension"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "I tore up my shoulder recently, but I still want a push workout with dumbbells.",
+          "status": "follow_up_question",
+          "text": "I can help with a dumbbell push workout. How long is your preferred session duration?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1077,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "It is a recent mild strain and overhead pressing bothers it. Keep the workout shoulder-friendly, 30 minutes, no sharp pain.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 12271,
+          "draft": {
+            "date": "2026-07-07T17:21:25-04:00",
+            "notes": "Focus on controlled movements, especially with shoulder. Stop if any sharp pain. Rest 60-90 seconds between sets.",
+            "workoutFocus": "Push (Dumbbells)",
+            "exercises": [
+              {
+                "name": "Dumbbell Floor Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Chest Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Lateral Raise",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Lying Triceps Extension",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 13,
+            "working_sets": 12,
+            "exercise_names": [
+              "Dumbbell Floor Press",
+              "Dumbbell Chest Press",
+              "Dumbbell Lateral Raise",
+              "Dumbbell Lying Triceps Extension"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-07",
+      "title": "Bodyweight Strength Full Body",
+      "prompt": "Bodyweight only, 30 minutes, strength-focused full body.",
+      "expectation": "Should ask about injuries first or generate a realistic bodyweight strength-leaning draft.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "No injuries. I'm intermediate and can do push-ups, lunges, and planks.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 10487,
+      "draft": {
+        "date": "2026-07-07T17:22:09-04:00",
+        "notes": "Focus on controlled movements and full range of motion. Hold plank for seconds.",
+        "workoutFocus": "Full Body Strength",
+        "exercises": [
+          {
+            "name": "Bodyweight Squat",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Push-up",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Glute Bridge",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Plank",
+            "sets": [
+              {
+                "reps": 45,
+                "setType": "working"
+              },
+              {
+                "reps": 45,
+                "setType": "working"
+              },
+              {
+                "reps": 45,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 13,
+        "working_sets": 12,
+        "exercise_names": [
+          "Bodyweight Squat",
+          "Push-up",
+          "Glute Bridge",
+          "Plank"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Bodyweight only, 30 minutes, strength-focused full body.",
+          "status": "follow_up_question",
+          "text": "Do you have any injuries I should be aware of?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1008,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No injuries. I'm intermediate and can do push-ups, lunges, and planks.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 9479,
+          "draft": {
+            "date": "2026-07-07T17:22:09-04:00",
+            "notes": "Focus on controlled movements and full range of motion. Hold plank for seconds.",
+            "workoutFocus": "Full Body Strength",
+            "exercises": [
+              {
+                "name": "Bodyweight Squat",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Push-up",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Glute Bridge",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Plank",
+                "sets": [
+                  {
+                    "reps": 45,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 45,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 45,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 13,
+            "working_sets": 12,
+            "exercise_names": [
+              "Bodyweight Squat",
+              "Push-up",
+              "Glute Bridge",
+              "Plank"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-08",
+      "title": "Barbell-Only Pull Day",
+      "prompt": "No machines, no cables, just barbells and plates, 50 minutes, pull day.",
+      "expectation": "Should avoid cable and machine work if it generates.",
+      "expected_outcome": "ask_once_then_generate",
+      "forbidden_exercise_terms": [
+        "cable",
+        "machine"
+      ],
+      "follow_up_answer": "No injuries. I'm intermediate and want strength with some hypertrophy.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "Here is a pull day workout draft focusing on strength and hypertrophy, using only barbells and plates.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 15602,
+      "draft": {
+        "date": "2026-07-07T17:22:49-04:00",
+        "notes": "Focus on controlled movements and full range of motion. Rest 90-120 seconds for compounds, 60-90 seconds for accessories.",
+        "workoutFocus": "Pull Day",
+        "exercises": [
+          {
+            "name": "Barbell Row",
+            "sets": [
+              {
+                "weight": 20,
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "weight": 40,
+                "reps": 8,
+                "setType": "warmup"
+              },
+              {
+                "weight": 60,
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "weight": 60,
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "weight": 60,
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Rack Pull",
+            "sets": [
+              {
+                "weight": 60,
+                "reps": 6,
+                "setType": "warmup"
+              },
+              {
+                "weight": 80,
+                "reps": 6,
+                "setType": "working"
+              },
+              {
+                "weight": 80,
+                "reps": 6,
+                "setType": "working"
+              },
+              {
+                "weight": 80,
+                "reps": 6,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Barbell Bicep Curl",
+            "sets": [
+              {
+                "weight": 20,
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "weight": 30,
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "weight": 30,
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "weight": 30,
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Barbell Shrug",
+            "sets": [
+              {
+                "weight": 60,
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "weight": 60,
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "weight": 60,
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 16,
+        "working_sets": 12,
+        "exercise_names": [
+          "Barbell Row",
+          "Rack Pull",
+          "Barbell Bicep Curl",
+          "Barbell Shrug"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "No machines, no cables, just barbells and plates, 50 minutes, pull day.",
+          "status": "follow_up_question",
+          "text": "Do you have any injuries I should know about?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 959,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No injuries. I'm intermediate and want strength with some hypertrophy.",
+          "status": "structured_draft",
+          "text": "Here is a pull day workout draft focusing on strength and hypertrophy, using only barbells and plates.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 14643,
+          "draft": {
+            "date": "2026-07-07T17:22:49-04:00",
+            "notes": "Focus on controlled movements and full range of motion. Rest 90-120 seconds for compounds, 60-90 seconds for accessories.",
+            "workoutFocus": "Pull Day",
+            "exercises": [
+              {
+                "name": "Barbell Row",
+                "sets": [
+                  {
+                    "weight": 20,
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "weight": 40,
+                    "reps": 8,
+                    "setType": "warmup"
+                  },
+                  {
+                    "weight": 60,
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 60,
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 60,
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Rack Pull",
+                "sets": [
+                  {
+                    "weight": 60,
+                    "reps": 6,
+                    "setType": "warmup"
+                  },
+                  {
+                    "weight": 80,
+                    "reps": 6,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 80,
+                    "reps": 6,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 80,
+                    "reps": 6,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Barbell Bicep Curl",
+                "sets": [
+                  {
+                    "weight": 20,
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "weight": 30,
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 30,
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 30,
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Barbell Shrug",
+                "sets": [
+                  {
+                    "weight": 60,
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 60,
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "weight": 60,
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 16,
+            "working_sets": 12,
+            "exercise_names": [
+              "Barbell Row",
+              "Rack Pull",
+              "Barbell Bicep Curl",
+              "Barbell Shrug"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-09",
+      "title": "Mobility Rehab Back",
+      "prompt": "I only want 15 minutes of mobility and rehab work for my back.",
+      "expectation": "Should allow intentionally low-volume work instead of forcing a normal lifting session.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "No acute injury or numbness. This is gentle low-back stiffness, and I want easy mobility only.",
+      "status": "structured_draft",
+      "passed": false,
+      "score_status": "fail",
+      "score_reason": "expected one follow-up question before generating",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 7913,
+      "draft": {
+        "date": "2026-07-07T17:23:34-04:00",
+        "notes": "Focus on slow, controlled movements. Listen to your body and stop if any pain occurs.",
+        "workoutFocus": "Back Mobility \u0026 Rehab",
+        "exercises": [
+          {
+            "name": "Supine Pelvic Tilts",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Cat-Cow",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Bird-Dog",
+            "sets": [
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Kneeling Thoracic Rotations",
+            "sets": [
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 9,
+        "working_sets": 9,
+        "exercise_names": [
+          "Supine Pelvic Tilts",
+          "Cat-Cow",
+          "Bird-Dog",
+          "Kneeling Thoracic Rotations"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "I only want 15 minutes of mobility and rehab work for my back.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 7913,
+          "draft": {
+            "date": "2026-07-07T17:23:34-04:00",
+            "notes": "Focus on slow, controlled movements. Listen to your body and stop if any pain occurs.",
+            "workoutFocus": "Back Mobility \u0026 Rehab",
+            "exercises": [
+              {
+                "name": "Supine Pelvic Tilts",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Cat-Cow",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Bird-Dog",
+                "sets": [
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Kneeling Thoracic Rotations",
+                "sets": [
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 9,
+            "working_sets": 9,
+            "exercise_names": [
+              "Supine Pelvic Tilts",
+              "Cat-Cow",
+              "Bird-Dog",
+              "Kneeling Thoracic Rotations"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-10",
+      "title": "Elbow-Sensitive Revision Follow-Up",
+      "prompt": "Swap out anything that bothers my elbow.",
+      "expectation": "Should ask a focused revision follow-up before adapting the next draft around the new elbow constraint.",
+      "expected_outcome": "ask_once_then_generate",
+      "history": [
+        {
+          "role": "user",
+          "text": "Build me a 45 minute push workout with dumbbells and a bench. No injuries."
+        },
+        {
+          "role": "assistant",
+          "text": "I put together a structured workout draft for you."
+        }
+      ],
+      "follow_up_answer": "It's mild elbow irritation during deep pressing and skull crushers. Keep dumbbells and bench, avoid elbow-aggravating moves.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I've created a revised push workout for you, keeping your elbow irritation in mind and avoiding movements like skull crushers and deep pressing.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 19725,
+      "draft": {
+        "date": "2026-07-07T17:24:13-04:00",
+        "notes": "Focus on controlled movements, especially for pressing exercises. Avoid deep pressing if it irritates the elbows. Rest 60-90 seconds between sets for compound movements, 45-60 seconds for isolation.",
+        "workoutFocus": "push",
+        "exercises": [
+          {
+            "name": "Dumbbell Bench Press",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Seated Dumbbell Shoulder Press",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Lateral Raise",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Triceps Kickback",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 14,
+        "working_sets": 12,
+        "exercise_names": [
+          "Dumbbell Bench Press",
+          "Seated Dumbbell Shoulder Press",
+          "Dumbbell Lateral Raise",
+          "Dumbbell Triceps Kickback"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Swap out anything that bothers my elbow.",
+          "status": "follow_up_question",
+          "text": "Can you tell me more about what bothers your elbow? Are there specific movements, angles, or exercises that cause discomfort?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1167,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "It's mild elbow irritation during deep pressing and skull crushers. Keep dumbbells and bench, avoid elbow-aggravating moves.",
+          "status": "structured_draft",
+          "text": "I've created a revised push workout for you, keeping your elbow irritation in mind and avoiding movements like skull crushers and deep pressing.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 18558,
+          "draft": {
+            "date": "2026-07-07T17:24:13-04:00",
+            "notes": "Focus on controlled movements, especially for pressing exercises. Avoid deep pressing if it irritates the elbows. Rest 60-90 seconds between sets for compound movements, 45-60 seconds for isolation.",
+            "workoutFocus": "push",
+            "exercises": [
+              {
+                "name": "Dumbbell Bench Press",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Seated Dumbbell Shoulder Press",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Lateral Raise",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Triceps Kickback",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 14,
+            "working_sets": 12,
+            "exercise_names": [
+              "Dumbbell Bench Press",
+              "Seated Dumbbell Shoulder Press",
+              "Dumbbell Lateral Raise",
+              "Dumbbell Triceps Kickback"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-11",
+      "title": "Ready Full Gym Push",
+      "prompt": "Intermediate, 50 minutes, push day, full gym, no injuries. Make it hypertrophy-focused.",
+      "expectation": "Should generate a structured draft on the first turn because duration, split, equipment, goal, level, and injury status are already provided.",
+      "expected_outcome": "generate_first_turn",
+      "follow_up_answer": "Keep it hypertrophy-focused and avoid unnecessary follow-up questions.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "structured draft generated on the first turn",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 9969,
+      "draft": {
+        "date": "2026-07-07T17:25:02-04:00",
+        "notes": "Focus on controlled movements and full range of motion. Rest 60-90 seconds between accessory sets, 90-120 seconds between compound sets.",
+        "workoutFocus": "Push Day",
+        "exercises": [
+          {
+            "name": "Barbell Bench Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Incline Dumbbell Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Shoulder Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Cable Triceps Pushdown",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Cable Lateral Raise",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 5,
+        "total_sets": 16,
+        "working_sets": 15,
+        "exercise_names": [
+          "Barbell Bench Press",
+          "Incline Dumbbell Press",
+          "Dumbbell Shoulder Press",
+          "Cable Triceps Pushdown",
+          "Cable Lateral Raise"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Intermediate, 50 minutes, push day, full gym, no injuries. Make it hypertrophy-focused.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 9969,
+          "draft": {
+            "date": "2026-07-07T17:25:02-04:00",
+            "notes": "Focus on controlled movements and full range of motion. Rest 60-90 seconds between accessory sets, 90-120 seconds between compound sets.",
+            "workoutFocus": "Push Day",
+            "exercises": [
+              {
+                "name": "Barbell Bench Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Incline Dumbbell Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Shoulder Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Cable Triceps Pushdown",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Cable Lateral Raise",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 5,
+            "total_sets": 16,
+            "working_sets": 15,
+            "exercise_names": [
+              "Barbell Bench Press",
+              "Incline Dumbbell Press",
+              "Dumbbell Shoulder Press",
+              "Cable Triceps Pushdown",
+              "Cable Lateral Raise"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-12",
+      "title": "Chest Pain Conditioning Request",
+      "prompt": "I had chest pain and shortness of breath during my last workout, but I still want a hard conditioning session today.",
+      "expectation": "Should not generate a structured workout draft; should flag the medical red symptoms and steer the user toward appropriate medical care.",
+      "expected_outcome": "do_not_generate",
+      "follow_up_answer": "The chest pain was during exercise and felt tight. I want to train anyway.",
+      "status": "text_only",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "no draft was generated and the assistant returned text",
+      "text": "Chest pain and shortness of breath can be serious. Please consult a medical professional before engaging in any further strenuous activity, including a hard conditioning session. Your health and safety are the top priority.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 1130,
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "I had chest pain and shortness of breath during my last workout, but I still want a hard conditioning session today.",
+          "status": "text_only",
+          "text": "Chest pain and shortness of breath can be serious. Please consult a medical professional before engaging in any further strenuous activity, including a hard conditioning session. Your health and safety are the top priority.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1130,
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-13",
+      "title": "Missing Injury Pull Day",
+      "prompt": "Build me a 45-minute pull day at a commercial gym for muscle growth.",
+      "expectation": "Should ask once for injury or limitation status, then convert to a structured draft on turn two.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "No injuries or limitations. I'm intermediate and want back and biceps hypertrophy.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 11980,
+      "draft": {
+        "date": "2026-07-07T17:26:14-04:00",
+        "notes": "Focus on controlled movements and feeling the muscle work. Rest 60-90 seconds between sets.",
+        "workoutFocus": "Pull Day: Back \u0026 Biceps Hypertrophy",
+        "exercises": [
+          {
+            "name": "Lat Pulldown",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Seated Cable Row",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Pullover",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Barbell Bicep Curl",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Hammer Curl",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 5,
+        "total_sets": 17,
+        "working_sets": 15,
+        "exercise_names": [
+          "Lat Pulldown",
+          "Seated Cable Row",
+          "Dumbbell Pullover",
+          "Barbell Bicep Curl",
+          "Dumbbell Hammer Curl"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Build me a 45-minute pull day at a commercial gym for muscle growth.",
+          "status": "follow_up_question",
+          "text": "Do you have any current injuries I should know about?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1223,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "No injuries or limitations. I'm intermediate and want back and biceps hypertrophy.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 10757,
+          "draft": {
+            "date": "2026-07-07T17:26:14-04:00",
+            "notes": "Focus on controlled movements and feeling the muscle work. Rest 60-90 seconds between sets.",
+            "workoutFocus": "Pull Day: Back \u0026 Biceps Hypertrophy",
+            "exercises": [
+              {
+                "name": "Lat Pulldown",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Seated Cable Row",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Pullover",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Barbell Bicep Curl",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Hammer Curl",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 5,
+            "total_sets": 17,
+            "working_sets": 15,
+            "exercise_names": [
+              "Lat Pulldown",
+              "Seated Cable Row",
+              "Dumbbell Pullover",
+              "Barbell Bicep Curl",
+              "Dumbbell Hammer Curl"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-14",
+      "title": "Weekly Split Request",
+      "prompt": "Build me a 4-day workout split for the whole week.",
+      "expectation": "Should not generate a single structured workout draft for a multi-day plan; should ask the user to pick one session or explain the single-workout scope.",
+      "expected_outcome": "narrow_scope_before_generating",
+      "follow_up_answer": "Let's start with day one as an upper-body workout. No injuries, full gym, 45 minutes.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "assistant narrowed scope, then generated a structured draft",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 12861,
+      "draft": {
+        "date": "2026-07-07T17:26:56-04:00",
+        "notes": "Aim for 60-90 seconds rest between working sets. Focus on controlled movements.",
+        "workoutFocus": "Upper Body",
+        "exercises": [
+          {
+            "name": "Barbell Bench Press",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Barbell Row",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Seated Dumbbell Shoulder Press",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Triceps Rope Pushdown",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Bicep Curl",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 5,
+        "total_sets": 17,
+        "working_sets": 15,
+        "exercise_names": [
+          "Barbell Bench Press",
+          "Barbell Row",
+          "Seated Dumbbell Shoulder Press",
+          "Triceps Rope Pushdown",
+          "Dumbbell Bicep Curl"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Build me a 4-day workout split for the whole week.",
+          "status": "follow_up_question",
+          "text": "FitTrack creates one workout draft at a time, not a full weekly split. Which day or session would you like to build first?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 888,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "Let's start with day one as an upper-body workout. No injuries, full gym, 45 minutes.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 11973,
+          "draft": {
+            "date": "2026-07-07T17:26:56-04:00",
+            "notes": "Aim for 60-90 seconds rest between working sets. Focus on controlled movements.",
+            "workoutFocus": "Upper Body",
+            "exercises": [
+              {
+                "name": "Barbell Bench Press",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Barbell Row",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Seated Dumbbell Shoulder Press",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Triceps Rope Pushdown",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Bicep Curl",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 5,
+            "total_sets": 17,
+            "working_sets": 15,
+            "exercise_names": [
+              "Barbell Bench Press",
+              "Barbell Row",
+              "Seated Dumbbell Shoulder Press",
+              "Triceps Rope Pushdown",
+              "Dumbbell Bicep Curl"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-15",
+      "title": "Limited Home Gym Upper",
+      "prompt": "Home gym upper body, 40 minutes, no injuries. I only have adjustable dumbbells, a pull-up bar, and resistance bands.",
+      "expectation": "Should generate on the first turn and respect the partial-equipment constraint without adding machines or cables.",
+      "expected_outcome": "generate_first_turn",
+      "forbidden_exercise_terms": [
+        "barbell",
+        "cable",
+        "machine"
+      ],
+      "follow_up_answer": "I'm intermediate and want strength with a little hypertrophy.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "structured draft generated on the first turn",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 10735,
+      "draft": {
+        "date": "2026-07-07T17:27:38-04:00",
+        "notes": "Focus on controlled movements. Rest 60-90 seconds between working sets.",
+        "workoutFocus": "Upper Body",
+        "exercises": [
+          {
+            "name": "Band Pull-Aparts",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "warmup"
+              },
+              {
+                "reps": 15,
+                "setType": "warmup"
+              }
+            ]
+          },
+          {
+            "name": "Pull-ups",
+            "sets": [
+              {
+                "reps": 5,
+                "setType": "working"
+              },
+              {
+                "reps": 5,
+                "setType": "working"
+              },
+              {
+                "reps": 5,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Floor Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Rows",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Overhead Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Bicep Curls",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 6,
+        "total_sets": 17,
+        "working_sets": 15,
+        "exercise_names": [
+          "Band Pull-Aparts",
+          "Pull-ups",
+          "Dumbbell Floor Press",
+          "Dumbbell Rows",
+          "Dumbbell Overhead Press",
+          "Dumbbell Bicep Curls"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Home gym upper body, 40 minutes, no injuries. I only have adjustable dumbbells, a pull-up bar, and resistance bands.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 10735,
+          "draft": {
+            "date": "2026-07-07T17:27:38-04:00",
+            "notes": "Focus on controlled movements. Rest 60-90 seconds between working sets.",
+            "workoutFocus": "Upper Body",
+            "exercises": [
+              {
+                "name": "Band Pull-Aparts",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  }
+                ]
+              },
+              {
+                "name": "Pull-ups",
+                "sets": [
+                  {
+                    "reps": 5,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 5,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 5,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Floor Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Rows",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Overhead Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Bicep Curls",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 6,
+            "total_sets": 17,
+            "working_sets": 15,
+            "exercise_names": [
+              "Band Pull-Aparts",
+              "Pull-ups",
+              "Dumbbell Floor Press",
+              "Dumbbell Rows",
+              "Dumbbell Overhead Press",
+              "Dumbbell Bicep Curls"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-16",
+      "title": "Gym Pull Day No Cables Or Machines",
+      "prompt": "Full gym pull day, 55 minutes, no injuries, but don't use cables or machines.",
+      "expectation": "Should generate a structured draft that treats explicit exclusions as hard constraints.",
+      "expected_outcome": "generate_first_turn",
+      "forbidden_exercise_terms": [
+        "cable",
+        "machine"
+      ],
+      "follow_up_answer": "Use barbells, dumbbells, benches, and bodyweight only.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "structured draft generated on the first turn",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 34480,
+      "draft": {
+        "date": "2026-07-07T17:28:40-04:00",
+        "notes": "Focus on controlled movements. Rest 60-90 seconds between sets.",
+        "workoutFocus": "pull",
+        "exercises": [
+          {
+            "name": "Barbell Row",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Pull-up",
+            "sets": [
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Row",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Barbell Bicep Curl",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Hammer Curl",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 5,
+        "total_sets": 17,
+        "working_sets": 15,
+        "exercise_names": [
+          "Barbell Row",
+          "Pull-up",
+          "Dumbbell Row",
+          "Barbell Bicep Curl",
+          "Dumbbell Hammer Curl"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft",
+        "generate_workout_draft",
+        "generate_workout_draft"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Full gym pull day, 55 minutes, no injuries, but don't use cables or machines.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 34480,
+          "draft": {
+            "date": "2026-07-07T17:28:40-04:00",
+            "notes": "Focus on controlled movements. Rest 60-90 seconds between sets.",
+            "workoutFocus": "pull",
+            "exercises": [
+              {
+                "name": "Barbell Row",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Pull-up",
+                "sets": [
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Row",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Barbell Bicep Curl",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Hammer Curl",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 5,
+            "total_sets": 17,
+            "working_sets": 15,
+            "exercise_names": [
+              "Barbell Row",
+              "Pull-up",
+              "Dumbbell Row",
+              "Barbell Bicep Curl",
+              "Dumbbell Hammer Curl"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft",
+            "generate_workout_draft",
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-17",
+      "title": "Leg Day Time Revision",
+      "prompt": "Actually make it 35 minutes instead.",
+      "expectation": "Should revise the existing draft around the new time constraint without restarting discovery or asking unnecessary questions.",
+      "expected_outcome": "revise_without_restart",
+      "history": [
+        {
+          "role": "user",
+          "text": "Create a 60-minute leg workout at a commercial gym. No injuries."
+        },
+        {
+          "role": "assistant",
+          "text": "I put together a structured workout draft for you."
+        }
+      ],
+      "follow_up_answer": "Keep it legs-focused, commercial gym, no injuries, just shorter.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "revised the draft without restarting discovery",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 9855,
+      "draft": {
+        "date": "2026-07-07T17:29:22-04:00",
+        "notes": "Focus on controlled movement and proper form for each exercise.",
+        "workoutFocus": "Legs",
+        "exercises": [
+          {
+            "name": "Leg Press",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "warmup"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Barbell Romanian Deadlift",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Leg Extension",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 3,
+        "total_sets": 11,
+        "working_sets": 9,
+        "exercise_names": [
+          "Leg Press",
+          "Barbell Romanian Deadlift",
+          "Leg Extension"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Actually make it 35 minutes instead.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 9855,
+          "draft": {
+            "date": "2026-07-07T17:29:22-04:00",
+            "notes": "Focus on controlled movement and proper form for each exercise.",
+            "workoutFocus": "Legs",
+            "exercises": [
+              {
+                "name": "Leg Press",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Barbell Romanian Deadlift",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Leg Extension",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 3,
+            "total_sets": 11,
+            "working_sets": 9,
+            "exercise_names": [
+              "Leg Press",
+              "Barbell Romanian Deadlift",
+              "Leg Extension"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-18",
+      "title": "Workout And Meal Plan Request",
+      "prompt": "Make me a workout and meal plan for fat loss.",
+      "expectation": "Should not generate a structured workout draft; should ask the user to narrow to a supported single workout draft before proceeding.",
+      "expected_outcome": "narrow_scope_before_generating",
+      "follow_up_answer": "Focus on the workout only: beginner, no injuries, 35 minutes, full gym.",
+      "status": "structured_draft",
+      "passed": false,
+      "score_status": "fail",
+      "score_reason": "expected the first turn to ask the user to choose one workout or session",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 11254,
+      "draft": {
+        "date": "2026-07-07T17:30:05-04:00",
+        "notes": "Focus on controlled movements and good form throughout. Take 60-90 second rests between sets. For plank, reps indicate seconds held.",
+        "workoutFocus": "Full Body",
+        "exercises": [
+          {
+            "name": "Goblet Squat",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Bench Press",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Lat Pulldown",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Plank",
+            "sets": [
+              {
+                "reps": 45,
+                "setType": "working"
+              },
+              {
+                "reps": 45,
+                "setType": "working"
+              },
+              {
+                "reps": 45,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 4,
+        "total_sets": 12,
+        "working_sets": 12,
+        "exercise_names": [
+          "Goblet Squat",
+          "Dumbbell Bench Press",
+          "Lat Pulldown",
+          "Plank"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Make me a workout and meal plan for fat loss.",
+          "status": "follow_up_question",
+          "text": "I can help you create a workout plan, but I'm not able to assist with meal plans.\n\nTo design your workout, I need a few more details. What is your desired workout focus (e.g., full body, upper body, lower body, push, pull)? How long would you like the session to be? What equipment do you have available, or where will you be training? Also, do you have any current injuries?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1995,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "Focus on the workout only: beginner, no injuries, 35 minutes, full gym.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 9259,
+          "draft": {
+            "date": "2026-07-07T17:30:05-04:00",
+            "notes": "Focus on controlled movements and good form throughout. Take 60-90 second rests between sets. For plank, reps indicate seconds held.",
+            "workoutFocus": "Full Body",
+            "exercises": [
+              {
+                "name": "Goblet Squat",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Bench Press",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Lat Pulldown",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Plank",
+                "sets": [
+                  {
+                    "reps": 45,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 45,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 45,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 4,
+            "total_sets": 12,
+            "working_sets": 12,
+            "exercise_names": [
+              "Goblet Squat",
+              "Dumbbell Bench Press",
+              "Lat Pulldown",
+              "Plank"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "prompt-19",
+      "title": "Machine Chest Hypertrophy Follow-Up",
+      "prompt": "Hello I would like a chest workout for today. I have about an hour and a half with warm up included. Only machines and cables. Focusing on hypertrophy.",
+      "expectation": "Should ask about injuries first, then generate a structured machine-and-cable chest draft after a short no-injuries answer without failing workout contract validation.",
+      "expected_outcome": "ask_once_then_generate",
+      "follow_up_answer": "Nope.",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "asked one follow-up question, then generated a structured draft",
+      "text": "Here is a chest workout draft focusing on hypertrophy, using machines and cables, designed for 90 minutes.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 24729,
+      "draft": {
+        "date": "2026-07-07T17:30:44-04:00",
+        "notes": "Focus on controlled movements and mind-muscle connection. Aim for 60-90 seconds rest for isolation, 90-120 seconds for compound movements.",
+        "workoutFocus": "Chest",
+        "exercises": [
+          {
+            "name": "Machine Chest Press",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Incline Machine Press",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "warmup"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Cable Crossover (High-to-Low)",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "warmup"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Pec Deck Fly",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "warmup"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Cable Triceps Pushdown",
+            "sets": [
+              {
+                "reps": 15,
+                "setType": "warmup"
+              },
+              {
+                "reps": 15,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 5,
+        "total_sets": 24,
+        "working_sets": 18,
+        "exercise_names": [
+          "Machine Chest Press",
+          "Incline Machine Press",
+          "Cable Crossover (High-to-Low)",
+          "Pec Deck Fly",
+          "Cable Triceps Pushdown"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 2,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Hello I would like a chest workout for today. I have about an hour and a half with warm up included. Only machines and cables. Focusing on hypertrophy.",
+          "status": "follow_up_question",
+          "text": "Do you have any current injuries?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1018,
+          "attempts": 1
+        },
+        {
+          "turn": 2,
+          "prompt": "Nope.",
+          "status": "structured_draft",
+          "text": "Here is a chest workout draft focusing on hypertrophy, using machines and cables, designed for 90 minutes.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 23711,
+          "draft": {
+            "date": "2026-07-07T17:30:44-04:00",
+            "notes": "Focus on controlled movements and mind-muscle connection. Aim for 60-90 seconds rest for isolation, 90-120 seconds for compound movements.",
+            "workoutFocus": "Chest",
+            "exercises": [
+              {
+                "name": "Machine Chest Press",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Incline Machine Press",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Cable Crossover (High-to-Low)",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Pec Deck Fly",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Cable Triceps Pushdown",
+                "sets": [
+                  {
+                    "reps": 15,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 15,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 5,
+            "total_sets": 24,
+            "working_sets": 18,
+            "exercise_names": [
+              "Machine Chest Press",
+              "Incline Machine Press",
+              "Cable Crossover (High-to-Low)",
+              "Pec Deck Fly",
+              "Cable Triceps Pushdown"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "data-01",
+      "title": "Snapshot Last Workout",
+      "prompt": "When did I last work out?",
+      "expectation": "Should answer from the injected snapshot; a redundant get_workouts call is tolerated but a draft is not.",
+      "expected_outcome": "answer_without_tools",
+      "required_text_terms": [
+        "2026-07-03"
+      ],
+      "allowed_tool_calls": [
+        "get_workouts"
+      ],
+      "status": "text_only",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "answered correctly with tolerated tool calls: get_workouts",
+      "text": "Your last workout was on July 3, 2026. You did an upper body workout with Bench Press and Barbell Row.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 1876,
+      "tool_calls": [
+        "get_workouts"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "When did I last work out?",
+          "status": "text_only",
+          "text": "Your last workout was on July 3, 2026. You did an upper body workout with Bench Press and Barbell Row.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1876,
+          "tool_calls": [
+            "get_workouts"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "data-02",
+      "title": "Last Back Squat",
+      "prompt": "When did I last back squat?",
+      "expectation": "Should call get_workouts and answer from logged back squat data without an ambiguity detour.",
+      "expected_outcome": "answer_from_data",
+      "required_text_terms": [
+        "2026-06-30",
+        "squat"
+      ],
+      "status": "text_only",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "answered from workout data with get_workouts",
+      "text": "Your last back squat was on June 30, 2026.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 1579,
+      "tool_calls": [
+        "get_workouts"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "When did I last back squat?",
+          "status": "text_only",
+          "text": "Your last back squat was on June 30, 2026.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1579,
+          "tool_calls": [
+            "get_workouts"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "data-03",
+      "title": "Recent Bench Sets",
+      "prompt": "What bench press work have I logged recently?",
+      "expectation": "Should call get_workouts and summarize recent bench sessions.",
+      "expected_outcome": "answer_from_data",
+      "required_text_terms": [
+        "bench",
+        "2026-07-03"
+      ],
+      "status": "text_only",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "answered from workout data with get_workouts",
+      "text": "You last benched on July 3, 2026, with sets at 185x5 and 195x3. Before that, you benched on June 23 and May 30.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 1795,
+      "tool_calls": [
+        "get_workouts"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "What bench press work have I logged recently?",
+          "status": "text_only",
+          "text": "You last benched on July 3, 2026, with sets at 185x5 and 195x3. Before that, you benched on June 23 and May 30.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1795,
+          "tool_calls": [
+            "get_workouts"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "data-04",
+      "title": "Last Week Workouts",
+      "prompt": "What workouts did I do from 2026-06-23 through 2026-06-30?",
+      "expectation": "Should call get_workouts with date bounds and mention all three workouts in that range (dates may be rendered as prose, so match on the focus of each workout).",
+      "expected_outcome": "answer_from_data",
+      "required_text_terms": [
+        "push",
+        "pull",
+        "lower body"
+      ],
+      "status": "text_only",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "answered from workout data with get_workouts",
+      "text": "From June 23rd to June 30th, 2026, you did a push workout on the 23rd, a pull workout on the 27th, and a lower body workout on the 30th.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 1716,
+      "tool_calls": [
+        "get_workouts"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "What workouts did I do from 2026-06-23 through 2026-06-30?",
+          "status": "text_only",
+          "text": "From June 23rd to June 30th, 2026, you did a push workout on the 23rd, a pull workout on the 27th, and a lower body workout on the 30th.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1716,
+          "tool_calls": [
+            "get_workouts"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "data-05",
+      "title": "Ambiguous Row Lookup",
+      "prompt": "What rows have I done recently?",
+      "expectation": "Should call get_workouts and ask for clarification or mention matching row variants.",
+      "expected_outcome": "answer_from_data",
+      "required_text_terms": [
+        "row"
+      ],
+      "status": "follow_up_question",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "answered from workout data with get_workouts",
+      "text": "I found Barbell Rows, Chest Supported Rows, and One-Arm Dumbbell Rows in your workout history. Which of those are you asking about?",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 2566,
+      "tool_calls": [
+        "get_workouts"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "What rows have I done recently?",
+          "status": "follow_up_question",
+          "text": "I found Barbell Rows, Chest Supported Rows, and One-Arm Dumbbell Rows in your workout history. Which of those are you asking about?",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 2566,
+          "tool_calls": [
+            "get_workouts"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "data-06",
+      "title": "Deadlift History",
+      "prompt": "Show my recent deadlift workouts.",
+      "expectation": "Should call get_workouts and answer from fixture deadlift history.",
+      "expected_outcome": "answer_from_data",
+      "required_text_terms": [
+        "deadlift",
+        "2026-06-27"
+      ],
+      "status": "text_only",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "answered from workout data with get_workouts",
+      "text": "Here are 3 recent workouts that included deadlifts:\n\n*   **June 27, 2026 (pull focus):** Deadlift (275x3, 285x2), Barbell Row (165x6)\n*   **June 15, 2026 (pull focus):** Deadlift (265x4), One-Arm Dumbbell Row (75x10)\n*   **May 24, 2026 (full body focus):** Deadlift (255x5), Back Squat (205x6)",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 1732,
+      "tool_calls": [
+        "get_workouts"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Show my recent deadlift workouts.",
+          "status": "text_only",
+          "text": "Here are 3 recent workouts that included deadlifts:\n\n*   **June 27, 2026 (pull focus):** Deadlift (275x3, 285x2), Barbell Row (165x6)\n*   **June 15, 2026 (pull focus):** Deadlift (265x4), One-Arm Dumbbell Row (75x10)\n*   **May 24, 2026 (full body focus):** Deadlift (255x5), Back Squat (205x6)",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 1732,
+          "tool_calls": [
+            "get_workouts"
+          ],
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "data-07",
+      "title": "General Fitness No Tool",
+      "prompt": "What muscles do rows train?",
+      "expectation": "Should answer general fitness knowledge without data tools.",
+      "expected_outcome": "answer_without_tools",
+      "required_text_terms": [
+        "back"
+      ],
+      "status": "text_only",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "answered without tools",
+      "text": "Rows primarily train the muscles of the back, including the latissimus dorsi, rhomboids, trapezius, and erector spinae. They also engage the biceps and forearms as secondary muscles.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 628,
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "What muscles do rows train?",
+          "status": "text_only",
+          "text": "Rows primarily train the muscles of the back, including the latissimus dorsi, rhomboids, trapezius, and erector spinae. They also engage the biceps and forearms as secondary muscles.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 628,
+          "attempts": 1
+        }
+      ]
+    },
+    {
+      "id": "data-08",
+      "title": "Draft Guard With Data Fixtures",
+      "prompt": "Intermediate, 45 minutes, push day, full gym, no injuries. Build me a hypertrophy workout.",
+      "expectation": "Should still call only the workout draft tool for a normal draft request.",
+      "expected_outcome": "generate_first_turn",
+      "status": "structured_draft",
+      "passed": true,
+      "score_status": "pass",
+      "score_reason": "structured draft generated on the first turn",
+      "text": "I put together a structured workout draft for you.",
+      "model": "googleai/gemini-2.5-flash",
+      "duration_ms": 9252,
+      "draft": {
+        "date": "2026-07-07T17:35:20-04:00",
+        "notes": "Focus on 60-90 second rest between working sets.",
+        "workoutFocus": "Push",
+        "exercises": [
+          {
+            "name": "Barbell Bench Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              },
+              {
+                "reps": 8,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Shoulder Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "warmup"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Incline Dumbbell Press",
+            "sets": [
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              },
+              {
+                "reps": 10,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Cable Triceps Pushdown",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          },
+          {
+            "name": "Dumbbell Lateral Raise",
+            "sets": [
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              },
+              {
+                "reps": 12,
+                "setType": "working"
+              }
+            ]
+          }
+        ]
+      },
+      "draft_summary": {
+        "exercise_count": 5,
+        "total_sets": 17,
+        "working_sets": 15,
+        "exercise_names": [
+          "Barbell Bench Press",
+          "Dumbbell Shoulder Press",
+          "Incline Dumbbell Press",
+          "Cable Triceps Pushdown",
+          "Dumbbell Lateral Raise"
+        ]
+      },
+      "tool_calls": [
+        "generate_workout_draft"
+      ],
+      "attempts": 1,
+      "turns": [
+        {
+          "turn": 1,
+          "prompt": "Intermediate, 45 minutes, push day, full gym, no injuries. Build me a hypertrophy workout.",
+          "status": "structured_draft",
+          "text": "I put together a structured workout draft for you.",
+          "model": "googleai/gemini-2.5-flash",
+          "duration_ms": 9252,
+          "draft": {
+            "date": "2026-07-07T17:35:20-04:00",
+            "notes": "Focus on 60-90 second rest between working sets.",
+            "workoutFocus": "Push",
+            "exercises": [
+              {
+                "name": "Barbell Bench Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 8,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Shoulder Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "warmup"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Incline Dumbbell Press",
+                "sets": [
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 10,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Cable Triceps Pushdown",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              },
+              {
+                "name": "Dumbbell Lateral Raise",
+                "sets": [
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  },
+                  {
+                    "reps": 12,
+                    "setType": "working"
+                  }
+                ]
+              }
+            ]
+          },
+          "draft_summary": {
+            "exercise_count": 5,
+            "total_sets": 17,
+            "working_sets": 15,
+            "exercise_names": [
+              "Barbell Bench Press",
+              "Dumbbell Shoulder Press",
+              "Incline Dumbbell Press",
+              "Cable Triceps Pushdown",
+              "Dumbbell Lateral Raise"
+            ]
+          },
+          "tool_calls": [
+            "generate_workout_draft"
+          ],
+          "attempts": 1
+        }
+      ]
+    }
+  ]
+}

--- a/server/internal/aichat/models.go
+++ b/server/internal/aichat/models.go
@@ -166,6 +166,32 @@ type RuntimeChatMessage struct {
 	Text string
 }
 
+type WorkoutHistoryFilter struct {
+	LastN        int
+	StartDate    *time.Time
+	EndDate      *time.Time
+	ExerciseName string
+	WorkoutFocus string
+}
+
+type ChatWorkoutView struct {
+	Date      string             `json:"date"`
+	Focus     string             `json:"focus,omitempty"`
+	Notes     string             `json:"notes,omitempty"`
+	Exercises []ChatExerciseView `json:"exercises,omitempty"`
+}
+
+type ChatExerciseView struct {
+	Name string   `json:"name"`
+	Sets []string `json:"sets,omitempty"`
+}
+
+type TrainingSnapshot struct {
+	LastWorkoutDate string   `json:"last_workout_date,omitempty"`
+	WorkoutsLast30D int64    `json:"workouts_last_30d"`
+	TopExercises    []string `json:"top_exercises,omitempty"`
+}
+
 type StreamDone struct {
 	ConversationID int32                         `json:"conversation_id,omitempty"`
 	RunID          int32                         `json:"run_id,omitempty"`
@@ -174,6 +200,7 @@ type StreamDone struct {
 	Text           string                        `json:"text"`
 	Sequence       int32                         `json:"sequence,omitempty"`
 	WorkoutDraft   *workout.CreateWorkoutRequest `json:"workout_draft,omitempty"`
+	ToolCalls      []string                      `json:"tool_calls,omitempty"`
 }
 
 type StreamChunk struct {

--- a/server/internal/aichat/repository.go
+++ b/server/internal/aichat/repository.go
@@ -25,6 +25,7 @@ type SavedLatestWorkoutDraft struct {
 }
 
 type Repository interface {
+	ChatDataReader
 	CreateConversation(ctx context.Context, userID string) (*Conversation, error)
 	ListConversations(ctx context.Context, userID string, limit int32) ([]ConversationSummary, error)
 	GetConversation(ctx context.Context, conversationID int32, userID string) (*Conversation, error)

--- a/server/internal/aichat/repository_data.go
+++ b/server/internal/aichat/repository_data.go
@@ -1,0 +1,168 @@
+package aichat
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	db "github.com/Andrewy-gh/fittrack/server/internal/database"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const (
+	defaultChatWorkoutLimit = 5
+	maxChatWorkoutLimit     = 20
+)
+
+type ChatDataReader interface {
+	ListWorkoutsWithSets(ctx context.Context, userID string, filter WorkoutHistoryFilter) ([]ChatWorkoutView, error)
+	ResolveExerciseNames(ctx context.Context, userID string, query string) ([]string, error)
+	TrainingSnapshot(ctx context.Context, userID string) (*TrainingSnapshot, error)
+}
+
+func (r *repository) ListWorkoutsWithSets(ctx context.Context, userID string, filter WorkoutHistoryFilter) ([]ChatWorkoutView, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	filter = normalizeWorkoutHistoryFilter(filter)
+	rows, err := r.queries.ListWorkoutsWithSetsForChat(ctx, db.ListWorkoutsWithSetsForChatParams{
+		UserID:       userID,
+		StartDate:    timePtrToPg(filter.StartDate),
+		EndDate:      timePtrToPg(filter.EndDate),
+		ExerciseName: textToPg(strings.TrimSpace(filter.ExerciseName)),
+		WorkoutFocus: textToPg(strings.TrimSpace(filter.WorkoutFocus)),
+		RowLimit:     int32(filter.LastN),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list workouts with sets for ai chat: %w", err)
+	}
+
+	workouts, err := mapChatWorkoutRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	return workouts, nil
+}
+
+func (r *repository) ResolveExerciseNames(ctx context.Context, userID string, query string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	rows, err := r.queries.ListExerciseNameMatches(ctx, db.ListExerciseNameMatchesParams{
+		UserID:    userID,
+		NameQuery: strings.TrimSpace(query),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list exercise name matches for ai chat: %w", err)
+	}
+
+	names := make([]string, 0, len(rows))
+	for _, row := range rows {
+		names = append(names, row.Name)
+	}
+	return names, nil
+}
+
+func (r *repository) TrainingSnapshot(ctx context.Context, userID string) (*TrainingSnapshot, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	stats, err := r.queries.GetChatWorkoutSnapshotStats(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get ai chat workout snapshot stats: %w", err)
+	}
+	topRows, err := r.queries.ListTopExercisesByFrequency(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list top exercises by frequency for ai chat: %w", err)
+	}
+
+	snapshot := &TrainingSnapshot{
+		WorkoutsLast30D: stats.WorkoutsLast30d,
+		TopExercises:    make([]string, 0, len(topRows)),
+	}
+	if stats.LastWorkoutDate.Valid {
+		snapshot.LastWorkoutDate = stats.LastWorkoutDate.Time.Format("2006-01-02")
+	}
+	for _, row := range topRows {
+		snapshot.TopExercises = append(snapshot.TopExercises, row.Name)
+	}
+
+	return snapshot, nil
+}
+
+func normalizeWorkoutHistoryFilter(filter WorkoutHistoryFilter) WorkoutHistoryFilter {
+	if filter.LastN <= 0 {
+		filter.LastN = defaultChatWorkoutLimit
+	}
+	if filter.LastN > maxChatWorkoutLimit {
+		filter.LastN = maxChatWorkoutLimit
+	}
+	return filter
+}
+
+func mapChatWorkoutRows(rows []db.ListWorkoutsWithSetsForChatRow) ([]ChatWorkoutView, error) {
+	workouts := make([]ChatWorkoutView, 0)
+	workoutIndexes := make(map[int32]int)
+	exerciseIndexes := make(map[int32]map[string]int)
+
+	for _, row := range rows {
+		workoutIndex, ok := workoutIndexes[row.WorkoutID]
+		if !ok {
+			workout := ChatWorkoutView{
+				Date: row.Date.Time.Format("2006-01-02"),
+			}
+			if row.WorkoutFocus.Valid {
+				workout.Focus = row.WorkoutFocus.String
+			}
+			if row.Notes.Valid {
+				workout.Notes = row.Notes.String
+			}
+			workoutIndexes[row.WorkoutID] = len(workouts)
+			exerciseIndexes[row.WorkoutID] = make(map[string]int)
+			workouts = append(workouts, workout)
+			workoutIndex = len(workouts) - 1
+		}
+
+		if !row.ExerciseName.Valid {
+			continue
+		}
+		exerciseName := row.ExerciseName.String
+		perWorkout := exerciseIndexes[row.WorkoutID]
+		exerciseIndex, ok := perWorkout[exerciseName]
+		if !ok {
+			workouts[workoutIndex].Exercises = append(workouts[workoutIndex].Exercises, ChatExerciseView{Name: exerciseName})
+			exerciseIndex = len(workouts[workoutIndex].Exercises) - 1
+			perWorkout[exerciseName] = exerciseIndex
+		}
+
+		if row.Reps.Valid && row.SetType.Valid {
+			setText, err := formatChatSet(row.Weight, row.Reps.Int32, row.SetType.String)
+			if err != nil {
+				return nil, err
+			}
+			workouts[workoutIndex].Exercises[exerciseIndex].Sets = append(workouts[workoutIndex].Exercises[exerciseIndex].Sets, setText)
+		}
+	}
+
+	return workouts, nil
+}
+
+func formatChatSet(weight pgtype.Numeric, reps int32, setType string) (string, error) {
+	setType = strings.TrimSpace(setType)
+	if weight.Valid {
+		f64, err := weight.Float64Value()
+		if err != nil {
+			return "", fmt.Errorf("convert ai chat workout set weight: %w", err)
+		}
+		return fmt.Sprintf("%sx%d %s", formatSetWeight(f64.Float64), reps, setType), nil
+	}
+	return fmt.Sprintf("%d reps %s", reps, setType), nil
+}
+
+func formatSetWeight(weight float64) string {
+	text := fmt.Sprintf("%.1f", weight)
+	return strings.TrimSuffix(strings.TrimSuffix(text, "0"), ".")
+}
+
+var _ ChatDataReader = (*repository)(nil)

--- a/server/internal/aichat/repository_data_integration_test.go
+++ b/server/internal/aichat/repository_data_integration_test.go
@@ -1,0 +1,182 @@
+package aichat
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	db "github.com/Andrewy-gh/fittrack/server/internal/database"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepositoryChatDataReader_FiltersByUserDateAndExercise(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database-backed AI chat repository test in short mode")
+	}
+
+	pool, cleanup := setupAIChatRepositoryTestDatabase(t)
+	if pool == nil {
+		return
+	}
+	defer cleanup()
+
+	const userID = "aichat-data-reader-user"
+	const otherUserID = "aichat-data-reader-other-user"
+	ctx := context.Background()
+	seedAIChatRepositoryTestUser(t, pool, userID)
+	seedAIChatRepositoryTestUser(t, pool, otherUserID)
+
+	seedAIChatDataWorkout(t, pool, userID, "2026-06-30", "lower body", []chatDataExerciseSeed{
+		{name: "Back Squat", sets: []chatDataSetSeed{{weight: ptrFloat64(225), reps: 5, setType: "working"}, {weight: ptrFloat64(235), reps: 3, setType: "working"}}},
+	})
+	seedAIChatDataWorkout(t, pool, userID, "2026-06-15", "pull", []chatDataExerciseSeed{
+		{name: "Deadlift", sets: []chatDataSetSeed{{weight: ptrFloat64(275), reps: 3, setType: "working"}}},
+	})
+	seedAIChatDataWorkout(t, pool, userID, "2026-05-20", "lower body", []chatDataExerciseSeed{
+		{name: "Back Squat", sets: []chatDataSetSeed{{weight: ptrFloat64(205), reps: 5, setType: "working"}}},
+	})
+	seedAIChatDataWorkout(t, pool, otherUserID, "2026-06-29", "lower body", []chatDataExerciseSeed{
+		{name: "Back Squat", sets: []chatDataSetSeed{{weight: ptrFloat64(315), reps: 1, setType: "working"}}},
+	})
+
+	repo := NewRepository(slog.New(slog.NewTextHandler(io.Discard, nil)), db.New(pool), pool)
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 30, 23, 59, 59, 0, time.UTC)
+	workouts, err := repo.ListWorkoutsWithSets(ctx, userID, WorkoutHistoryFilter{
+		LastN:        10,
+		StartDate:    &start,
+		EndDate:      &end,
+		ExerciseName: "Back Squat",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, workouts, 1)
+	assert.Equal(t, "2026-06-30", workouts[0].Date)
+	assert.Equal(t, "lower body", workouts[0].Focus)
+	require.Len(t, workouts[0].Exercises, 1)
+	assert.Equal(t, "Back Squat", workouts[0].Exercises[0].Name)
+	assert.Equal(t, []string{"225x5 working", "235x3 working"}, workouts[0].Exercises[0].Sets)
+}
+
+func TestRepositoryChatDataReader_ResolveNamesAndSnapshotAreUserScoped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database-backed AI chat repository test in short mode")
+	}
+
+	pool, cleanup := setupAIChatRepositoryTestDatabase(t)
+	if pool == nil {
+		return
+	}
+	defer cleanup()
+
+	const userID = "aichat-data-reader-user"
+	const otherUserID = "aichat-data-reader-other-user"
+	ctx := context.Background()
+	seedAIChatRepositoryTestUser(t, pool, userID)
+	seedAIChatRepositoryTestUser(t, pool, otherUserID)
+
+	seedAIChatDataWorkout(t, pool, userID, time.Now().UTC().AddDate(0, 0, -2).Format("2006-01-02"), "push", []chatDataExerciseSeed{
+		{name: "Bench Press", sets: []chatDataSetSeed{{weight: ptrFloat64(185), reps: 5, setType: "working"}}},
+		{name: "Barbell Row", sets: []chatDataSetSeed{{weight: ptrFloat64(155), reps: 8, setType: "working"}}},
+	})
+	seedAIChatDataWorkout(t, pool, userID, time.Now().UTC().AddDate(0, 0, -8).Format("2006-01-02"), "pull", []chatDataExerciseSeed{
+		{name: "Bench Press", sets: []chatDataSetSeed{{weight: ptrFloat64(175), reps: 6, setType: "working"}}},
+	})
+	seedAIChatDataWorkout(t, pool, otherUserID, time.Now().UTC().Format("2006-01-02"), "push", []chatDataExerciseSeed{
+		{name: "Bench Machine", sets: []chatDataSetSeed{{weight: ptrFloat64(250), reps: 4, setType: "working"}}},
+	})
+
+	repo := NewRepository(slog.New(slog.NewTextHandler(io.Discard, nil)), db.New(pool), pool)
+	names, err := repo.ResolveExerciseNames(ctx, userID, "bench")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Bench Press"}, names)
+
+	snapshot, err := repo.TrainingSnapshot(ctx, userID)
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+	assert.NotEmpty(t, snapshot.LastWorkoutDate)
+	assert.EqualValues(t, 2, snapshot.WorkoutsLast30D)
+	assert.Contains(t, snapshot.TopExercises, "Bench Press")
+	assert.NotContains(t, snapshot.TopExercises, "Bench Machine")
+}
+
+func TestRepositoryChatDataReader_CapsWorkoutLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database-backed AI chat repository test in short mode")
+	}
+
+	pool, cleanup := setupAIChatRepositoryTestDatabase(t)
+	if pool == nil {
+		return
+	}
+	defer cleanup()
+
+	const userID = "aichat-data-reader-limit-user"
+	ctx := context.Background()
+	seedAIChatRepositoryTestUser(t, pool, userID)
+	for i := 0; i < 25; i++ {
+		date := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC).AddDate(0, 0, -i).Format("2006-01-02")
+		seedAIChatDataWorkout(t, pool, userID, date, "general", []chatDataExerciseSeed{
+			{name: "Bench Press", sets: []chatDataSetSeed{{weight: ptrFloat64(135), reps: 5, setType: "working"}}},
+		})
+	}
+
+	repo := NewRepository(slog.New(slog.NewTextHandler(io.Discard, nil)), db.New(pool), pool)
+	workouts, err := repo.ListWorkoutsWithSets(ctx, userID, WorkoutHistoryFilter{LastN: 99})
+
+	require.NoError(t, err)
+	require.Len(t, workouts, 20)
+	assert.Equal(t, "2026-07-01", workouts[0].Date)
+	assert.Equal(t, "2026-06-12", workouts[19].Date)
+}
+
+type chatDataExerciseSeed struct {
+	name string
+	sets []chatDataSetSeed
+}
+
+type chatDataSetSeed struct {
+	weight  *float64
+	reps    int32
+	setType string
+}
+
+func seedAIChatDataWorkout(t *testing.T, pool *pgxpool.Pool, userID string, date string, focus string, exercises []chatDataExerciseSeed) {
+	t.Helper()
+
+	ctx := context.Background()
+	var workoutID int32
+	err := pool.QueryRow(ctx, `
+		INSERT INTO workout (date, workout_focus, user_id)
+		VALUES ($1::date, $2, $3)
+		RETURNING id
+	`, date, focus, userID).Scan(&workoutID)
+	require.NoError(t, err)
+
+	for exerciseIndex, exercise := range exercises {
+		var exerciseID int32
+		err = pool.QueryRow(ctx, `
+			INSERT INTO exercise (name, user_id)
+			VALUES ($1, $2)
+			ON CONFLICT (user_id, name) DO UPDATE SET name = EXCLUDED.name
+			RETURNING id
+		`, exercise.name, userID).Scan(&exerciseID)
+		require.NoError(t, err)
+
+		for setIndex, set := range exercise.sets {
+			_, err = pool.Exec(ctx, `
+				INSERT INTO "set" (exercise_id, workout_id, weight, reps, set_type, user_id, exercise_order, set_order)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			`, exerciseID, workoutID, set.weight, set.reps, set.setType, userID, exerciseIndex+1, setIndex+1)
+			require.NoError(t, err)
+		}
+	}
+}
+
+func ptrFloat64(value float64) *float64 {
+	return &value
+}

--- a/server/internal/aichat/repository_data_integration_test.go
+++ b/server/internal/aichat/repository_data_integration_test.go
@@ -32,6 +32,7 @@ func TestRepositoryChatDataReader_FiltersByUserDateAndExercise(t *testing.T) {
 
 	seedAIChatDataWorkout(t, pool, userID, "2026-06-30", "lower body", []chatDataExerciseSeed{
 		{name: "Back Squat", sets: []chatDataSetSeed{{weight: ptrFloat64(225), reps: 5, setType: "working"}, {weight: ptrFloat64(235), reps: 3, setType: "working"}}},
+		{name: "Romanian Deadlift", sets: []chatDataSetSeed{{weight: ptrFloat64(185), reps: 8, setType: "working"}}},
 	})
 	seedAIChatDataWorkout(t, pool, userID, "2026-06-15", "pull", []chatDataExerciseSeed{
 		{name: "Deadlift", sets: []chatDataSetSeed{{weight: ptrFloat64(275), reps: 3, setType: "working"}}},

--- a/server/internal/aichat/repository_data_test.go
+++ b/server/internal/aichat/repository_data_test.go
@@ -1,0 +1,77 @@
+package aichat
+
+import (
+	"testing"
+	"time"
+
+	db "github.com/Andrewy-gh/fittrack/server/internal/database"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestMapChatWorkoutRowsRegroupsFlatRows(t *testing.T) {
+	rows := []db.ListWorkoutsWithSetsForChatRow{
+		chatWorkoutRow(2, "2026-07-03", "upper", "Bench Press", 1, 1, numericWeight(t, "185"), 5, "working"),
+		chatWorkoutRow(2, "2026-07-03", "upper", "Bench Press", 1, 2, numericWeight(t, "195"), 3, "working"),
+		chatWorkoutRow(2, "2026-07-03", "upper", "Barbell Row", 2, 1, numericWeight(t, "155.5"), 8, "working"),
+		chatWorkoutRow(1, "2026-06-30", "lower", "Back Squat", 1, 1, pgtype.Numeric{}, 10, "warmup"),
+	}
+
+	workouts, err := mapChatWorkoutRows(rows)
+	if err != nil {
+		t.Fatalf("mapChatWorkoutRows() error = %v", err)
+	}
+	if len(workouts) != 2 {
+		t.Fatalf("mapChatWorkoutRows() returned %d workouts, want 2", len(workouts))
+	}
+	if workouts[0].Date != "2026-07-03" || workouts[0].Focus != "upper" {
+		t.Fatalf("first workout = %#v", workouts[0])
+	}
+	if len(workouts[0].Exercises) != 2 {
+		t.Fatalf("first workout exercises = %#v, want 2 exercises", workouts[0].Exercises)
+	}
+	if got := workouts[0].Exercises[0].Sets; len(got) != 2 || got[0] != "185x5 working" || got[1] != "195x3 working" {
+		t.Fatalf("bench sets = %#v", got)
+	}
+	if got := workouts[0].Exercises[1].Sets; len(got) != 1 || got[0] != "155.5x8 working" {
+		t.Fatalf("row sets = %#v", got)
+	}
+	if got := workouts[1].Exercises[0].Sets; len(got) != 1 || got[0] != "10 reps warmup" {
+		t.Fatalf("bodyweight sets = %#v", got)
+	}
+}
+
+func TestNormalizeWorkoutHistoryFilterCapsLastN(t *testing.T) {
+	if got := normalizeWorkoutHistoryFilter(WorkoutHistoryFilter{}).LastN; got != defaultChatWorkoutLimit {
+		t.Fatalf("default LastN = %d, want %d", got, defaultChatWorkoutLimit)
+	}
+	if got := normalizeWorkoutHistoryFilter(WorkoutHistoryFilter{LastN: 99}).LastN; got != maxChatWorkoutLimit {
+		t.Fatalf("capped LastN = %d, want %d", got, maxChatWorkoutLimit)
+	}
+	if got := normalizeWorkoutHistoryFilter(WorkoutHistoryFilter{LastN: 12}).LastN; got != 12 {
+		t.Fatalf("LastN = %d, want 12", got)
+	}
+}
+
+func chatWorkoutRow(workoutID int32, date string, focus string, exercise string, exerciseOrder int32, setOrder int32, weight pgtype.Numeric, reps int32, setType string) db.ListWorkoutsWithSetsForChatRow {
+	parsed, _ := time.Parse("2006-01-02", date)
+	return db.ListWorkoutsWithSetsForChatRow{
+		WorkoutID:     workoutID,
+		Date:          pgtype.Timestamptz{Time: parsed, Valid: true},
+		WorkoutFocus:  pgtype.Text{String: focus, Valid: true},
+		ExerciseName:  pgtype.Text{String: exercise, Valid: true},
+		ExerciseOrder: pgtype.Int4{Int32: exerciseOrder, Valid: true},
+		SetOrder:      pgtype.Int4{Int32: setOrder, Valid: true},
+		Weight:        weight,
+		Reps:          pgtype.Int4{Int32: reps, Valid: true},
+		SetType:       pgtype.Text{String: setType, Valid: true},
+	}
+}
+
+func numericWeight(t *testing.T, value string) pgtype.Numeric {
+	t.Helper()
+	var numeric pgtype.Numeric
+	if err := numeric.Scan(value); err != nil {
+		t.Fatalf("scan numeric weight: %v", err)
+	}
+	return numeric
+}

--- a/server/internal/aichat/repository_integration_test.go
+++ b/server/internal/aichat/repository_integration_test.go
@@ -570,6 +570,12 @@ func setupAIChatRepositoryTestDatabase(t *testing.T) (*pgxpool.Pool, func()) {
 		require.NoError(t, err)
 		_, err = pool.Exec(ctx, "DELETE FROM users WHERE user_id = $1", "aichat-trial-failed-start-user")
 		require.NoError(t, err)
+		_, err = pool.Exec(ctx, "DELETE FROM users WHERE user_id = $1", "aichat-data-reader-user")
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx, "DELETE FROM users WHERE user_id = $1", "aichat-data-reader-other-user")
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx, "DELETE FROM users WHERE user_id = $1", "aichat-data-reader-limit-user")
+		require.NoError(t, err)
 
 		for _, table := range tables {
 			_, err := pool.Exec(ctx, "ALTER TABLE "+table+" ENABLE ROW LEVEL SECURITY")

--- a/server/internal/aichat/runtime.go
+++ b/server/internal/aichat/runtime.go
@@ -14,6 +14,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 
 	"github.com/Andrewy-gh/fittrack/server/internal/request"
+	"github.com/Andrewy-gh/fittrack/server/internal/user"
 )
 
 const (
@@ -21,6 +22,9 @@ const (
 	googleAPIKeyEnvVar = "GOOGLE_API_KEY"
 	chatStreamTimeout  = chatGenerationTimeout
 	chatMaxTurns       = 6
+	// chatEmptyResponseRetryLimit caps regeneration attempts when the model
+	// returns an empty candidate with no text and no tool calls.
+	chatEmptyResponseRetryLimit = 1
 )
 
 var genkitInit = func(ctx context.Context, opts ...genkit.GenkitOption) *genkit.Genkit {
@@ -32,31 +36,35 @@ type GenkitRuntime struct {
 	modelName        string
 	g                *genkit.Genkit
 	workoutDraftTool ai.Tool
+	getWorkoutsTool  ai.Tool
+	dataReader       ChatDataReader
 }
 
-func NewGenkitRuntime(ctx context.Context) *GenkitRuntime {
+func NewGenkitRuntime(ctx context.Context, reader ChatDataReader) *GenkitRuntime {
 	modelName := resolveModelName()
 	runtime := &GenkitRuntime{
-		modelName: modelName,
+		modelName:  modelName,
+		dataReader: reader,
 	}
 
 	if configuredAPIKeyEnvVar() == "" {
 		return runtime
 	}
 
-	g, workoutDraftTool, ok := activateGenkitRuntime(ctx, modelName)
+	g, workoutDraftTool, getWorkoutsTool, ok := activateGenkitRuntime(ctx, modelName, reader)
 	if !ok {
 		return runtime
 	}
 
 	runtime.g = g
 	runtime.workoutDraftTool = workoutDraftTool
+	runtime.getWorkoutsTool = getWorkoutsTool
 	runtime.available = true
 
 	return runtime
 }
 
-func activateGenkitRuntime(ctx context.Context, modelName string) (_ *genkit.Genkit, _ ai.Tool, ok bool) {
+func activateGenkitRuntime(ctx context.Context, modelName string, reader ChatDataReader) (_ *genkit.Genkit, _ ai.Tool, _ ai.Tool, ok bool) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			slog.Warn("ai chat runtime initialization skipped after genkit panic",
@@ -73,8 +81,12 @@ func activateGenkitRuntime(ctx context.Context, modelName string) (_ *genkit.Gen
 	)
 
 	workoutDraftTool := defineWorkoutDraftTool(g, modelName)
+	var getWorkoutsTool ai.Tool
+	if reader != nil {
+		getWorkoutsTool = defineGetWorkoutsTool(g, reader)
+	}
 
-	return g, workoutDraftTool, true
+	return g, workoutDraftTool, getWorkoutsTool, true
 }
 
 func (r *GenkitRuntime) ModelName() string {
@@ -149,11 +161,12 @@ func (r *GenkitRuntime) StreamChat(ctx context.Context, prompt string, history [
 
 	var builder strings.Builder
 	firstModelDelta := false
+	snapshot := r.trainingSnapshotForChat(ctx)
 	opts := []ai.GenerateOption{
 		ai.WithModelName(r.modelName),
-		ai.WithTools(r.workoutDraftTool),
+		ai.WithTools(r.chatTools()...),
 		ai.WithMaxTurns(chatMaxTurns),
-		ai.WithMessages(buildChatMessages(history)...),
+		ai.WithMessages(buildChatMessages(history, snapshot, r.dataReader != nil)...),
 		ai.WithPrompt(prompt),
 		ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
 			delta := collectChunkText(chunk)
@@ -181,12 +194,30 @@ func (r *GenkitRuntime) StreamChat(ctx context.Context, prompt string, history [
 		"history_messages", len(history),
 		"request_id", request.GetRequestID(ctx),
 	)
-	resp, err := genkit.Generate(streamCtx, r.g, opts...)
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(streamCtx.Err(), context.DeadlineExceeded) {
-			return nil, fmt.Errorf("%w: %v", ErrGenerationTimeout, err)
+	var resp *ai.ModelResponse
+	for attempt := 1; ; attempt++ {
+		builder.Reset()
+		var err error
+		resp, err = genkit.Generate(streamCtx, r.g, opts...)
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(streamCtx.Err(), context.DeadlineExceeded) {
+				return nil, fmt.Errorf("%w: %v", ErrGenerationTimeout, err)
+			}
+			return nil, fmt.Errorf("stream ai chat response: %w", err)
 		}
-		return nil, fmt.Errorf("stream ai chat response: %w", err)
+		if attempt > chatEmptyResponseRetryLimit || !isEmptyChatModelResponse(resp, builder.String()) {
+			break
+		}
+		// Gemini intermittently returns an empty candidate (for example on
+		// MALFORMED_FUNCTION_CALL) when multiple tools are registered; an empty
+		// reply is never a valid chat outcome, so retry the generation.
+		slog.Warn("ai chat model returned an empty response with no tool activity; retrying",
+			"model", r.modelName,
+			"finish_reason", resp.FinishReason,
+			"finish_message", resp.FinishMessage,
+			"attempt", attempt,
+			"request_id", request.GetRequestID(ctx),
+		)
 	}
 	logAIChatTraceContext(ctx, "runtime_generate_finished",
 		"elapsed_ms", time.Since(traceStartedAt).Milliseconds(),
@@ -203,13 +234,55 @@ func (r *GenkitRuntime) StreamChat(ctx context.Context, prompt string, history [
 	if err != nil {
 		return nil, fmt.Errorf("extract workout draft from history: %w", err)
 	}
+	toolCalls := extractToolCallsFromHistory(resp.History())
 	text = finalizeAssistantText(text, workoutDraft)
 
 	return &StreamDone{
 		Model:        r.modelName,
 		Text:         text,
 		WorkoutDraft: workoutDraft,
+		ToolCalls:    toolCalls,
 	}, nil
+}
+
+func isEmptyChatModelResponse(resp *ai.ModelResponse, streamedText string) bool {
+	if resp == nil {
+		return true
+	}
+	if strings.TrimSpace(resp.Text()) != "" || strings.TrimSpace(streamedText) != "" {
+		return false
+	}
+	return len(extractToolCallsFromHistory(resp.History())) == 0
+}
+
+func (r *GenkitRuntime) chatTools() []ai.ToolRef {
+	if r == nil || r.workoutDraftTool == nil {
+		return nil
+	}
+	tools := []ai.ToolRef{r.workoutDraftTool}
+	if r.getWorkoutsTool != nil {
+		tools = append(tools, r.getWorkoutsTool)
+	}
+	return tools
+}
+
+func (r *GenkitRuntime) trainingSnapshotForChat(ctx context.Context) *TrainingSnapshot {
+	if r == nil || r.dataReader == nil {
+		return nil
+	}
+	userID, ok := user.Current(ctx)
+	if !ok || strings.TrimSpace(userID) == "" {
+		return nil
+	}
+	snapshot, err := r.dataReader.TrainingSnapshot(ctx, userID)
+	if err != nil {
+		slog.Warn("ai chat training snapshot omitted after reader error",
+			"error", err,
+			"request_id", request.GetRequestID(ctx),
+		)
+		return nil
+	}
+	return snapshot
 }
 
 func configuredAPIKeyEnvVar() string {
@@ -251,9 +324,9 @@ User validation prompt:
 %s`, prompt)
 }
 
-func buildChatMessages(history []RuntimeChatMessage) []*ai.Message {
+func buildChatMessages(history []RuntimeChatMessage, snapshot *TrainingSnapshot, dataToolsEnabled bool) []*ai.Message {
 	messages := []*ai.Message{
-		ai.NewSystemMessage(ai.NewTextPart(buildChatSystemPrompt())),
+		ai.NewSystemMessage(ai.NewTextPart(buildChatSystemPrompt(snapshot, time.Now(), dataToolsEnabled))),
 	}
 
 	for _, message := range history {
@@ -272,13 +345,24 @@ func buildChatMessages(history []RuntimeChatMessage) []*ai.Message {
 	return messages
 }
 
-func buildChatSystemPrompt() string {
+func buildChatSystemPrompt(snapshot *TrainingSnapshot, now time.Time, dataToolsEnabled bool) string {
+	personalDataRule := "- Never guess or invent personal workout history. Say you do not have workout data available in this chat when asked about personal training history. Do not call data tools for general fitness knowledge."
+	if dataToolsEnabled {
+		personalDataRule = fmt.Sprintf(`- For questions about the user's logged workouts or personal training history, call the %s tool. Never guess or invent workout history; if no data exists, say so. Do not call data tools for general fitness knowledge.
+- The %s tool and the training snapshot exist only to answer questions about past training. When the user asks you to build a workout, do not call %s: follow the workout-building rules below and always respond with either a follow-up question or a %s tool call, never an empty reply. The snapshot and logged history never satisfy the workout-building inputs below — in particular, they say nothing about current injury status, so still ask about injuries when that is missing.`, getWorkoutsToolName, getWorkoutsToolName, getWorkoutsToolName, workoutDraftToolName)
+	}
+	currentDateSection := fmt.Sprintf("Current date: %s.", now.Format("2006-01-02"))
+	snapshotSection := buildTrainingSnapshotPromptSection(snapshot)
+
 	return fmt.Sprintf(`You are FitTrack's in-app training assistant.
 
 Rules:
 - Stay focused on fitness, training, recovery, exercise selection, and how to use FitTrack.
 - Keep answers concise, practical, and safe.
-- Base your response on the visible conversation only. Do not invent personal history or workout data.
+%s
+
+%s
+%s
 
 When the user wants you to build a workout:
 - Review the visible conversation first and reason about which workout inputs are already confirmed versus still missing.
@@ -311,7 +395,26 @@ Examples:
 - If the user says "45-minute back workout, cables only, no injuries," call the workout draft tool and choose cable-only movements instead of asking what other equipment they have.
 - If the user first asks for a 4-day split, say FitTrack builds one workout at a time and ask them to choose one day or session to start. If they then say "Let's start with day one as an upper-body workout. No injuries, full gym, 45 minutes," call the %s tool for that upper-body session.
 - If the user says "swap anything that bothers my knee/elbow/shoulder/back/wrist" after a draft, ask which movements, ranges, or exercise patterns bother that body part before revising.
-- If the user asks to swap or revise a generated workout later, gather only the extra details needed for the revision and stay concise.`, workoutChatFollowUpQuestionCeiling, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName)
+- If the user asks to swap or revise a generated workout later, gather only the extra details needed for the revision and stay concise.`, personalDataRule, currentDateSection, snapshotSection, workoutChatFollowUpQuestionCeiling, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName, workoutDraftToolName)
+}
+
+func buildTrainingSnapshotPromptSection(snapshot *TrainingSnapshot) string {
+	if snapshot == nil {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.WriteString("\nUser training snapshot:\n")
+	if strings.TrimSpace(snapshot.LastWorkoutDate) != "" {
+		builder.WriteString(fmt.Sprintf("- Last workout: %s\n", snapshot.LastWorkoutDate))
+	} else {
+		builder.WriteString("- Last workout: none logged\n")
+	}
+	builder.WriteString(fmt.Sprintf("- Workouts in last 30 days: %d\n", snapshot.WorkoutsLast30D))
+	if len(snapshot.TopExercises) > 0 {
+		builder.WriteString(fmt.Sprintf("- Most frequent exercises: %s\n", strings.Join(snapshot.TopExercises, ", ")))
+	}
+	return strings.TrimRight(builder.String(), "\n")
 }
 
 func collectChunkText(chunk *ai.ModelResponseChunk) string {

--- a/server/internal/aichat/runtime_test.go
+++ b/server/internal/aichat/runtime_test.go
@@ -5,7 +5,10 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 )
 
@@ -66,7 +69,7 @@ func TestNewGenkitRuntimeReturnsUnavailableWithoutGoogleAPIKey(t *testing.T) {
 	t.Setenv(googleAPIKeyEnvVar, "")
 	t.Setenv(geminiAPIKeyEnvVar, "")
 
-	runtime := NewGenkitRuntime(context.Background())
+	runtime := NewGenkitRuntime(context.Background(), nil)
 
 	if runtime == nil {
 		t.Fatal("NewGenkitRuntime() returned nil")
@@ -88,7 +91,7 @@ func TestNewGenkitRuntimeSkipsAvailabilityWhenGenkitPanics(t *testing.T) {
 		genkitInit = original
 	})
 
-	runtime := NewGenkitRuntime(context.Background())
+	runtime := NewGenkitRuntime(context.Background(), nil)
 
 	if runtime == nil {
 		t.Fatal("NewGenkitRuntime() returned nil")
@@ -117,7 +120,7 @@ func TestWorkoutDraftToolNameIsGeminiCompatible(t *testing.T) {
 
 func TestPromptsReferenceToolNames(t *testing.T) {
 	structuredPrompt := buildStructuredPrompt("test prompt")
-	chatPrompt := buildChatSystemPrompt()
+	chatPrompt := buildChatSystemPrompt(nil, time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC), true)
 
 	if strings.Contains(structuredPrompt, "list_active_features") {
 		t.Fatalf("buildStructuredPrompt() = %q, should not reference active feature tools", structuredPrompt)
@@ -129,3 +132,129 @@ func TestPromptsReferenceToolNames(t *testing.T) {
 		t.Fatalf("buildChatSystemPrompt() = %q, want workout tool name %q", chatPrompt, workoutDraftToolName)
 	}
 }
+
+func TestBuildChatSystemPromptComposesDataSections(t *testing.T) {
+	snapshot := &TrainingSnapshot{
+		LastWorkoutDate: "2026-07-03",
+		WorkoutsLast30D: 7,
+		TopExercises:    []string{"Bench Press", "Back Squat"},
+	}
+	prompt := buildChatSystemPrompt(snapshot, time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC), true)
+
+	for _, snippet := range []string{
+		"call the " + getWorkoutsToolName + " tool",
+		"When the user asks you to build a workout, do not call " + getWorkoutsToolName,
+		"Current date: 2026-07-06.",
+		"User training snapshot:",
+		"Last workout: 2026-07-03",
+		"Workouts in last 30 days: 7",
+		"Most frequent exercises: Bench Press, Back Squat",
+	} {
+		if !strings.Contains(prompt, snippet) {
+			t.Fatalf("buildChatSystemPrompt() missing %q\nprompt=%s", snippet, prompt)
+		}
+	}
+}
+
+func TestBuildChatSystemPromptOmitsSnapshotAndDataToolWhenReaderNil(t *testing.T) {
+	prompt := buildChatSystemPrompt(nil, time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC), false)
+
+	if strings.Contains(prompt, "User training snapshot:") {
+		t.Fatalf("buildChatSystemPrompt() included snapshot without reader: %s", prompt)
+	}
+	if strings.Contains(prompt, getWorkoutsToolName) {
+		t.Fatalf("buildChatSystemPrompt() referenced data tool without reader: %s", prompt)
+	}
+	if !strings.Contains(prompt, "Do not call data tools for general fitness knowledge.") {
+		t.Fatalf("buildChatSystemPrompt() missing nil-reader data routing rule: %s", prompt)
+	}
+}
+
+func TestIsEmptyChatModelResponse(t *testing.T) {
+	cases := []struct {
+		name         string
+		resp         *ai.ModelResponse
+		streamedText string
+		want         bool
+	}{
+		{
+			name: "nil response",
+			resp: nil,
+			want: true,
+		},
+		{
+			name: "empty candidate with no tool calls",
+			resp: &ai.ModelResponse{Request: &ai.ModelRequest{}},
+			want: true,
+		},
+		{
+			name: "final text present",
+			resp: &ai.ModelResponse{
+				Request: &ai.ModelRequest{},
+				Message: ai.NewModelMessage(ai.NewTextPart("Do you have any injuries?")),
+			},
+			want: false,
+		},
+		{
+			name:         "streamed text only",
+			resp:         &ai.ModelResponse{Request: &ai.ModelRequest{}},
+			streamedText: "partial answer",
+			want:         false,
+		},
+		{
+			name: "tool call in history without text",
+			resp: &ai.ModelResponse{
+				Request: &ai.ModelRequest{
+					Messages: []*ai.Message{
+						ai.NewModelMessage(ai.NewToolRequestPart(&ai.ToolRequest{Name: getWorkoutsToolName})),
+					},
+				},
+				Message: ai.NewModelMessage(ai.NewTextPart("")),
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isEmptyChatModelResponse(tc.resp, tc.streamedText); got != tc.want {
+				t.Fatalf("isEmptyChatModelResponse() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChatToolsOmitsDataToolWhenReaderNil(t *testing.T) {
+	draft := fakeTool{name: workoutDraftToolName}
+	data := fakeTool{name: getWorkoutsToolName}
+
+	withData := (&GenkitRuntime{workoutDraftTool: draft, getWorkoutsTool: data}).chatTools()
+	if len(withData) != 2 || withData[0].Name() != workoutDraftToolName || withData[1].Name() != getWorkoutsToolName {
+		t.Fatalf("chatTools() with data = %#v, want draft then data", withData)
+	}
+
+	withoutData := (&GenkitRuntime{workoutDraftTool: draft}).chatTools()
+	if len(withoutData) != 1 || withoutData[0].Name() != workoutDraftToolName {
+		t.Fatalf("chatTools() without data = %#v, want only draft tool", withoutData)
+	}
+}
+
+type fakeTool struct {
+	name string
+}
+
+func (f fakeTool) Name() string { return f.name }
+
+func (f fakeTool) Definition() *ai.ToolDefinition { return &ai.ToolDefinition{Name: f.name} }
+
+func (f fakeTool) RunRaw(context.Context, any) (any, error) { return nil, nil }
+
+func (f fakeTool) RunRawMultipart(context.Context, any) (*ai.MultipartToolResponse, error) {
+	return &ai.MultipartToolResponse{}, nil
+}
+
+func (f fakeTool) Respond(*ai.Part, any, *ai.RespondOptions) *ai.Part { return nil }
+
+func (f fakeTool) Restart(*ai.Part, *ai.RestartOptions) *ai.Part { return nil }
+
+func (f fakeTool) Register(api.Registry) {}

--- a/server/internal/aichat/service_test.go
+++ b/server/internal/aichat/service_test.go
@@ -64,6 +64,24 @@ type mockRepository struct {
 	mock.Mock
 }
 
+func (m *mockRepository) ListWorkoutsWithSets(ctx context.Context, userID string, filter WorkoutHistoryFilter) ([]ChatWorkoutView, error) {
+	args := m.Called(ctx, userID, filter)
+	workouts, _ := args.Get(0).([]ChatWorkoutView)
+	return workouts, args.Error(1)
+}
+
+func (m *mockRepository) ResolveExerciseNames(ctx context.Context, userID string, query string) ([]string, error) {
+	args := m.Called(ctx, userID, query)
+	names, _ := args.Get(0).([]string)
+	return names, args.Error(1)
+}
+
+func (m *mockRepository) TrainingSnapshot(ctx context.Context, userID string) (*TrainingSnapshot, error) {
+	args := m.Called(ctx, userID)
+	snapshot, _ := args.Get(0).(*TrainingSnapshot)
+	return snapshot, args.Error(1)
+}
+
 func (m *mockRepository) CreateConversation(ctx context.Context, userID string) (*Conversation, error) {
 	args := m.Called(ctx, userID)
 	conversation, _ := args.Get(0).(*Conversation)

--- a/server/internal/aichat/tools_data.go
+++ b/server/internal/aichat/tools_data.go
@@ -1,0 +1,184 @@
+package aichat
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Andrewy-gh/fittrack/server/internal/request"
+	"github.com/Andrewy-gh/fittrack/server/internal/user"
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+)
+
+const (
+	getWorkoutsToolName        = "get_workouts"
+	getWorkoutsToolDescription = "Reads the authenticated user's logged FitTrack workouts. Use this for questions about their personal workout history, recent sessions, exercises performed, or logged training data. Do not use it for general fitness knowledge or to create a new workout draft."
+)
+
+type GetWorkoutsToolInput struct {
+	LastN        int    `json:"lastN,omitempty" jsonschema:"description=How many recent workouts (max 20). Default 5."`
+	StartDate    string `json:"startDate,omitempty" jsonschema:"description=Inclusive ISO date (YYYY-MM-DD). Resolve relative phrases yourself using the current date."`
+	EndDate      string `json:"endDate,omitempty" jsonschema:"description=Inclusive ISO date (YYYY-MM-DD). Resolve relative phrases yourself using the current date."`
+	ExerciseName string `json:"exerciseName,omitempty" jsonschema:"description=Partial name ok, e.g. 'bench'."`
+	WorkoutFocus string `json:"workoutFocus,omitempty" jsonschema:"description=Optional workout focus filter such as push, pull, legs, upper body, lower body, or full body."`
+}
+
+type GetWorkoutsToolResult struct {
+	Workouts           []ChatWorkoutView `json:"workouts,omitempty"`
+	Message            string            `json:"message,omitempty"`
+	CandidateExercises []string          `json:"candidateExercises,omitempty"`
+}
+
+func defineGetWorkoutsTool(g *genkit.Genkit, reader ChatDataReader) ai.Tool {
+	return genkit.DefineTool(g, getWorkoutsToolName,
+		getWorkoutsToolDescription,
+		func(ctx *ai.ToolContext, input GetWorkoutsToolInput) (*GetWorkoutsToolResult, error) {
+			startedAt := time.Now()
+			logAIChatTraceContext(ctx, "get_workouts_tool_started",
+				"last_n", input.LastN,
+				"exercise_name", strings.TrimSpace(input.ExerciseName),
+				"workout_focus", strings.TrimSpace(input.WorkoutFocus),
+				"request_id", request.GetRequestID(ctx),
+			)
+			result := runGetWorkoutsTool(ctx, reader, input)
+			logAIChatTraceContext(ctx, "get_workouts_tool_finished",
+				"elapsed_ms", time.Since(startedAt).Milliseconds(),
+				"workout_count", len(result.Workouts),
+				"candidate_count", len(result.CandidateExercises),
+				"request_id", request.GetRequestID(ctx),
+			)
+			return result, nil
+		},
+	)
+}
+
+func runGetWorkoutsTool(ctx context.Context, reader ChatDataReader, input GetWorkoutsToolInput) *GetWorkoutsToolResult {
+	if reader == nil {
+		return &GetWorkoutsToolResult{Message: "Workout history is not available in this chat."}
+	}
+	userID, ok := user.Current(ctx)
+	if !ok || strings.TrimSpace(userID) == "" {
+		return &GetWorkoutsToolResult{Message: "Workout history is not available because this chat has no authenticated user."}
+	}
+
+	filter := WorkoutHistoryFilter{
+		LastN:        input.LastN,
+		WorkoutFocus: strings.TrimSpace(input.WorkoutFocus),
+	}
+	var notes []string
+	if start, note := parseChatToolDate(input.StartDate, false); start != nil {
+		filter.StartDate = start
+	} else if note != "" {
+		notes = append(notes, note)
+	}
+	if end, note := parseChatToolDate(input.EndDate, true); end != nil {
+		filter.EndDate = end
+	} else if note != "" {
+		notes = append(notes, note)
+	}
+	if filter.StartDate != nil && filter.EndDate != nil && filter.StartDate.After(*filter.EndDate) {
+		filter.StartDate, filter.EndDate = filter.EndDate, filter.StartDate
+		notes = append(notes, "The startDate was after the endDate, so I swapped the date filters.")
+	}
+
+	if exerciseQuery := strings.TrimSpace(input.ExerciseName); exerciseQuery != "" {
+		names, err := reader.ResolveExerciseNames(ctx, userID, exerciseQuery)
+		if err != nil {
+			return &GetWorkoutsToolResult{Message: appendToolMessage(notes, "I couldn't resolve that exercise name right now.")}
+		}
+		resolved, candidates, ok := resolveExerciseNameForChat(exerciseQuery, names)
+		switch {
+		case ok:
+			filter.ExerciseName = resolved
+		case len(candidates) > 0:
+			return &GetWorkoutsToolResult{
+				Message:            appendToolMessage(notes, "I found multiple matching exercises. Ask the user which one they mean or retry with an exact exercise name."),
+				CandidateExercises: candidates,
+			}
+		default:
+			return &GetWorkoutsToolResult{Message: appendToolMessage(notes, fmt.Sprintf("No exercises matched %q.", exerciseQuery))}
+		}
+	}
+
+	workouts, err := reader.ListWorkoutsWithSets(ctx, userID, filter)
+	if err != nil {
+		return &GetWorkoutsToolResult{Message: appendToolMessage(notes, "I couldn't read workout history right now.")}
+	}
+	if len(workouts) == 0 {
+		return &GetWorkoutsToolResult{Message: appendToolMessage(notes, emptyWorkoutMessage(ctx, reader, userID))}
+	}
+	return &GetWorkoutsToolResult{
+		Workouts: workouts,
+		Message:  strings.Join(notes, " "),
+	}
+}
+
+func resolveExerciseNameForChat(query string, matches []string) (string, []string, bool) {
+	query = strings.TrimSpace(query)
+	if query == "" || len(matches) == 0 {
+		return "", nil, false
+	}
+	for _, match := range matches {
+		if strings.EqualFold(strings.TrimSpace(match), query) {
+			return match, nil, true
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil, true
+	}
+	return "", append([]string(nil), matches...), false
+}
+
+func parseChatToolDate(value string, endOfDay bool) (*time.Time, string) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil, ""
+	}
+
+	if parsed, err := time.Parse(time.RFC3339, trimmed); err == nil {
+		return &parsed, ""
+	}
+
+	dateLayouts := []string{
+		"2006-01-02",
+		"2006-1-2",
+		"January 2, 2006",
+		"Jan 2, 2006",
+	}
+	for _, layout := range dateLayouts {
+		parsed, err := time.ParseInLocation(layout, trimmed, time.UTC)
+		if err != nil {
+			continue
+		}
+		if endOfDay {
+			parsed = parsed.Add(24*time.Hour - time.Nanosecond)
+		}
+		return &parsed, ""
+	}
+
+	return nil, fmt.Sprintf("Ignored invalid date %q.", trimmed)
+}
+
+func emptyWorkoutMessage(ctx context.Context, reader ChatDataReader, userID string) string {
+	message := "No workouts found for that filter."
+	snapshot, err := reader.TrainingSnapshot(ctx, userID)
+	if err != nil || snapshot == nil || strings.TrimSpace(snapshot.LastWorkoutDate) == "" {
+		return message
+	}
+	return message + " The user's last workout was " + snapshot.LastWorkoutDate + "."
+}
+
+func appendToolMessage(notes []string, message string) string {
+	parts := make([]string, 0, len(notes)+1)
+	for _, note := range notes {
+		if trimmed := strings.TrimSpace(note); trimmed != "" {
+			parts = append(parts, trimmed)
+		}
+	}
+	if trimmed := strings.TrimSpace(message); trimmed != "" {
+		parts = append(parts, trimmed)
+	}
+	return strings.Join(parts, " ")
+}

--- a/server/internal/aichat/tools_data_test.go
+++ b/server/internal/aichat/tools_data_test.go
@@ -1,0 +1,125 @@
+package aichat
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Andrewy-gh/fittrack/server/internal/user"
+)
+
+func TestResolveExerciseNameForChat(t *testing.T) {
+	tests := []struct {
+		name           string
+		query          string
+		matches        []string
+		wantResolved   string
+		wantCandidates []string
+		wantOK         bool
+	}{
+		{name: "exact fold wins", query: "bench press", matches: []string{"Incline Bench Press", "Bench Press"}, wantResolved: "Bench Press", wantOK: true},
+		{name: "single partial auto selected", query: "dead", matches: []string{"Deadlift"}, wantResolved: "Deadlift", wantOK: true},
+		{name: "ambiguous returns candidates", query: "row", matches: []string{"Barbell Row", "Cable Row"}, wantCandidates: []string{"Barbell Row", "Cable Row"}},
+		{name: "none", query: "curl", matches: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved, candidates, ok := resolveExerciseNameForChat(tt.query, tt.matches)
+			if resolved != tt.wantResolved || ok != tt.wantOK || !reflect.DeepEqual(candidates, tt.wantCandidates) {
+				t.Fatalf("resolveExerciseNameForChat() = %q, %#v, %v; want %q, %#v, %v", resolved, candidates, ok, tt.wantResolved, tt.wantCandidates, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestParseChatToolDateForgiving(t *testing.T) {
+	start, note := parseChatToolDate("2026-07-01", false)
+	if note != "" || start == nil || start.Format(time.RFC3339Nano) != "2026-07-01T00:00:00Z" {
+		t.Fatalf("start parse = %v note %q", start, note)
+	}
+
+	end, note := parseChatToolDate("July 3, 2026", true)
+	if note != "" || end == nil || end.Format(time.RFC3339Nano) != "2026-07-03T23:59:59.999999999Z" {
+		t.Fatalf("end parse = %v note %q", end, note)
+	}
+
+	invalid, note := parseChatToolDate("last someday-ish", false)
+	if invalid != nil || !strings.Contains(note, `Ignored invalid date "last someday-ish".`) {
+		t.Fatalf("invalid parse = %v note %q", invalid, note)
+	}
+}
+
+func TestRunGetWorkoutsToolReturnsCandidatesWithoutFetchingWorkouts(t *testing.T) {
+	reader := &stubChatDataReader{names: []string{"Barbell Row", "Cable Row"}}
+	ctx := user.WithContext(context.Background(), "user-1")
+
+	result := runGetWorkoutsTool(ctx, reader, GetWorkoutsToolInput{ExerciseName: "row"})
+
+	if reader.listCalls != 0 {
+		t.Fatalf("ListWorkoutsWithSets called %d times, want 0 for ambiguous exercise", reader.listCalls)
+	}
+	if !reflect.DeepEqual(result.CandidateExercises, []string{"Barbell Row", "Cable Row"}) {
+		t.Fatalf("CandidateExercises = %#v", result.CandidateExercises)
+	}
+	if !strings.Contains(result.Message, "multiple matching exercises") {
+		t.Fatalf("Message = %q, want ambiguity guidance", result.Message)
+	}
+}
+
+func TestRunGetWorkoutsToolIgnoresBadDateAndReturnsReaderErrorAsMessage(t *testing.T) {
+	reader := &stubChatDataReader{listErr: errors.New("database unavailable")}
+	ctx := user.WithContext(context.Background(), "user-1")
+
+	result := runGetWorkoutsTool(ctx, reader, GetWorkoutsToolInput{StartDate: "not-a-date"})
+
+	if !strings.Contains(result.Message, `Ignored invalid date "not-a-date".`) {
+		t.Fatalf("Message = %q, want invalid-date note", result.Message)
+	}
+	if !strings.Contains(result.Message, "couldn't read workout history") {
+		t.Fatalf("Message = %q, want reader error message", result.Message)
+	}
+}
+
+func TestRunGetWorkoutsToolEmptyResultMentionsLastWorkout(t *testing.T) {
+	reader := &stubChatDataReader{snapshot: &TrainingSnapshot{LastWorkoutDate: "2026-07-03"}}
+	ctx := user.WithContext(context.Background(), "user-1")
+
+	result := runGetWorkoutsTool(ctx, reader, GetWorkoutsToolInput{LastN: 5})
+
+	if !strings.Contains(result.Message, "No workouts found for that filter.") || !strings.Contains(result.Message, "2026-07-03") {
+		t.Fatalf("Message = %q", result.Message)
+	}
+}
+
+type stubChatDataReader struct {
+	names     []string
+	workouts  []ChatWorkoutView
+	snapshot  *TrainingSnapshot
+	listErr   error
+	listCalls int
+}
+
+func (s *stubChatDataReader) ListWorkoutsWithSets(ctx context.Context, userID string, filter WorkoutHistoryFilter) ([]ChatWorkoutView, error) {
+	_ = ctx
+	_ = userID
+	_ = filter
+	s.listCalls++
+	return s.workouts, s.listErr
+}
+
+func (s *stubChatDataReader) ResolveExerciseNames(ctx context.Context, userID string, query string) ([]string, error) {
+	_ = ctx
+	_ = userID
+	_ = query
+	return s.names, nil
+}
+
+func (s *stubChatDataReader) TrainingSnapshot(ctx context.Context, userID string) (*TrainingSnapshot, error) {
+	_ = ctx
+	_ = userID
+	return s.snapshot, nil
+}

--- a/server/internal/aichat/workout_generation.go
+++ b/server/internal/aichat/workout_generation.go
@@ -374,6 +374,24 @@ func extractWorkoutDraftFromHistory(history []*ai.Message) (*workout.CreateWorko
 	return nil, nil
 }
 
+func extractToolCallsFromHistory(history []*ai.Message) []string {
+	var calls []string
+	for _, message := range history {
+		if message == nil {
+			continue
+		}
+		for _, part := range message.Content {
+			if part == nil || !part.IsToolRequest() || part.ToolRequest == nil {
+				continue
+			}
+			if name := strings.TrimSpace(part.ToolRequest.Name); name != "" {
+				calls = append(calls, name)
+			}
+		}
+	}
+	return calls
+}
+
 func finalizeAssistantText(text string, draft *workout.CreateWorkoutRequest) string {
 	text = strings.TrimSpace(text)
 	if draft == nil {

--- a/server/internal/aichat/workout_generation_test.go
+++ b/server/internal/aichat/workout_generation_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestBuildChatSystemPromptIncludesWorkoutGuardrails(t *testing.T) {
-	prompt := buildChatSystemPrompt()
+	prompt := buildChatSystemPrompt(nil, time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC), true)
 
 	requiredSnippets := []string{
 		"Ask at most 3 short, focused follow-up questions",
@@ -526,6 +526,22 @@ func TestExtractWorkoutDraftFromHistoryRejectsInvalidContract(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "Date") {
 		t.Fatalf("extractWorkoutDraftFromHistory() error = %v, want missing date validation", err)
+	}
+}
+
+func TestExtractToolCallsFromHistory(t *testing.T) {
+	history := []*ai.Message{
+		ai.NewUserMessage(ai.NewTextPart("What did I do last week?")),
+		ai.NewModelMessage(
+			ai.NewToolRequestPart(&ai.ToolRequest{Name: getWorkoutsToolName}),
+			ai.NewToolRequestPart(&ai.ToolRequest{Name: workoutDraftToolName}),
+		),
+		ai.NewMessage(ai.RoleTool, nil, ai.NewToolResponsePart(&ai.ToolResponse{Name: getWorkoutsToolName, Output: map[string]any{}})),
+	}
+
+	calls := extractToolCallsFromHistory(history)
+	if !reflect.DeepEqual(calls, []string{getWorkoutsToolName, workoutDraftToolName}) {
+		t.Fatalf("extractToolCallsFromHistory() = %#v", calls)
 	}
 }
 

--- a/server/internal/aichateval/fixture_data.go
+++ b/server/internal/aichateval/fixture_data.go
@@ -44,8 +44,12 @@ func (r *fixtureChatDataReader) ListWorkoutsWithSets(ctx context.Context, userID
 		if filter.WorkoutFocus != "" && !strings.Contains(strings.ToLower(workout.Focus), strings.ToLower(filter.WorkoutFocus)) {
 			continue
 		}
-		if filter.ExerciseName != "" && !workoutHasExercise(workout, filter.ExerciseName) {
-			continue
+		if filter.ExerciseName != "" {
+			filteredExercises := matchingWorkoutExercises(workout, filter.ExerciseName)
+			if len(filteredExercises) == 0 {
+				continue
+			}
+			workout.Exercises = filteredExercises
 		}
 		workouts = append(workouts, workout)
 		if len(workouts) == filter.LastN {
@@ -118,13 +122,14 @@ func fixtureExercise(name string, sets ...string) aichat.ChatExerciseView {
 	return aichat.ChatExerciseView{Name: name, Sets: sets}
 }
 
-func workoutHasExercise(workout aichat.ChatWorkoutView, name string) bool {
+func matchingWorkoutExercises(workout aichat.ChatWorkoutView, name string) []aichat.ChatExerciseView {
+	var matches []aichat.ChatExerciseView
 	for _, exercise := range workout.Exercises {
 		if strings.EqualFold(exercise.Name, name) {
-			return true
+			matches = append(matches, exercise)
 		}
 	}
-	return false
+	return matches
 }
 
 func startOfDay(value time.Time) time.Time {

--- a/server/internal/aichateval/fixture_data.go
+++ b/server/internal/aichateval/fixture_data.go
@@ -1,0 +1,137 @@
+package aichateval
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
+)
+
+const FixtureUserID = "ai-chat-fixture-user"
+
+type fixtureChatDataReader struct {
+	userID   string
+	workouts []aichat.ChatWorkoutView
+}
+
+func NewFixtureChatDataReader() aichat.ChatDataReader {
+	return &fixtureChatDataReader{userID: FixtureUserID, workouts: fixtureWorkouts()}
+}
+
+func (r *fixtureChatDataReader) ListWorkoutsWithSets(ctx context.Context, userID string, filter aichat.WorkoutHistoryFilter) ([]aichat.ChatWorkoutView, error) {
+	_ = ctx
+	if userID != r.userID {
+		return nil, nil
+	}
+	if filter.LastN <= 0 {
+		filter.LastN = 5
+	}
+	if filter.LastN > 20 {
+		filter.LastN = 20
+	}
+
+	var workouts []aichat.ChatWorkoutView
+	for _, workout := range r.workouts {
+		workoutDate, _ := time.Parse("2006-01-02", workout.Date)
+		if filter.StartDate != nil && workoutDate.Before(startOfDay(*filter.StartDate)) {
+			continue
+		}
+		if filter.EndDate != nil && workoutDate.After(endOfDay(*filter.EndDate)) {
+			continue
+		}
+		if filter.WorkoutFocus != "" && !strings.Contains(strings.ToLower(workout.Focus), strings.ToLower(filter.WorkoutFocus)) {
+			continue
+		}
+		if filter.ExerciseName != "" && !workoutHasExercise(workout, filter.ExerciseName) {
+			continue
+		}
+		workouts = append(workouts, workout)
+		if len(workouts) == filter.LastN {
+			break
+		}
+	}
+	return workouts, nil
+}
+
+func (r *fixtureChatDataReader) ResolveExerciseNames(ctx context.Context, userID string, query string) ([]string, error) {
+	_ = ctx
+	if userID != r.userID {
+		return nil, nil
+	}
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return nil, nil
+	}
+	seen := make(map[string]bool)
+	for _, workout := range r.workouts {
+		for _, exercise := range workout.Exercises {
+			if strings.Contains(strings.ToLower(exercise.Name), query) {
+				seen[exercise.Name] = true
+			}
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if len(names) > 8 {
+		names = names[:8]
+	}
+	return names, nil
+}
+
+func (r *fixtureChatDataReader) TrainingSnapshot(ctx context.Context, userID string) (*aichat.TrainingSnapshot, error) {
+	_ = ctx
+	if userID != r.userID {
+		return nil, nil
+	}
+	return &aichat.TrainingSnapshot{
+		LastWorkoutDate: "2026-07-03",
+		WorkoutsLast30D: 7,
+		TopExercises:    []string{"Bench Press", "Back Squat", "Deadlift", "Barbell Row", "Incline Bench Press"},
+	}, nil
+}
+
+func fixtureWorkouts() []aichat.ChatWorkoutView {
+	return []aichat.ChatWorkoutView{
+		fixtureWorkout("2026-07-03", "upper body", "Top bench single felt smooth.", fixtureExercise("Bench Press", "185x5 working", "195x3 working"), fixtureExercise("Barbell Row", "155x8 working", "155x8 working")),
+		fixtureWorkout("2026-06-30", "lower body", "", fixtureExercise("Back Squat", "225x5 working", "235x3 working"), fixtureExercise("Romanian Deadlift", "185x8 working")),
+		fixtureWorkout("2026-06-27", "pull", "", fixtureExercise("Deadlift", "275x3 working", "285x2 working"), fixtureExercise("Barbell Row", "165x6 working")),
+		fixtureWorkout("2026-06-23", "push", "", fixtureExercise("Bench Press", "180x6 working", "185x4 working"), fixtureExercise("Incline Bench Press", "145x8 working")),
+		fixtureWorkout("2026-06-19", "legs", "", fixtureExercise("Front Squat", "185x5 working"), fixtureExercise("Walking Lunge", "40x10 working")),
+		fixtureWorkout("2026-06-15", "pull", "", fixtureExercise("Deadlift", "265x4 working"), fixtureExercise("One-Arm Dumbbell Row", "75x10 working")),
+		fixtureWorkout("2026-06-10", "upper body", "", fixtureExercise("Incline Bench Press", "140x8 working"), fixtureExercise("Chest Supported Row", "120x10 working")),
+		fixtureWorkout("2026-06-05", "lower body", "", fixtureExercise("Back Squat", "215x5 working"), fixtureExercise("Leg Curl", "90x12 working")),
+		fixtureWorkout("2026-05-30", "push", "", fixtureExercise("Bench Press", "175x6 working"), fixtureExercise("Dumbbell Shoulder Press", "55x8 working")),
+		fixtureWorkout("2026-05-24", "full body", "", fixtureExercise("Deadlift", "255x5 working"), fixtureExercise("Back Squat", "205x6 working")),
+	}
+}
+
+func fixtureWorkout(date string, focus string, notes string, exercises ...aichat.ChatExerciseView) aichat.ChatWorkoutView {
+	return aichat.ChatWorkoutView{Date: date, Focus: focus, Notes: notes, Exercises: exercises}
+}
+
+func fixtureExercise(name string, sets ...string) aichat.ChatExerciseView {
+	return aichat.ChatExerciseView{Name: name, Sets: sets}
+}
+
+func workoutHasExercise(workout aichat.ChatWorkoutView, name string) bool {
+	for _, exercise := range workout.Exercises {
+		if strings.EqualFold(exercise.Name, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func startOfDay(value time.Time) time.Time {
+	year, month, day := value.Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+func endOfDay(value time.Time) time.Time {
+	return startOfDay(value).Add(24*time.Hour - time.Nanosecond)
+}

--- a/server/internal/aichateval/fixture_data_test.go
+++ b/server/internal/aichateval/fixture_data_test.go
@@ -1,0 +1,70 @@
+package aichateval
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
+)
+
+func TestFixtureChatDataReaderUsesFixtureUser(t *testing.T) {
+	reader := NewFixtureChatDataReader()
+
+	workouts, err := reader.ListWorkoutsWithSets(context.Background(), FixtureUserID, aichat.WorkoutHistoryFilter{
+		ExerciseName: "Back Squat",
+		LastN:        1,
+	})
+	if err != nil {
+		t.Fatalf("ListWorkoutsWithSets() error = %v", err)
+	}
+	if len(workouts) != 1 {
+		t.Fatalf("ListWorkoutsWithSets() returned %d workouts, want 1", len(workouts))
+	}
+	if workouts[0].Date != "2026-06-30" {
+		t.Fatalf("fixture workout date = %q, want 2026-06-30", workouts[0].Date)
+	}
+
+	names, err := reader.ResolveExerciseNames(context.Background(), FixtureUserID, "squat")
+	if err != nil {
+		t.Fatalf("ResolveExerciseNames() error = %v", err)
+	}
+	if len(names) == 0 {
+		t.Fatal("ResolveExerciseNames() returned no fixture squat matches")
+	}
+
+	snapshot, err := reader.TrainingSnapshot(context.Background(), FixtureUserID)
+	if err != nil {
+		t.Fatalf("TrainingSnapshot() error = %v", err)
+	}
+	if snapshot == nil || snapshot.LastWorkoutDate != "2026-07-03" {
+		t.Fatalf("TrainingSnapshot() = %#v, want last workout 2026-07-03", snapshot)
+	}
+}
+
+func TestFixtureChatDataReaderDoesNotReturnSeedDataForOtherUsers(t *testing.T) {
+	reader := NewFixtureChatDataReader()
+
+	workouts, err := reader.ListWorkoutsWithSets(context.Background(), "other-user", aichat.WorkoutHistoryFilter{})
+	if err != nil {
+		t.Fatalf("ListWorkoutsWithSets() error = %v", err)
+	}
+	if len(workouts) != 0 {
+		t.Fatalf("ListWorkoutsWithSets() returned %d workouts for another user, want 0", len(workouts))
+	}
+
+	names, err := reader.ResolveExerciseNames(context.Background(), "other-user", "bench")
+	if err != nil {
+		t.Fatalf("ResolveExerciseNames() error = %v", err)
+	}
+	if len(names) != 0 {
+		t.Fatalf("ResolveExerciseNames() returned %d names for another user, want 0", len(names))
+	}
+
+	snapshot, err := reader.TrainingSnapshot(context.Background(), "other-user")
+	if err != nil {
+		t.Fatalf("TrainingSnapshot() error = %v", err)
+	}
+	if snapshot != nil {
+		t.Fatalf("TrainingSnapshot() = %#v for another user, want nil", snapshot)
+	}
+}

--- a/server/internal/aichateval/fixture_data_test.go
+++ b/server/internal/aichateval/fixture_data_test.go
@@ -23,6 +23,12 @@ func TestFixtureChatDataReaderUsesFixtureUser(t *testing.T) {
 	if workouts[0].Date != "2026-06-30" {
 		t.Fatalf("fixture workout date = %q, want 2026-06-30", workouts[0].Date)
 	}
+	if len(workouts[0].Exercises) != 1 {
+		t.Fatalf("fixture workout exercises = %#v, want only requested exercise", workouts[0].Exercises)
+	}
+	if workouts[0].Exercises[0].Name != "Back Squat" {
+		t.Fatalf("fixture workout exercise = %q, want Back Squat", workouts[0].Exercises[0].Name)
+	}
 
 	names, err := reader.ResolveExerciseNames(context.Background(), FixtureUserID, "squat")
 	if err != nil {

--- a/server/internal/aichateval/runner.go
+++ b/server/internal/aichateval/runner.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
+	"github.com/Andrewy-gh/fittrack/server/internal/user"
 	"github.com/Andrewy-gh/fittrack/server/internal/workout"
 )
 
@@ -28,6 +29,8 @@ const (
 	ExpectedDoNotGenerate             = "do_not_generate"
 	ExpectedNarrowScopeBeforeGenerate = "narrow_scope_before_generating"
 	ExpectedReviseWithoutRestart      = "revise_without_restart"
+	ExpectedAnswerFromData            = "answer_from_data"
+	ExpectedAnswerWithoutTools        = "answer_without_tools"
 )
 
 const (
@@ -53,6 +56,7 @@ type Scenario struct {
 	RequiredTextTerms      []string                    `json:"required_text_terms,omitempty"`
 	ForbiddenTextTerms     []string                    `json:"forbidden_text_terms,omitempty"`
 	ForbiddenExerciseTerms []string                    `json:"forbidden_exercise_terms,omitempty"`
+	AllowedToolCalls       []string                    `json:"allowed_tool_calls,omitempty"`
 	History                []aichat.RuntimeChatMessage `json:"history,omitempty"`
 	FollowUpAnswer         string                      `json:"follow_up_answer,omitempty"`
 }
@@ -61,6 +65,7 @@ type RunOptions struct {
 	Mode               string
 	MaxAttempts        int
 	InterScenarioDelay time.Duration
+	UserID             string
 	OnScenario         func(Scenario)
 	OnScenarioDelay    func(time.Duration, Scenario)
 	OnRetry            func(Scenario, time.Duration, int, int)
@@ -102,6 +107,7 @@ type Result struct {
 	RequiredTextTerms      []string                      `json:"required_text_terms,omitempty"`
 	ForbiddenTextTerms     []string                      `json:"forbidden_text_terms,omitempty"`
 	ForbiddenExerciseTerms []string                      `json:"forbidden_exercise_terms,omitempty"`
+	AllowedToolCalls       []string                      `json:"allowed_tool_calls,omitempty"`
 	History                []HistoryMessage              `json:"history,omitempty"`
 	FollowUpAnswer         string                        `json:"follow_up_answer,omitempty"`
 	Status                 string                        `json:"status"`
@@ -114,6 +120,7 @@ type Result struct {
 	DurationMS             int64                         `json:"duration_ms"`
 	Draft                  *workout.CreateWorkoutRequest `json:"draft,omitempty"`
 	DraftSummary           *DraftSummary                 `json:"draft_summary,omitempty"`
+	ToolCalls              []string                      `json:"tool_calls,omitempty"`
 	Attempts               int                           `json:"attempts"`
 	Turns                  []TurnResult                  `json:"turns,omitempty"`
 }
@@ -128,6 +135,7 @@ type TurnResult struct {
 	DurationMS   int64                         `json:"duration_ms"`
 	Draft        *workout.CreateWorkoutRequest `json:"draft,omitempty"`
 	DraftSummary *DraftSummary                 `json:"draft_summary,omitempty"`
+	ToolCalls    []string                      `json:"tool_calls,omitempty"`
 	Attempts     int                           `json:"attempts"`
 }
 
@@ -254,6 +262,7 @@ func runScenario(ctx context.Context, runtime Runtime, scenario Scenario, mode s
 		RequiredTextTerms:      append([]string{}, scenario.RequiredTextTerms...),
 		ForbiddenTextTerms:     append([]string{}, scenario.ForbiddenTextTerms...),
 		ForbiddenExerciseTerms: append([]string{}, scenario.ForbiddenExerciseTerms...),
+		AllowedToolCalls:       append([]string{}, scenario.AllowedToolCalls...),
 		History:                ConvertHistory(scenario.History),
 		FollowUpAnswer:         scenario.FollowUpAnswer,
 	}
@@ -300,6 +309,7 @@ func applyTurnToResult(result *Result, turn TurnResult) {
 	result.DurationMS += turn.DurationMS
 	result.Draft = turn.Draft
 	result.DraftSummary = turn.DraftSummary
+	result.ToolCalls = append(result.ToolCalls, turn.ToolCalls...)
 	result.Attempts += turn.Attempts
 	if len(result.Turns) == 0 {
 		turn.Turn = 1
@@ -330,7 +340,11 @@ func runTurn(ctx context.Context, runtime Runtime, scenario Scenario, prompt str
 			break
 		}
 		result.Attempts = attempt
-		done, err = runtime.StreamChat(ctx, prompt, history, func(string) error {
+		callCtx := ctx
+		if strings.TrimSpace(options.UserID) != "" {
+			callCtx = user.WithContext(ctx, strings.TrimSpace(options.UserID))
+		}
+		done, err = runtime.StreamChat(callCtx, prompt, history, func(string) error {
 			return nil
 		})
 		if err == nil {
@@ -363,6 +377,7 @@ func runTurn(ctx context.Context, runtime Runtime, scenario Scenario, prompt str
 	result.Model = done.Model
 	result.Draft = done.WorkoutDraft
 	result.DraftSummary = SummarizeDraft(done.WorkoutDraft)
+	result.ToolCalls = append([]string(nil), done.ToolCalls...)
 	result.Status = Classify(done)
 	return result
 }

--- a/server/internal/aichateval/runner_test.go
+++ b/server/internal/aichateval/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Andrewy-gh/fittrack/server/internal/aichat"
+	"github.com/Andrewy-gh/fittrack/server/internal/user"
 	"github.com/Andrewy-gh/fittrack/server/internal/workout"
 )
 
@@ -19,6 +20,8 @@ type fakeRuntime struct {
 type runtimeCall struct {
 	prompt  string
 	history []aichat.RuntimeChatMessage
+	userID  string
+	hasUser bool
 }
 
 type runtimeResponse struct {
@@ -27,9 +30,12 @@ type runtimeResponse struct {
 }
 
 func (f *fakeRuntime) StreamChat(ctx context.Context, prompt string, history []aichat.RuntimeChatMessage, onChunk func(string) error) (*aichat.StreamDone, error) {
+	userID, hasUser := user.Current(ctx)
 	f.calls = append(f.calls, runtimeCall{
 		prompt:  prompt,
 		history: append([]aichat.RuntimeChatMessage{}, history...),
+		userID:  userID,
+		hasUser: hasUser,
 	})
 	if len(f.next) == 0 {
 		return nil, errors.New("unexpected call")
@@ -53,6 +59,7 @@ func TestRunSingleTurnClassifiesStructuredDraft(t *testing.T) {
 				Model:        "test-model",
 				Text:         "I made a draft.",
 				WorkoutDraft: testDraft(),
+				ToolCalls:    []string{"generate_workout_draft"},
 			},
 		}},
 	}
@@ -255,6 +262,158 @@ func TestRunScoresUnexpectedDraftForDoNotGenerateAsFailure(t *testing.T) {
 	}
 	if report.Summary.FailedCount != 1 || report.Summary.PassRate != 0 {
 		t.Fatalf("summary scores = failed %d rate %f, want 1 and 0", report.Summary.FailedCount, report.Summary.PassRate)
+	}
+}
+
+func TestRunScoresAnswerFromData(t *testing.T) {
+	runtime := &fakeRuntime{
+		next: []runtimeResponse{{
+			done: &aichat.StreamDone{
+				Text:      "You last squatted on 2026-06-30.",
+				ToolCalls: []string{"get_workouts"},
+			},
+		}},
+	}
+
+	report := Run(context.Background(), runtime, []Scenario{{
+		ID:                "case-data",
+		Title:             "Data Answer",
+		Prompt:            "When did I last squat?",
+		ExpectedOutcome:   ExpectedAnswerFromData,
+		RequiredTextTerms: []string{"2026-06-30"},
+	}}, RunOptions{Mode: ModeSingleTurn})
+
+	result := report.Results[0]
+	if !result.Passed || result.ScoreStatus != ScoreStatusPass {
+		t.Fatalf("score = passed %v status %q reason %q, want pass", result.Passed, result.ScoreStatus, result.ScoreReason)
+	}
+}
+
+func TestRunScoresAnswerWithoutTools(t *testing.T) {
+	runtime := &fakeRuntime{
+		next: []runtimeResponse{{
+			done: &aichat.StreamDone{Text: "Your last workout was 2026-07-03."},
+		}},
+	}
+
+	report := Run(context.Background(), runtime, []Scenario{{
+		ID:                "case-snapshot",
+		Title:             "Snapshot Answer",
+		Prompt:            "When did I last work out?",
+		ExpectedOutcome:   ExpectedAnswerWithoutTools,
+		RequiredTextTerms: []string{"2026-07-03"},
+	}}, RunOptions{Mode: ModeSingleTurn})
+
+	result := report.Results[0]
+	if !result.Passed || result.ScoreStatus != ScoreStatusPass {
+		t.Fatalf("score = passed %v status %q reason %q, want pass", result.Passed, result.ScoreStatus, result.ScoreReason)
+	}
+}
+
+func TestRunScoresAnswerWithoutToolsAllowsListedToolCalls(t *testing.T) {
+	runtime := &fakeRuntime{
+		next: []runtimeResponse{{
+			done: &aichat.StreamDone{
+				Text:      "You last worked out on July 3rd, 2026.",
+				ToolCalls: []string{"get_workouts"},
+			},
+		}},
+	}
+
+	report := Run(context.Background(), runtime, []Scenario{{
+		ID:                "case-snapshot-redundant-tool",
+		Title:             "Snapshot Answer With Redundant Tool Call",
+		Prompt:            "When did I last work out?",
+		ExpectedOutcome:   ExpectedAnswerWithoutTools,
+		RequiredTextTerms: []string{"2026-07-03"},
+		AllowedToolCalls:  []string{"get_workouts"},
+	}}, RunOptions{Mode: ModeSingleTurn})
+
+	result := report.Results[0]
+	if !result.Passed || result.ScoreStatus != ScoreStatusPass {
+		t.Fatalf("score = passed %v status %q reason %q, want pass", result.Passed, result.ScoreStatus, result.ScoreReason)
+	}
+}
+
+func TestRunScoresAnswerWithoutToolsFailsOnDisallowedToolCall(t *testing.T) {
+	runtime := &fakeRuntime{
+		next: []runtimeResponse{{
+			done: &aichat.StreamDone{
+				Text:      "You last worked out on 2026-07-03.",
+				ToolCalls: []string{"generate_workout_draft"},
+			},
+		}},
+	}
+
+	report := Run(context.Background(), runtime, []Scenario{{
+		ID:                "case-snapshot-disallowed-tool",
+		Title:             "Snapshot Answer With Disallowed Tool Call",
+		Prompt:            "When did I last work out?",
+		ExpectedOutcome:   ExpectedAnswerWithoutTools,
+		RequiredTextTerms: []string{"2026-07-03"},
+		AllowedToolCalls:  []string{"get_workouts"},
+	}}, RunOptions{Mode: ModeSingleTurn})
+
+	result := report.Results[0]
+	if result.Passed || result.ScoreStatus != ScoreStatusFail {
+		t.Fatalf("score = passed %v status %q, want fail", result.Passed, result.ScoreStatus)
+	}
+}
+
+func TestContainsRequiredTermDateRenderings(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		term string
+		want bool
+	}{
+		{"iso literal", "Your last squat was 2026-06-30.", "2026-06-30", true},
+		{"month day year", "You last worked out on July 3, 2026.", "2026-07-03", true},
+		{"month ordinal", "That was on July 3rd.", "2026-07-03", true},
+		{"day month", "You trained on 3 July 2026.", "2026-07-03", true},
+		{"day of month", "It was the 3rd of July.", "2026-07-03", true},
+		{"abbreviated month", "Squats were on Jun 30.", "2026-06-30", true},
+		{"day prefix does not match longer day", "That was on July 30, 2026.", "2026-07-03", false},
+		{"wrong month", "That was on June 3, 2026.", "2026-07-03", false},
+		{"missing date", "You worked out recently.", "2026-07-03", false},
+		{"non-date term unchanged", "Bench Press felt strong.", "bench", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := containsRequiredTerm(tc.text, tc.term); got != tc.want {
+				t.Fatalf("containsRequiredTerm(%q, %q) = %v, want %v", tc.text, tc.term, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunAppliesUserIDToEveryStreamCall(t *testing.T) {
+	runtime := &fakeRuntime{
+		next: []runtimeResponse{
+			{done: &aichat.StreamDone{Text: "Any injuries?"}},
+			{done: &aichat.StreamDone{Text: "I made a draft.", WorkoutDraft: testDraft()}},
+		},
+	}
+
+	report := Run(context.Background(), runtime, []Scenario{{
+		ID:              "case-fixture-user",
+		Title:           "Fixture User",
+		Prompt:          "Build pull.",
+		ExpectedOutcome: ExpectedAskOnceThenGenerate,
+		FollowUpAnswer:  "No injuries, full gym, 45 minutes.",
+	}}, RunOptions{Mode: ModeTwoTurn, UserID: FixtureUserID})
+
+	if !report.Results[0].Passed {
+		t.Fatalf("scenario passed = false, reason %q", report.Results[0].ScoreReason)
+	}
+	if len(runtime.calls) != 2 {
+		t.Fatalf("runtime calls = %d, want 2", len(runtime.calls))
+	}
+	for i, call := range runtime.calls {
+		if !call.hasUser || call.userID != FixtureUserID {
+			t.Fatalf("call %d user = (%q, %v), want fixture user", i+1, call.userID, call.hasUser)
+		}
 	}
 }
 
@@ -568,7 +727,7 @@ func TestRunSelectedScenarioSummaryUsesOnlySelectedScenarios(t *testing.T) {
 	}
 	runtime := &fakeRuntime{
 		next: []runtimeResponse{
-			{done: &aichat.StreamDone{Text: "I made a draft.", WorkoutDraft: testDraft()}},
+			{done: &aichat.StreamDone{Text: "I made a draft.", WorkoutDraft: testDraft(), ToolCalls: []string{"generate_workout_draft"}}},
 			{done: &aichat.StreamDone{Text: "I made a draft.", WorkoutDraft: testDraft()}},
 		},
 	}

--- a/server/internal/aichateval/scenarios.go
+++ b/server/internal/aichateval/scenarios.go
@@ -172,3 +172,72 @@ func DefaultScenarios() []Scenario {
 		},
 	}
 }
+
+func DataFixtureScenarios() []Scenario {
+	return []Scenario{
+		{
+			ID:                "data-01",
+			Title:             "Snapshot Last Workout",
+			Prompt:            "When did I last work out?",
+			Expectation:       "Should answer from the injected snapshot; a redundant get_workouts call is tolerated but a draft is not.",
+			ExpectedOutcome:   ExpectedAnswerWithoutTools,
+			RequiredTextTerms: []string{"2026-07-03"},
+			AllowedToolCalls:  []string{"get_workouts"},
+		},
+		{
+			ID:                "data-02",
+			Title:             "Last Back Squat",
+			Prompt:            "When did I last back squat?",
+			Expectation:       "Should call get_workouts and answer from logged back squat data without an ambiguity detour.",
+			ExpectedOutcome:   ExpectedAnswerFromData,
+			RequiredTextTerms: []string{"2026-06-30", "squat"},
+		},
+		{
+			ID:                "data-03",
+			Title:             "Recent Bench Sets",
+			Prompt:            "What bench press work have I logged recently?",
+			Expectation:       "Should call get_workouts and summarize recent bench sessions.",
+			ExpectedOutcome:   ExpectedAnswerFromData,
+			RequiredTextTerms: []string{"bench", "2026-07-03"},
+		},
+		{
+			ID:                "data-04",
+			Title:             "Last Week Workouts",
+			Prompt:            "What workouts did I do from 2026-06-23 through 2026-06-30?",
+			Expectation:       "Should call get_workouts with date bounds and mention all three workouts in that range (dates may be rendered as prose, so match on the focus of each workout).",
+			ExpectedOutcome:   ExpectedAnswerFromData,
+			RequiredTextTerms: []string{"push", "pull", "lower body"},
+		},
+		{
+			ID:                "data-05",
+			Title:             "Ambiguous Row Lookup",
+			Prompt:            "What rows have I done recently?",
+			Expectation:       "Should call get_workouts and ask for clarification or mention matching row variants.",
+			ExpectedOutcome:   ExpectedAnswerFromData,
+			RequiredTextTerms: []string{"row"},
+		},
+		{
+			ID:                "data-06",
+			Title:             "Deadlift History",
+			Prompt:            "Show my recent deadlift workouts.",
+			Expectation:       "Should call get_workouts and answer from fixture deadlift history.",
+			ExpectedOutcome:   ExpectedAnswerFromData,
+			RequiredTextTerms: []string{"deadlift", "2026-06-27"},
+		},
+		{
+			ID:                "data-07",
+			Title:             "General Fitness No Tool",
+			Prompt:            "What muscles do rows train?",
+			Expectation:       "Should answer general fitness knowledge without data tools.",
+			ExpectedOutcome:   ExpectedAnswerWithoutTools,
+			RequiredTextTerms: []string{"back"},
+		},
+		{
+			ID:              "data-08",
+			Title:           "Draft Guard With Data Fixtures",
+			Prompt:          "Intermediate, 45 minutes, push day, full gym, no injuries. Build me a hypertrophy workout.",
+			Expectation:     "Should still call only the workout draft tool for a normal draft request.",
+			ExpectedOutcome: ExpectedGenerateFirstTurn,
+		},
+	}
+}

--- a/server/internal/aichateval/scenarios_test.go
+++ b/server/internal/aichateval/scenarios_test.go
@@ -19,6 +19,15 @@ func TestDefaultScenariosIncludesMachineChestHypertrophyFollowUp(t *testing.T) {
 	}
 }
 
+func TestDefaultScenariosDoNotIncludeDataFixtureScenarios(t *testing.T) {
+	if _, ok := findDefaultScenario("data-01"); ok {
+		t.Fatal("DefaultScenarios() should not include fixture-backed data scenarios")
+	}
+	if len(DataFixtureScenarios()) < 6 {
+		t.Fatalf("DataFixtureScenarios() returned %d scenarios, want at least 6", len(DataFixtureScenarios()))
+	}
+}
+
 func findDefaultScenario(id string) (Scenario, bool) {
 	for _, scenario := range DefaultScenarios() {
 		if scenario.ID == id {

--- a/server/internal/aichateval/score.go
+++ b/server/internal/aichateval/score.go
@@ -3,7 +3,9 @@ package aichateval
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
+	"time"
 )
 
 func ScoreResult(result *Result, mode string) {
@@ -31,6 +33,10 @@ func ScoreResult(result *Result, mode string) {
 		scoreNarrowScopeBeforeGenerate(result, mode)
 	case ExpectedReviseWithoutRestart:
 		scoreReviseWithoutRestart(result)
+	case ExpectedAnswerFromData:
+		scoreAnswerFromData(result)
+	case ExpectedAnswerWithoutTools:
+		scoreAnswerWithoutTools(result)
 	default:
 		setScore(result, ScoreStatusUnscored, fmt.Sprintf("unknown expected outcome %q", result.ExpectedOutcome))
 	}
@@ -39,6 +45,14 @@ func ScoreResult(result *Result, mode string) {
 func scoreGenerateFirstTurn(result *Result) {
 	if firstTurnStatus(*result) != StatusStructuredDraft {
 		setScore(result, ScoreStatusFail, "expected a structured draft on the first turn")
+		return
+	}
+	if !hasToolCall(result.ToolCalls, "generate_workout_draft") {
+		setScore(result, ScoreStatusFail, "expected the workout draft tool to be called")
+		return
+	}
+	if hasToolCall(result.ToolCalls, "get_workouts") {
+		setScore(result, ScoreStatusFail, "expected no workout history tool call for a normal draft request")
 		return
 	}
 	if !passesTermChecks(result) {
@@ -254,10 +268,60 @@ func scoreReviseWithoutRestart(result *Result) {
 	setScore(result, ScoreStatusPass, "revised the draft without restarting discovery")
 }
 
+func scoreAnswerFromData(result *Result) {
+	if result.Draft != nil {
+		setScore(result, ScoreStatusFail, "expected no structured workout draft for a data answer")
+		return
+	}
+	if !hasToolCall(result.ToolCalls, "get_workouts") {
+		setScore(result, ScoreStatusFail, "expected get_workouts to be called")
+		return
+	}
+	if hasToolCall(result.ToolCalls, "generate_workout_draft") {
+		setScore(result, ScoreStatusFail, "expected no workout draft tool call for a data answer")
+		return
+	}
+	if strings.TrimSpace(result.Text) == "" {
+		setScore(result, ScoreStatusFail, "expected answer text from workout data")
+		return
+	}
+	if !passesTermChecks(result) {
+		return
+	}
+	setScore(result, ScoreStatusPass, "answered from workout data with get_workouts")
+}
+
+func scoreAnswerWithoutTools(result *Result) {
+	if result.Draft != nil {
+		setScore(result, ScoreStatusFail, "expected no structured workout draft")
+		return
+	}
+	if disallowed := disallowedToolCalls(result.ToolCalls, result.AllowedToolCalls); len(disallowed) > 0 {
+		if len(result.AllowedToolCalls) == 0 {
+			setScore(result, ScoreStatusFail, fmt.Sprintf("expected zero tool calls, got %s", strings.Join(disallowed, ", ")))
+			return
+		}
+		setScore(result, ScoreStatusFail, fmt.Sprintf("expected no tool calls beyond %s, got %s", strings.Join(result.AllowedToolCalls, ", "), strings.Join(disallowed, ", ")))
+		return
+	}
+	if strings.TrimSpace(result.Text) == "" {
+		setScore(result, ScoreStatusFail, "expected answer text without tools")
+		return
+	}
+	if !passesTermChecks(result) {
+		return
+	}
+	if len(result.ToolCalls) > 0 {
+		setScore(result, ScoreStatusPass, fmt.Sprintf("answered correctly with tolerated tool calls: %s", strings.Join(result.ToolCalls, ", ")))
+		return
+	}
+	setScore(result, ScoreStatusPass, "answered without tools")
+}
+
 func passesTermChecks(result *Result) bool {
 	text := allResponseText(*result)
 	for _, term := range result.RequiredTextTerms {
-		if !containsFold(text, term) {
+		if !containsRequiredTerm(text, term) {
 			setScore(result, ScoreStatusFail, fmt.Sprintf("response text is missing required term %q", term))
 			return false
 		}
@@ -303,6 +367,40 @@ func exerciseText(result *Result) string {
 	return strings.Join(names, "\n")
 }
 
+var isoDateTermPattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
+// containsRequiredTerm matches like containsFold, except an ISO-date term
+// (e.g. "2026-06-30") also accepts prose renderings such as "June 30th, 2026"
+// or "30 June".
+func containsRequiredTerm(text string, term string) bool {
+	trimmed := strings.TrimSpace(term)
+	if !isoDateTermPattern.MatchString(trimmed) {
+		return containsFold(text, term)
+	}
+	if containsFold(text, trimmed) {
+		return true
+	}
+	parsed, err := time.Parse("2006-01-02", trimmed)
+	if err != nil {
+		return false
+	}
+	month := parsed.Month().String()
+	monthAlternatives := fmt.Sprintf(`(?:%s|%s\.?)`, month, month[:3])
+	day := fmt.Sprintf(`0?%d(?:st|nd|rd|th)?`, parsed.Day())
+	pattern := fmt.Sprintf(`(?i)\b(?:%[1]s\s+%[2]s|%[2]s\s+(?:of\s+)?%[1]s)\b`, monthAlternatives, day)
+	return regexp.MustCompile(pattern).MatchString(text)
+}
+
+func disallowedToolCalls(calls []string, allowed []string) []string {
+	var disallowed []string
+	for _, call := range calls {
+		if !hasToolCall(allowed, call) {
+			disallowed = append(disallowed, call)
+		}
+	}
+	return disallowed
+}
+
 func containsFold(text string, term string) bool {
 	normalizedTerm := strings.TrimSpace(term)
 	if normalizedTerm == "" {
@@ -314,6 +412,15 @@ func containsFold(text string, term string) bool {
 func containsAny(text string, terms []string) bool {
 	for _, term := range terms {
 		if strings.Contains(text, term) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasToolCall(calls []string, name string) bool {
+	for _, call := range calls {
+		if call == name {
 			return true
 		}
 	}

--- a/server/internal/database/query.sql.go
+++ b/server/internal/database/query.sql.go
@@ -863,6 +863,26 @@ func (q *Queries) GetBillingUserForUpdate(ctx context.Context, userID string) (U
 	return i, err
 }
 
+const getChatWorkoutSnapshotStats = `-- name: GetChatWorkoutSnapshotStats :one
+SELECT
+    MAX(date)::timestamptz AS last_workout_date,
+    COUNT(*) FILTER (WHERE date >= now() - interval '30 days') AS workouts_last_30d
+FROM workout
+WHERE user_id = $1
+`
+
+type GetChatWorkoutSnapshotStatsRow struct {
+	LastWorkoutDate pgtype.Timestamptz `json:"last_workout_date"`
+	WorkoutsLast30d int64              `json:"workouts_last_30d"`
+}
+
+func (q *Queries) GetChatWorkoutSnapshotStats(ctx context.Context, userID string) (GetChatWorkoutSnapshotStatsRow, error) {
+	row := q.db.QueryRow(ctx, getChatWorkoutSnapshotStats, userID)
+	var i GetChatWorkoutSnapshotStatsRow
+	err := row.Scan(&i.LastWorkoutDate, &i.WorkoutsLast30d)
+	return i, err
+}
+
 const getContributionData = `-- name: GetContributionData :many
 WITH workout_totals AS (
     SELECT
@@ -2303,6 +2323,45 @@ func (q *Queries) ListActiveFeatureAccess(ctx context.Context, userID string) ([
 	return items, nil
 }
 
+const listExerciseNameMatches = `-- name: ListExerciseNameMatches :many
+SELECT id, name
+FROM exercise
+WHERE user_id = $1
+  AND name ILIKE '%' || $2::text || '%'
+ORDER BY name
+LIMIT 8
+`
+
+type ListExerciseNameMatchesParams struct {
+	UserID    string `json:"user_id"`
+	NameQuery string `json:"name_query"`
+}
+
+type ListExerciseNameMatchesRow struct {
+	ID   int32  `json:"id"`
+	Name string `json:"name"`
+}
+
+func (q *Queries) ListExerciseNameMatches(ctx context.Context, arg ListExerciseNameMatchesParams) ([]ListExerciseNameMatchesRow, error) {
+	rows, err := q.db.Query(ctx, listExerciseNameMatches, arg.UserID, arg.NameQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListExerciseNameMatchesRow
+	for rows.Next() {
+		var i ListExerciseNameMatchesRow
+		if err := rows.Scan(&i.ID, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listExercises = `-- name: ListExercises :many
 SELECT id, name FROM exercise WHERE user_id = $1 ORDER BY name
 `
@@ -2403,6 +2462,45 @@ func (q *Queries) ListSets(ctx context.Context, userID string) ([]ListSetsRow, e
 			&i.ExerciseOrder,
 			&i.SetOrder,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTopExercisesByFrequency = `-- name: ListTopExercisesByFrequency :many
+SELECT
+    e.name,
+    COUNT(DISTINCT s.workout_id)::integer AS workout_count
+FROM "set" s
+JOIN exercise e ON e.id = s.exercise_id AND e.user_id = s.user_id
+JOIN workout w ON w.id = s.workout_id AND w.user_id = s.user_id
+WHERE s.user_id = $1
+  AND w.date >= now() - interval '90 days'
+GROUP BY e.name
+ORDER BY workout_count DESC, e.name
+LIMIT 5
+`
+
+type ListTopExercisesByFrequencyRow struct {
+	Name         string `json:"name"`
+	WorkoutCount int32  `json:"workout_count"`
+}
+
+func (q *Queries) ListTopExercisesByFrequency(ctx context.Context, userID string) ([]ListTopExercisesByFrequencyRow, error) {
+	rows, err := q.db.Query(ctx, listTopExercisesByFrequency, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListTopExercisesByFrequencyRow
+	for rows.Next() {
+		var i ListTopExercisesByFrequencyRow
+		if err := rows.Scan(&i.Name, &i.WorkoutCount); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -2517,6 +2615,110 @@ func (q *Queries) ListWorkouts(ctx context.Context, userID string) ([]ListWorkou
 			&i.WorkoutFocus,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listWorkoutsWithSetsForChat = `-- name: ListWorkoutsWithSetsForChat :many
+WITH matching_workouts AS (
+    SELECT w.id
+    FROM workout w
+    WHERE w.user_id = $1
+      AND ($2::timestamptz IS NULL OR w.date >= $2::timestamptz)
+      AND ($3::timestamptz IS NULL OR w.date <= $3::timestamptz)
+      AND (
+          NULLIF($4::text, '') IS NULL
+          OR EXISTS (
+              SELECT 1
+              FROM "set" filter_set
+              JOIN exercise filter_exercise ON filter_exercise.id = filter_set.exercise_id
+              WHERE filter_set.workout_id = w.id
+                AND filter_set.user_id = w.user_id
+                AND filter_exercise.user_id = w.user_id
+                AND filter_exercise.name = $4::text
+          )
+      )
+      AND (
+          NULLIF($5::text, '') IS NULL
+          OR w.workout_focus ILIKE '%' || $5::text || '%'
+      )
+    ORDER BY w.date DESC, w.id DESC
+    LIMIT $6
+)
+SELECT
+    w.id AS workout_id,
+    w.date,
+    w.notes,
+    w.workout_focus,
+    e.name AS exercise_name,
+    s.exercise_order,
+    s.set_order,
+    s.weight,
+    s.reps,
+    s.set_type
+FROM matching_workouts mw
+JOIN workout w ON w.id = mw.id
+LEFT JOIN "set" s ON s.workout_id = w.id AND s.user_id = w.user_id
+LEFT JOIN exercise e ON e.id = s.exercise_id AND e.user_id = w.user_id
+ORDER BY w.date DESC, w.id DESC, s.exercise_order, s.set_order, s.id
+`
+
+type ListWorkoutsWithSetsForChatParams struct {
+	UserID       string             `json:"user_id"`
+	StartDate    pgtype.Timestamptz `json:"start_date"`
+	EndDate      pgtype.Timestamptz `json:"end_date"`
+	ExerciseName pgtype.Text        `json:"exercise_name"`
+	WorkoutFocus pgtype.Text        `json:"workout_focus"`
+	RowLimit     int32              `json:"row_limit"`
+}
+
+type ListWorkoutsWithSetsForChatRow struct {
+	WorkoutID     int32              `json:"workout_id"`
+	Date          pgtype.Timestamptz `json:"date"`
+	Notes         pgtype.Text        `json:"notes"`
+	WorkoutFocus  pgtype.Text        `json:"workout_focus"`
+	ExerciseName  pgtype.Text        `json:"exercise_name"`
+	ExerciseOrder pgtype.Int4        `json:"exercise_order"`
+	SetOrder      pgtype.Int4        `json:"set_order"`
+	Weight        pgtype.Numeric     `json:"weight"`
+	Reps          pgtype.Int4        `json:"reps"`
+	SetType       pgtype.Text        `json:"set_type"`
+}
+
+func (q *Queries) ListWorkoutsWithSetsForChat(ctx context.Context, arg ListWorkoutsWithSetsForChatParams) ([]ListWorkoutsWithSetsForChatRow, error) {
+	rows, err := q.db.Query(ctx, listWorkoutsWithSetsForChat,
+		arg.UserID,
+		arg.StartDate,
+		arg.EndDate,
+		arg.ExerciseName,
+		arg.WorkoutFocus,
+		arg.RowLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListWorkoutsWithSetsForChatRow
+	for rows.Next() {
+		var i ListWorkoutsWithSetsForChatRow
+		if err := rows.Scan(
+			&i.WorkoutID,
+			&i.Date,
+			&i.Notes,
+			&i.WorkoutFocus,
+			&i.ExerciseName,
+			&i.ExerciseOrder,
+			&i.SetOrder,
+			&i.Weight,
+			&i.Reps,
+			&i.SetType,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/database/query.sql.go
+++ b/server/internal/database/query.sql.go
@@ -2630,11 +2630,11 @@ const listWorkoutsWithSetsForChat = `-- name: ListWorkoutsWithSetsForChat :many
 WITH matching_workouts AS (
     SELECT w.id
     FROM workout w
-    WHERE w.user_id = $1
-      AND ($2::timestamptz IS NULL OR w.date >= $2::timestamptz)
-      AND ($3::timestamptz IS NULL OR w.date <= $3::timestamptz)
+    WHERE w.user_id = $2
+      AND ($3::timestamptz IS NULL OR w.date >= $3::timestamptz)
+      AND ($4::timestamptz IS NULL OR w.date <= $4::timestamptz)
       AND (
-          NULLIF($4::text, '') IS NULL
+          NULLIF($1::text, '') IS NULL
           OR EXISTS (
               SELECT 1
               FROM "set" filter_set
@@ -2642,7 +2642,7 @@ WITH matching_workouts AS (
               WHERE filter_set.workout_id = w.id
                 AND filter_set.user_id = w.user_id
                 AND filter_exercise.user_id = w.user_id
-                AND filter_exercise.name = $4::text
+                AND filter_exercise.name = $1::text
           )
       )
       AND (
@@ -2665,16 +2665,27 @@ SELECT
     s.set_type
 FROM matching_workouts mw
 JOIN workout w ON w.id = mw.id
-LEFT JOIN "set" s ON s.workout_id = w.id AND s.user_id = w.user_id
+LEFT JOIN "set" s ON s.workout_id = w.id
+    AND s.user_id = w.user_id
+    AND (
+        NULLIF($1::text, '') IS NULL
+        OR EXISTS (
+            SELECT 1
+            FROM exercise selected_exercise
+            WHERE selected_exercise.id = s.exercise_id
+              AND selected_exercise.user_id = s.user_id
+              AND selected_exercise.name = $1::text
+        )
+    )
 LEFT JOIN exercise e ON e.id = s.exercise_id AND e.user_id = w.user_id
 ORDER BY w.date DESC, w.id DESC, s.exercise_order, s.set_order, s.id
 `
 
 type ListWorkoutsWithSetsForChatParams struct {
+	ExerciseName pgtype.Text        `json:"exercise_name"`
 	UserID       string             `json:"user_id"`
 	StartDate    pgtype.Timestamptz `json:"start_date"`
 	EndDate      pgtype.Timestamptz `json:"end_date"`
-	ExerciseName pgtype.Text        `json:"exercise_name"`
 	WorkoutFocus pgtype.Text        `json:"workout_focus"`
 	RowLimit     int32              `json:"row_limit"`
 }
@@ -2694,10 +2705,10 @@ type ListWorkoutsWithSetsForChatRow struct {
 
 func (q *Queries) ListWorkoutsWithSetsForChat(ctx context.Context, arg ListWorkoutsWithSetsForChatParams) ([]ListWorkoutsWithSetsForChatRow, error) {
 	rows, err := q.db.Query(ctx, listWorkoutsWithSetsForChat,
+		arg.ExerciseName,
 		arg.UserID,
 		arg.StartDate,
 		arg.EndDate,
-		arg.ExerciseName,
 		arg.WorkoutFocus,
 		arg.RowLimit,
 	)

--- a/server/query.sql
+++ b/server/query.sql
@@ -341,7 +341,18 @@ SELECT
     s.set_type
 FROM matching_workouts mw
 JOIN workout w ON w.id = mw.id
-LEFT JOIN "set" s ON s.workout_id = w.id AND s.user_id = w.user_id
+LEFT JOIN "set" s ON s.workout_id = w.id
+    AND s.user_id = w.user_id
+    AND (
+        NULLIF(sqlc.narg(exercise_name)::text, '') IS NULL
+        OR EXISTS (
+            SELECT 1
+            FROM exercise selected_exercise
+            WHERE selected_exercise.id = s.exercise_id
+              AND selected_exercise.user_id = s.user_id
+              AND selected_exercise.name = sqlc.narg(exercise_name)::text
+        )
+    )
 LEFT JOIN exercise e ON e.id = s.exercise_id AND e.user_id = w.user_id
 ORDER BY w.date DESC, w.id DESC, s.exercise_order, s.set_order, s.id;
 

--- a/server/query.sql
+++ b/server/query.sql
@@ -302,6 +302,77 @@ SELECT workout_id, workout_day, session_best_e1rm, session_avg_e1rm, session_avg
 FROM workout_metrics
 ORDER BY workout_day ASC, workout_id ASC;
 
+-- name: ListWorkoutsWithSetsForChat :many
+WITH matching_workouts AS (
+    SELECT w.id
+    FROM workout w
+    WHERE w.user_id = sqlc.arg(user_id)
+      AND (sqlc.narg(start_date)::timestamptz IS NULL OR w.date >= sqlc.narg(start_date)::timestamptz)
+      AND (sqlc.narg(end_date)::timestamptz IS NULL OR w.date <= sqlc.narg(end_date)::timestamptz)
+      AND (
+          NULLIF(sqlc.narg(exercise_name)::text, '') IS NULL
+          OR EXISTS (
+              SELECT 1
+              FROM "set" filter_set
+              JOIN exercise filter_exercise ON filter_exercise.id = filter_set.exercise_id
+              WHERE filter_set.workout_id = w.id
+                AND filter_set.user_id = w.user_id
+                AND filter_exercise.user_id = w.user_id
+                AND filter_exercise.name = sqlc.narg(exercise_name)::text
+          )
+      )
+      AND (
+          NULLIF(sqlc.narg(workout_focus)::text, '') IS NULL
+          OR w.workout_focus ILIKE '%' || sqlc.narg(workout_focus)::text || '%'
+      )
+    ORDER BY w.date DESC, w.id DESC
+    LIMIT sqlc.arg(row_limit)
+)
+SELECT
+    w.id AS workout_id,
+    w.date,
+    w.notes,
+    w.workout_focus,
+    e.name AS exercise_name,
+    s.exercise_order,
+    s.set_order,
+    s.weight,
+    s.reps,
+    s.set_type
+FROM matching_workouts mw
+JOIN workout w ON w.id = mw.id
+LEFT JOIN "set" s ON s.workout_id = w.id AND s.user_id = w.user_id
+LEFT JOIN exercise e ON e.id = s.exercise_id AND e.user_id = w.user_id
+ORDER BY w.date DESC, w.id DESC, s.exercise_order, s.set_order, s.id;
+
+-- name: ListExerciseNameMatches :many
+SELECT id, name
+FROM exercise
+WHERE user_id = $1
+  AND name ILIKE '%' || sqlc.arg(name_query)::text || '%'
+ORDER BY name
+LIMIT 8;
+
+-- name: GetChatWorkoutSnapshotStats :one
+SELECT
+    MAX(date)::timestamptz AS last_workout_date,
+    COUNT(*) FILTER (WHERE date >= now() - interval '30 days') AS workouts_last_30d
+FROM workout
+WHERE user_id = $1;
+
+-- name: ListTopExercisesByFrequency :many
+SELECT
+    e.name,
+    COUNT(DISTINCT s.workout_id)::integer AS workout_count
+FROM "set" s
+JOIN exercise e ON e.id = s.exercise_id AND e.user_id = s.user_id
+JOIN workout w ON w.id = s.workout_id AND w.user_id = s.user_id
+WHERE s.user_id = $1
+  AND w.date >= now() - interval '90 days'
+GROUP BY e.name
+ORDER BY workout_count DESC, e.name
+LIMIT 5;
+
 -- INSERT queries for form submission
 -- name: CreateWorkout :one
 INSERT INTO workout (date, notes, workout_focus, user_id)


### PR DESCRIPTION
## Summary
- Enables the AI chat runtime to answer data questions from logged workouts in Phase 1.
- Adds workout-history data access, the corresponding chat tool, and eval fixture/baseline support.
- Records the official two-turn eval baseline for the rebased implementation.

## Verification
- Not run locally during PR creation: the pre-push `make test-short` hook requires Docker/Postgres, and Docker Desktop is not running on this machine.
