### PR TITLE
fix: format chat workout dates timezone-independently

### DIFF
--- a/server/internal/aichat/repository_data.go
+++ b/server/internal/aichat/repository_data.go
@@ -17,6 +17,7 @@ const (
 	maxChatWorkoutLimit         = 20
 	defaultExerciseStatsWindow  = "3m"
 	maxExerciseStatsTrendPoints = 8
+	chatDateLayout              = "2006-01-02"
 )
 
 type ChatDataReader interface {
@@ -89,7 +90,7 @@ func (r *repository) TrainingSnapshot(ctx context.Context, userID string) (*Trai
 		TopExercises:    make([]string, 0, len(topRows)),
 	}
 	if stats.LastWorkoutDate.Valid {
-		snapshot.LastWorkoutDate = stats.LastWorkoutDate.Time.Format("2006-01-02")
+		snapshot.LastWorkoutDate = formatChatWorkoutDate(stats.LastWorkoutDate.Time)
 	}
 	for _, row := range topRows {
 		snapshot.TopExercises = append(snapshot.TopExercises, row.Name)
@@ -218,7 +219,7 @@ func (r *repository) ExerciseStats(ctx context.Context, userID string, exerciseN
 	}
 	if len(recentSets) > 0 {
 		if recentSets[0].WorkoutDate.Valid {
-			stats.LastSessionDate = recentSets[0].WorkoutDate.Time.Format("2006-01-02")
+			stats.LastSessionDate = formatChatWorkoutDate(recentSets[0].WorkoutDate.Time)
 		}
 		for _, row := range recentSets {
 			setText, err := formatRecentExerciseStatSet(row.Weight, row.Reps)
@@ -353,7 +354,7 @@ func (r *repository) workoutDate(ctx context.Context, userID string, workoutID i
 	if !row.Date.Valid {
 		return "", nil
 	}
-	return row.Date.Time.Format("2006-01-02"), nil
+	return formatChatWorkoutDate(row.Date.Time), nil
 }
 
 type exerciseStatsTrendRow struct {
@@ -419,7 +420,7 @@ func mapChatWorkoutRows(rows []db.ListWorkoutsWithSetsForChatRow) ([]ChatWorkout
 		workoutIndex, ok := workoutIndexes[row.WorkoutID]
 		if !ok {
 			workout := ChatWorkoutView{
-				Date: row.Date.Time.Format("2006-01-02"),
+				Date: formatChatWorkoutDate(row.Date.Time),
 			}
 			if row.WorkoutFocus.Valid {
 				workout.Focus = row.WorkoutFocus.String
@@ -546,7 +547,7 @@ func mapExerciseStatsTrendPoints(points []exerciseStatsTrendRow) []ExerciseStats
 	mapped := make([]ExerciseStatsTrendPoint, 0, len(points))
 	for _, point := range points {
 		mapped = append(mapped, ExerciseStatsTrendPoint{
-			Date:      point.WorkoutDay.Format("2006-01-02"),
+			Date:      formatChatWorkoutDate(point.WorkoutDay),
 			BestE1RM:  point.SessionBestE1RM,
 			AvgE1RM:   point.SessionAvgE1RM,
 			Volume:    point.TotalVolumeWorking,
@@ -582,6 +583,10 @@ func formatRecentExerciseStatSet(weight pgtype.Numeric, reps int32) (string, err
 func formatSetWeight(weight float64) string {
 	text := fmt.Sprintf("%.1f", weight)
 	return strings.TrimSuffix(strings.TrimSuffix(text, "0"), ".")
+}
+
+func formatChatWorkoutDate(value time.Time) string {
+	return value.UTC().Format(chatDateLayout)
 }
 
 var _ ChatDataReader = (*repository)(nil)

--- a/server/internal/aichat/repository_data_test.go
+++ b/server/internal/aichat/repository_data_test.go
@@ -43,6 +43,15 @@ func TestMapChatWorkoutRowsRegroupsFlatRows(t *testing.T) {
 	}
 }
 
+func TestFormatChatWorkoutDateUsesUTCCalendarDay(t *testing.T) {
+	utcMinusFour := time.FixedZone("UTC-4", -4*60*60)
+	scannedLocalTime := time.Date(2026, 6, 30, 20, 0, 0, 0, utcMinusFour)
+
+	if got := formatChatWorkoutDate(scannedLocalTime); got != "2026-07-01" {
+		t.Fatalf("formatChatWorkoutDate() = %q, want 2026-07-01", got)
+	}
+}
+
 func TestNormalizeWorkoutHistoryFilterCapsLastN(t *testing.T) {
 	if got := normalizeWorkoutHistoryFilter(WorkoutHistoryFilter{}).LastN; got != defaultChatWorkoutLimit {
 		t.Fatalf("default LastN = %d, want %d", got, defaultChatWorkoutLimit)


### PR DESCRIPTION
## Root cause

Workout create/update accepts RFC3339 instants, and the app stores workout dates as `timestamptz`. The chat repository was formatting those timestamps with `Time.Format("2006-01-02")`, which uses the `time.Time` value's local zone. On a UTC-4 server, a UTC-midnight workout can render as the previous local evening, so chat-visible dates came back one day early even though the stored data was correct.

## Fix

Added one chat date formatter that converts timestamps to UTC before rendering the `YYYY-MM-DD` date, then used it for all chat-facing workout date strings: workout history rows, exercise best-date lookup, last-session date, trend points, and the training snapshot last-workout date.

I chose the Go-side UTC formatter instead of changing only SQL casts because chat pulls dates from both chat-specific queries and shared workout queries. This keeps every chat path consistent with the existing app convention: client/non-chat paths treat workout dates as ISO instants, while date-only history surfaces derive a stable calendar date before display.

## Test evidence

- `go test ./internal/aichat -run "TestFormatChatWorkoutDateUsesUTCCalendarDay|TestMapChatWorkoutRowsRegroupsFlatRows|TestCompactExerciseStatsTrend" -count=1`
- `git diff --check`
- `bash -lc "cd server && make test-fast"`
- `bash -lc "cd server && go vet ./..."`
- `bash -lc "export PATH=\"/home/lenny-unix/go/bin:/home/lenny-unix/.local/go/bin:$PATH\"; cd server && make test-short"`
- `bash -lc "cd server && set -a && . ./setenv.sh && go test ./internal/aichat/ -run TestRepository -count=1"`
- `bash -lc "cd server && set -a && . ./setenv.sh && TZ=UTC go test ./internal/aichat/ -run TestRepository -count=1"`
- `bash -lc "cd server && set -a && . ./setenv.sh && go test ./internal/aichat/ -count=1"`

Closes #226