### PR TITLE
chore: add make test-integration; document test-short's -short semantics

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build clean docker-down migrate-create migrate-up migrate-down sqlc swagger run test test-fast test-short vet dev
+.PHONY: help build clean docker-down migrate-create migrate-up migrate-down sqlc swagger run test test-fast test-db-ready test-short test-integration vet dev
 
 GOCMD=go
 GOBUILD=$(GOCMD) build
@@ -19,6 +19,7 @@ DB_READY_TIMEOUT ?= 90
 AIR_CMD ?= air
 DB_DATA_DIR ?= _db-data
 ENV_FILE ?= setenv.sh
+TEST_DB_ENV_FILE ?= /tmp/fittrack-test-db.env
 
 help:
 	@echo "Available commands:"
@@ -27,7 +28,8 @@ help:
 	@echo "  docker-down  - Stop Docker containers"
 	@echo "  run          - Run the application"
 	@echo "  test-fast    - Quick local check for server code changes (no DB package)"
-	@echo "  test-short   - Use before push for DB/integration-impacting server changes"
+	@echo "  test-short   - Use before push for DB-impacting server changes (integration tests are skipped; see test-integration)"
+	@echo "  test-integration - Start local DB and run full server suite with integration tests"
 	@echo "  test         - Full verbose suite (deep local check / CI parity)"
 	@echo "  vet          - Run go vet"
 	@echo "  migrate-up   - Run database migrations up"
@@ -92,7 +94,7 @@ test-fast: ## Run fast test suite without DB integration package
 	fi; \
 	$(GOTEST) -short $$pkgs
 
-test-short: ## Start local DB and run short test suite
+test-db-ready: ## Prepare local test DB for server tests
 	@echo "==> Starting database container: $(DB_SERVICE)"
 	@if ! command -v docker >/dev/null 2>&1; then \
 		echo "ERROR: docker is not installed or not on PATH."; \
@@ -100,7 +102,7 @@ test-short: ## Start local DB and run short test suite
 	fi
 	@if [ ! -f "$(ENV_FILE)" ]; then \
 		echo "ERROR: expected env file at $$(pwd)/$(ENV_FILE)"; \
-		echo "Create setenv.sh with DB_USER, DB_PASSWORD, DB_NAME, and DATABASE_URL before running make test-short."; \
+		echo "Create setenv.sh with DB_USER, DB_PASSWORD, DB_NAME, and DATABASE_URL before running DB-backed test targets."; \
 		exit 1; \
 	fi
 	. ./$(ENV_FILE); \
@@ -170,8 +172,17 @@ test-short: ## Start local DB and run short test suite
 	echo "==> PostgreSQL credentials verified"; \
 	echo "==> Applying migrations"; \
 	goose -dir migrations postgres "$$db_url" up; \
+	printf 'DATABASE_URL=%q\n' "$$db_url" > "$(TEST_DB_ENV_FILE)"
+
+test-short: test-db-ready ## Start local DB and run short test suite (integration tests are skipped; see test-integration)
+	@. "$(TEST_DB_ENV_FILE)"; \
 	echo "==> Running go test -short ./..."; \
-	DATABASE_URL="$$db_url" $(GOTEST) -short ./...
+	DATABASE_URL="$$DATABASE_URL" $(GOTEST) -short ./...
+
+test-integration: test-db-ready ## Start local DB and run full server suite with integration tests
+	@. "$(TEST_DB_ENV_FILE)"; \
+	echo "==> Running go test ./..."; \
+	DATABASE_URL="$$DATABASE_URL" $(GOTEST) ./...
 
 vet:
 	$(GOCMD) vet -v ./...

--- a/server/README.md
+++ b/server/README.md
@@ -327,6 +327,9 @@ make run               # Run the compiled binary
 make swagger           # Generate OpenAPI documentation
 make sqlc              # Generate SQL code from query.sql
 make test              # Run all tests
+make test-fast         # Run the quick short suite without the DB package
+make test-short        # Start the local DB and run the short suite
+make test-integration  # Start the local DB and run the full suite with integration tests
 make vet               # Run go vet
 make migrate-up        # Apply all pending migrations
 make migrate-down      # Rollback last migration
@@ -334,4 +337,6 @@ make migrate-create    # Create a new migration file (NAME=<name>)
 make docker-down       # Stop PostgreSQL container
 make clean             # Clean build files and cache
 ```
+
+Use `make test` for the full Go suite without local DB setup, and `make test-fast` for the quick no-DB-package short-mode check used by pre-commit. Use `make test-short` when you need the local DB boot and migrations but still want short-mode tests, and use `make test-integration` when you need DB-backed integration tests because it runs the full suite without `-short`.
 


### PR DESCRIPTION
## Summary
- Add `make test-integration` for DB-backed integration coverage.
- Factor `test-short` and `test-integration` through a shared `test-db-ready` prerequisite so DB startup, credential verification, migrations, and `DATABASE_URL` normalization stay in one place.
- Document the server test target matrix in `server/README.md`.

## Target matrix
- `make test`: full Go suite without local DB setup.
- `make test-fast`: quick short-mode server check without the DB package; used by pre-commit.
- `make test-short`: starts the local DB and runs `go test -short ./...`; integration tests are skipped.
- `make test-integration`: starts the local DB and runs `go test ./...`; integration tests run.

## Verification
- `make test-fast` passed from Git Bash.
- `go vet ./...` passed from Git Bash.
- `make test-short` passed from Git Bash and still runs `go test -short ./...`.
- `make test-integration` reached `go test ./...`; it fails only on the known issue #226 UTC-4 date off-by-one tests: `FiltersByUserDateAndExercise`, `CapsWorkoutLimit`, and `ExerciseStatsAreUserScoped`.

Closes #228