### PR TITLE
chore: post-review cleanup (Makefile portability, limitations validation, API nullability, provenance note)

### DIFF
--- a/client/src/client/schemas.gen.ts
+++ b/client/src/client/schemas.gen.ts
@@ -695,6 +695,7 @@ export const trainingprofile_ProfileResponseSchema = {
       items: {
         type: "string",
       },
+      "x-nullable": true,
     },
     preferred_session_duration_minutes: {
       type: "integer",
@@ -731,6 +732,7 @@ export const trainingprofile_UpdateProfileRequestSchema = {
       items: {
         type: "string",
       },
+      "x-nullable": true,
     },
     preferred_session_duration_minutes: {
       type: "integer",

--- a/client/src/client/types.gen.ts
+++ b/client/src/client/types.gen.ts
@@ -245,7 +245,7 @@ export type TrainingprofileProfileResponse = {
   available_equipment?: Array<string>;
   avoided_exercises?: Array<string>;
   experience_level?: string;
-  movement_limitations?: Array<string>;
+  movement_limitations?: Array<string> | null;
   preferred_session_duration_minutes?: number;
   primary_goal?: string;
   usual_training_location?: string;
@@ -255,7 +255,7 @@ export type TrainingprofileUpdateProfileRequest = {
   available_equipment?: Array<string>;
   avoided_exercises?: Array<string>;
   experience_level?: string;
-  movement_limitations?: Array<string>;
+  movement_limitations?: Array<string> | null;
   preferred_session_duration_minutes?: number;
   primary_goal?: string;
   usual_training_location?: string;

--- a/client/src/features/training-profile/pages/training-profile-page.test.tsx
+++ b/client/src/features/training-profile/pages/training-profile-page.test.tsx
@@ -179,7 +179,7 @@ describe("TrainingProfilePage", () => {
     });
   });
 
-  it("sends the limitation list when limitations are provided", async () => {
+  it("adds a drafted limitation when Save is clicked", async () => {
     const user = userEvent.setup();
     renderPage();
 
@@ -188,7 +188,7 @@ describe("TrainingProfilePage", () => {
     );
     await user.type(
       screen.getByLabelText("Movement limitation details"),
-      "knee pain{Enter}",
+      "knee pain",
     );
     await user.click(screen.getByRole("button", { name: "Save" }));
 

--- a/client/src/features/training-profile/pages/training-profile-page.test.tsx
+++ b/client/src/features/training-profile/pages/training-profile-page.test.tsx
@@ -198,4 +198,39 @@ describe("TrainingProfilePage", () => {
       );
     });
   });
+
+  it("blocks saving limitations mode without tags until another option is chosen", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(
+      await screen.findByRole("radio", { name: "I have limitations:" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(mockUpdateTrainingProfile).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(
+        "Add at least one limitation, or choose another option.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("radio", { name: "No known limitations" }),
+    );
+
+    expect(
+      screen.queryByText(
+        "Add at least one limitation, or choose another option.",
+      ),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(latestUpdatePayload()).toEqual(
+        expect.objectContaining({ movement_limitations: [] }),
+      );
+    });
+  });
 });

--- a/client/src/features/training-profile/pages/training-profile-page.tsx
+++ b/client/src/features/training-profile/pages/training-profile-page.tsx
@@ -441,6 +441,7 @@ function TagInput({
         value={draft}
         aria-invalid={error ? true : undefined}
         onChange={(event) => setDraft(event.currentTarget.value)}
+        onBlur={addDraft}
         onKeyDown={(event) => {
           if (event.key === "Enter") {
             event.preventDefault();

--- a/client/src/features/training-profile/pages/training-profile-page.tsx
+++ b/client/src/features/training-profile/pages/training-profile-page.tsx
@@ -45,6 +45,9 @@ const introCopy =
 const movementHelperText =
   "If you choose 'No known limitations', the AI coach will stop asking about injuries before workouts. Leave 'Not specified' if you'd rather be asked.";
 
+const movementLimitationsRequiredMessage =
+  "Add at least one limitation, or choose another option.";
+
 const goalOptions: SelectOption[] = [
   { value: "strength", label: "Strength" },
   { value: "hypertrophy", label: "Hypertrophy" },
@@ -118,6 +121,12 @@ export function TrainingProfilePage() {
         nextErrors.preferredSessionDurationMinutes =
           "Enter a duration from 10 to 240 minutes.";
       }
+    }
+    if (
+      form.movementState === "list" &&
+      cleanTagList(form.movementLimitations).length === 0
+    ) {
+      nextErrors.movementLimitations = movementLimitationsRequiredMessage;
     }
     return nextErrors;
   }
@@ -300,6 +309,7 @@ export function TrainingProfilePage() {
             <TagInput
               label="Movement limitation details"
               values={form.movementLimitations}
+              error={errors.movementLimitations}
               onChange={(movementLimitations) =>
                 updateForm({ movementLimitations })
               }
@@ -395,10 +405,12 @@ function FieldShell({
 function TagInput({
   label,
   values,
+  error,
   onChange,
 }: {
   label: string;
   values: string[];
+  error?: string;
   onChange: (values: string[]) => void;
 }) {
   const [draft, setDraft] = useState("");
@@ -427,6 +439,7 @@ function TagInput({
       <Input
         id={inputId}
         value={draft}
+        aria-invalid={error ? true : undefined}
         onChange={(event) => setDraft(event.currentTarget.value)}
         onKeyDown={(event) => {
           if (event.key === "Enter") {
@@ -455,6 +468,7 @@ function TagInput({
           ))}
         </div>
       ) : null}
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
     </div>
   );
 }

--- a/server/Makefile
+++ b/server/Makefile
@@ -19,7 +19,7 @@ DB_READY_TIMEOUT ?= 90
 AIR_CMD ?= air
 DB_DATA_DIR ?= _db-data
 ENV_FILE ?= setenv.sh
-TEST_DB_ENV_FILE ?= /tmp/fittrack-test-db.env
+TEST_DB_ENV_FILE ?= $(CURDIR)/tmp/fittrack-test-db.env
 
 help:
 	@echo "Available commands:"
@@ -137,7 +137,7 @@ test-db-ready: ## Prepare local test DB for server tests
 		fi; \
 		now=$$(date +%s); \
 		elapsed=$$(( now - start_ts )); \
-		if [ "$$elapsed" -ge 30 ]; then \
+		if [ "$$elapsed" -ge "$(DB_READY_TIMEOUT)" ]; then \
 			echo "ERROR: Timed out waiting for PostgreSQL readiness"; \
 			echo "Tip: Check logs with: docker compose logs $(DB_SERVICE)"; \
 			exit 1; \
@@ -172,7 +172,9 @@ test-db-ready: ## Prepare local test DB for server tests
 	echo "==> PostgreSQL credentials verified"; \
 	echo "==> Applying migrations"; \
 	goose -dir migrations postgres "$$db_url" up; \
-	printf 'DATABASE_URL=%q\n' "$$db_url" > "$(TEST_DB_ENV_FILE)"
+	mkdir -p "$$(dirname "$(TEST_DB_ENV_FILE)")"; \
+	escaped_db_url="$$(printf '%s\n' "$$db_url" | sed "s/'/'\\\\''/g")"; \
+	printf "DATABASE_URL='%s'\n" "$$escaped_db_url" > "$(TEST_DB_ENV_FILE)"
 
 test-short: test-db-ready ## Start local DB and run short test suite (integration tests are skipped; see test-integration)
 	@. "$(TEST_DB_ENV_FILE)"; \

--- a/server/README.md
+++ b/server/README.md
@@ -131,6 +131,8 @@ The live API chat runtime uses the same model default as the smoke test:
 - supported API key env vars: `GEMINI_API_KEY` or `GOOGLE_API_KEY`
 - optional model override: `GEMINI_MODEL`
 
+Manual training profile settings saves intentionally clear chat provenance: `source_conversation_id` and `source_message_id` only reference the chat message that last wrote the profile via AI.
+
 For local development, keep using the existing server env workflow:
 
 1. Put values in your shell, `server/.env`, or `server/setenv.sh`

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -2445,7 +2445,8 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "type": "string"
-                    }
+                    },
+                    "x-nullable": true
                 },
                 "preferred_session_duration_minutes": {
                     "type": "integer"
@@ -2480,7 +2481,8 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "type": "string"
-                    }
+                    },
+                    "x-nullable": true
                 },
                 "preferred_session_duration_minutes": {
                     "type": "integer"

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -2442,7 +2442,8 @@
                     "type": "array",
                     "items": {
                         "type": "string"
-                    }
+                    },
+                    "x-nullable": true
                 },
                 "preferred_session_duration_minutes": {
                     "type": "integer"
@@ -2477,7 +2478,8 @@
                     "type": "array",
                     "items": {
                         "type": "string"
-                    }
+                    },
+                    "x-nullable": true
                 },
                 "preferred_session_duration_minutes": {
                     "type": "integer"

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -488,6 +488,7 @@ definitions:
         items:
           type: string
         type: array
+        x-nullable: true
       preferred_session_duration_minutes:
         type: integer
       primary_goal:
@@ -511,6 +512,7 @@ definitions:
         items:
           type: string
         type: array
+        x-nullable: true
       preferred_session_duration_minutes:
         type: integer
       primary_goal:

--- a/server/internal/database/query.sql.go
+++ b/server/internal/database/query.sql.go
@@ -3977,6 +3977,7 @@ VALUES (
     $6::jsonb,
     $7::jsonb,
     $8::jsonb,
+    -- Manual settings saves supersede AI-written profile provenance.
     NULL,
     NULL
 )
@@ -3988,6 +3989,7 @@ ON CONFLICT (user_id) DO UPDATE SET
     available_equipment = $6::jsonb,
     avoided_exercises = $7::jsonb,
     movement_limitations = $8::jsonb,
+    -- These columns only reference the chat message that last wrote the profile via AI.
     source_conversation_id = NULL,
     source_message_id = NULL,
     updated_at = CURRENT_TIMESTAMP

--- a/server/internal/trainingprofile/models.go
+++ b/server/internal/trainingprofile/models.go
@@ -15,7 +15,7 @@ type ProfileResponse struct {
 	UsualTrainingLocation           *string   `json:"usual_training_location"`
 	AvailableEquipment              []string  `json:"available_equipment"`
 	AvoidedExercises                []string  `json:"avoided_exercises"`
-	MovementLimitations             *[]string `json:"movement_limitations"`
+	MovementLimitations             *[]string `json:"movement_limitations" extensions:"x-nullable"`
 }
 
 type UpdateProfileRequest struct {
@@ -25,7 +25,7 @@ type UpdateProfileRequest struct {
 	UsualTrainingLocation           *string   `json:"usual_training_location"`
 	AvailableEquipment              []string  `json:"available_equipment"`
 	AvoidedExercises                []string  `json:"avoided_exercises"`
-	MovementLimitations             *[]string `json:"movement_limitations"`
+	MovementLimitations             *[]string `json:"movement_limitations" extensions:"x-nullable"`
 }
 
 type ValidationError struct {

--- a/server/query.sql
+++ b/server/query.sql
@@ -534,6 +534,7 @@ VALUES (
     sqlc.arg(available_equipment)::jsonb,
     sqlc.arg(avoided_exercises)::jsonb,
     sqlc.narg(movement_limitations)::jsonb,
+    -- Manual settings saves supersede AI-written profile provenance.
     NULL,
     NULL
 )
@@ -545,6 +546,7 @@ ON CONFLICT (user_id) DO UPDATE SET
     available_equipment = sqlc.arg(available_equipment)::jsonb,
     avoided_exercises = sqlc.arg(avoided_exercises)::jsonb,
     movement_limitations = sqlc.narg(movement_limitations)::jsonb,
+    -- These columns only reference the chat message that last wrote the profile via AI.
     source_conversation_id = NULL,
     source_message_id = NULL,
     updated_at = CURRENT_TIMESTAMP


### PR DESCRIPTION
## Summary

- Fix test DB env-file portability from PR #234 review by replacing Bash `%q` output with POSIX-sourceable single-quote escaping and scoping the env file to `server/tmp/` per checkout.
- Fix the PR #235 limitations trap by blocking training-profile saves when "I have limitations" is selected with no tags, preserving the difference between unspecified limitations and explicit none.
- Fix the PR #235 API contract gap by marking `movement_limitations` as `x-nullable` in Swagger and regenerating the TypeScript client so request/response types include `null`.
- Document the provenance decision: manual training-profile settings saves clear chat provenance because the source columns only reference AI-written profile updates.

Closes #237

## Verification

- `make sqlc`
- `make swagger`
- `bun run openapi-ts` (with temporary ignored eslint shim removed afterward)
- `bunx vitest run src/features/training-profile/pages/training-profile-page.test.tsx`
- `go test -short ./internal/trainingprofile`
- Git Bash: `make test-fast`
- `go vet ./...`
- Git Bash: `make test-short`
- Git Bash: `make test-integration`
- `bun run tsc`
- `bun run lint`
- `bun run fmt:check`
- `bun run test`
- `bun run build`