### PR TITLE
fix: scale sweep default timeout with scenario count and pacing

### DIFF
--- a/server/cmd/ai-chat-scenario-sweep/main.go
+++ b/server/cmd/ai-chat-scenario-sweep/main.go
@@ -22,6 +22,8 @@ const (
 	defaultLogName       = "fittrack-ai-chat-scenario-sweep-runs.jsonl"
 	defaultRunTimeout    = 15 * time.Minute
 	defaultScenarioDelay = 75 * time.Second
+	baseTimeoutHeadroom  = 5 * time.Minute
+	scenarioHeadroom     = 90 * time.Second
 )
 
 func main() {
@@ -34,10 +36,11 @@ func main() {
 	toID := flag.String("to", "", "run an inclusive scenario id range ending at this id")
 	withDataFixtures := flag.Bool("with-data-fixtures", false, "include AI chat data Q&A scenarios backed by in-memory workout fixtures")
 	flag.Parse()
+	timeoutExplicit := flagWasSet("timeout")
 	if err := aichateval.ValidateMode(*mode); err != nil {
 		fail("%v", err)
 	}
-	if *timeout <= 0 {
+	if timeoutExplicit && *timeout <= 0 {
 		fail("timeout must be greater than zero")
 	}
 	if *scenarioDelay < 0 {
@@ -61,6 +64,11 @@ func main() {
 	if err != nil {
 		fail("invalid scenario selection: %v", err)
 	}
+	runTimeout := selectedRunTimeout(*timeout, timeoutExplicit, len(scenarios), *scenarioDelay, *mode)
+	if runTimeout <= 0 {
+		fail("timeout must be greater than zero")
+	}
+	fmt.Fprintf(os.Stderr, "Using sweep timeout %s (source=%s, scenarios=%d, mode=%s, scenario_delay=%s)\n", runTimeout, timeoutSource(timeoutExplicit), len(scenarios), *mode, *scenarioDelay)
 	if err := loadLocalEnv(); err != nil {
 		fail("failed to load local env files: %v", err)
 	}
@@ -70,7 +78,7 @@ func main() {
 		fail("failed to create output directory: %v", err)
 	}
 
-	runtimeCtx, cancel := context.WithTimeout(context.Background(), *timeout)
+	runtimeCtx, cancel := context.WithTimeout(context.Background(), runTimeout)
 	defer cancel()
 
 	runtime := aichat.NewGenkitRuntime(runtimeCtx, dataReader)
@@ -154,6 +162,39 @@ func selectedScenarioDelay(delay time.Duration, scenarioCount int) time.Duration
 		return 0
 	}
 	return delay
+}
+
+func selectedRunTimeout(explicit time.Duration, explicitSet bool, scenarioCount int, delay time.Duration, mode string) time.Duration {
+	if explicitSet {
+		return explicit
+	}
+
+	headroom := scenarioHeadroom
+	if mode == aichateval.ModeTwoTurn {
+		headroom *= 2
+	}
+	scaled := time.Duration(scenarioCount)*(delay+headroom) + baseTimeoutHeadroom
+	if scaled < defaultRunTimeout {
+		return defaultRunTimeout
+	}
+	return scaled
+}
+
+func timeoutSource(explicitSet bool) string {
+	if explicitSet {
+		return "explicit"
+	}
+	return "computed_default"
+}
+
+func flagWasSet(name string) bool {
+	wasSet := false
+	flag.Visit(func(item *flag.Flag) {
+		if item.Name == name {
+			wasSet = true
+		}
+	})
+	return wasSet
 }
 
 func fail(format string, args ...any) {

--- a/server/cmd/ai-chat-scenario-sweep/main_test.go
+++ b/server/cmd/ai-chat-scenario-sweep/main_test.go
@@ -114,6 +114,62 @@ func TestSelectedScenarioDelaySkipsSingleScenarioRuns(t *testing.T) {
 	}
 }
 
+func TestSelectedRunTimeoutFloorsComputedDefault(t *testing.T) {
+	got := selectedRunTimeout(0, false, 1, defaultScenarioDelay, aichateval.ModeSingleTurn)
+	if got != defaultRunTimeout {
+		t.Fatalf("selectedRunTimeout(single scenario) = %s, want %s", got, defaultRunTimeout)
+	}
+}
+
+func TestSelectedRunTimeoutScalesWithScenarioCountDelayAndMode(t *testing.T) {
+	tests := []struct {
+		name          string
+		scenarioCount int
+		delay         time.Duration
+		mode          string
+		want          time.Duration
+	}{
+		{
+			name:          "single turn",
+			scenarioCount: 20,
+			delay:         75 * time.Second,
+			mode:          aichateval.ModeSingleTurn,
+			want:          time.Hour,
+		},
+		{
+			name:          "custom delay",
+			scenarioCount: 20,
+			delay:         30 * time.Second,
+			mode:          aichateval.ModeSingleTurn,
+			want:          45 * time.Minute,
+		},
+		{
+			name:          "two turn doubles per scenario headroom",
+			scenarioCount: 20,
+			delay:         75 * time.Second,
+			mode:          aichateval.ModeTwoTurn,
+			want:          90 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectedRunTimeout(0, false, tt.scenarioCount, tt.delay, tt.mode)
+			if got != tt.want {
+				t.Fatalf("selectedRunTimeout() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectedRunTimeoutUsesExplicitOverride(t *testing.T) {
+	explicit := 2 * time.Minute
+	got := selectedRunTimeout(explicit, true, 20, defaultScenarioDelay, aichateval.ModeTwoTurn)
+	if got != explicit {
+		t.Fatalf("selectedRunTimeout(explicit) = %s, want %s", got, explicit)
+	}
+}
+
 func splitNonEmptyLines(body string) []string {
 	var lines []string
 	for _, line := range strings.Split(body, "\n") {


### PR DESCRIPTION
## Summary
- Scale the sweep timeout only when `-timeout` is not explicitly set.
- Compute the implicit timeout after scenario selection with:
  `max(15m, selectedCount * (scenarioDelay + perScenarioHeadroom) + 5m)`
- Use 90s per-scenario headroom in single-turn mode and 180s in two-turn mode.
- Log the effective timeout at startup with source, scenario count, mode, and delay.

## Motivation
The previous defaults could not fit together: 20+ scenarios paced at the default 75s delay could exceed the fixed 15m timeout before later scenarios were attempted. That produced misleading `context deadline exceeded` operational errors with zero duration and zero attempts.

## Verification
- `go test ./cmd/ai-chat-scenario-sweep`
- `go run ./cmd/ai-chat-scenario-sweep -h`
- `make test-fast`
- `go vet ./...`

Closes #227