### PR TITLE
fix: create new conversations from chat navigation

### DIFF
--- a/client/src/components/nav/app-bottom-bar.tsx
+++ b/client/src/components/nav/app-bottom-bar.tsx
@@ -22,13 +22,14 @@ export function AppBottomBar({ user }: AppBottomBarProps) {
       style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 0.75rem)" }}
     >
       <div className="pointer-events-auto mx-auto flex max-w-md items-center justify-between gap-1 rounded-full border bg-background/95 px-2 py-2 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/85">
-        {navItems.map(({ to, label, icon: Icon }) => {
+        {navItems.map(({ to, label, icon: Icon, search }) => {
           const active = isActivePath(pathname, to);
 
           return (
             <Link
               key={to}
               to={to}
+              search={search}
               aria-current={active ? "page" : undefined}
               aria-label={label}
               title={label}

--- a/client/src/components/nav/app-top-bar.tsx
+++ b/client/src/components/nav/app-top-bar.tsx
@@ -31,13 +31,14 @@ export function AppTopBar({ user }: AppTopBarProps) {
         aria-label="Primary navigation"
         className="hidden items-center gap-1 md:flex"
       >
-        {navItems.map(({ to, label }) => {
+        {navItems.map(({ to, label, search }) => {
           const active = isActivePath(pathname, to);
 
           return (
             <Link
               key={to}
               to={to}
+              search={search}
               aria-current={active ? "page" : undefined}
               className={cn(
                 "rounded-md px-3 py-2 text-sm font-medium transition-colors",

--- a/client/src/components/nav/landing-top-bar.tsx
+++ b/client/src/components/nav/landing-top-bar.tsx
@@ -50,13 +50,14 @@ export function LandingTopBar({ user }: LandingTopBarProps) {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              {navItems.map(({ to, label, icon: Icon }) => (
+              {navItems.map(({ to, label, icon: Icon, search }) => (
                 <DropdownMenuItem
                   asChild
                   key={to}
                 >
                   <Link
                     to={to}
+                    search={search}
                     preload={false}
                     className="flex items-center gap-2"
                   >

--- a/client/src/components/nav/nav-items.test.ts
+++ b/client/src/components/nav/nav-items.test.ts
@@ -6,10 +6,10 @@ describe("navItems", () => {
     expect(
       navItems.map(({ icon: _icon, ...destination }) => destination),
     ).toEqual([
-      { to: "/workouts", label: "Workouts" },
-      { to: "/exercises", label: "Exercises" },
-      { to: "/analytics", label: "Analytics" },
-      { to: "/chat", label: "AI Chat" },
+      { to: "/workouts", label: "Workouts", search: undefined },
+      { to: "/exercises", label: "Exercises", search: undefined },
+      { to: "/analytics", label: "Analytics", search: undefined },
+      { to: "/chat", label: "AI Chat", search: { createChat: true } },
     ]);
   });
 });

--- a/client/src/components/nav/nav-items.ts
+++ b/client/src/components/nav/nav-items.ts
@@ -1,8 +1,18 @@
 import { Activity, Bot, ChartColumn, Dumbbell } from "lucide-react";
 
 export const navItems = [
-  { to: "/workouts", label: "Workouts", icon: Dumbbell },
-  { to: "/exercises", label: "Exercises", icon: Activity },
-  { to: "/analytics", label: "Analytics", icon: ChartColumn },
-  { to: "/chat", label: "AI Chat", icon: Bot },
+  { to: "/workouts", label: "Workouts", icon: Dumbbell, search: undefined },
+  { to: "/exercises", label: "Exercises", icon: Activity, search: undefined },
+  {
+    to: "/analytics",
+    label: "Analytics",
+    icon: ChartColumn,
+    search: undefined,
+  },
+  {
+    to: "/chat",
+    label: "AI Chat",
+    icon: Bot,
+    search: { createChat: true },
+  },
 ] as const;

--- a/client/src/components/nav/nav-side-drawer.tsx
+++ b/client/src/components/nav/nav-side-drawer.tsx
@@ -67,7 +67,7 @@ export function NavSideDrawer({ user, children }: NavSideDrawerProps) {
           aria-label="Main navigation"
           className="flex flex-col p-3"
         >
-          {navItems.map(({ to, label, icon: Icon }) => {
+          {navItems.map(({ to, label, icon: Icon, search }) => {
             const active = isActivePath(pathname, to);
 
             return (
@@ -77,6 +77,7 @@ export function NavSideDrawer({ user, children }: NavSideDrawerProps) {
               >
                 <Link
                   to={to}
+                  search={search}
                   aria-current={active ? "page" : undefined}
                   className={cn(
                     "flex items-center gap-3 rounded-lg px-3 py-3 text-sm font-medium transition-colors",

--- a/client/src/features/chat/api/ai-chat.ts
+++ b/client/src/features/chat/api/ai-chat.ts
@@ -218,9 +218,12 @@ async function readApiError(response: Response): Promise<ApiError> {
   }
 }
 
-export async function createAIChatConversation(): Promise<AIChatConversation> {
+export async function createAIChatConversation(
+  options: ConversationRequestOptions = {},
+): Promise<AIChatConversation> {
   const response = await postAiConversations({
     throwOnError: true,
+    signal: options.signal,
   });
 
   return response.data as AIChatConversation;

--- a/client/src/features/chat/api/ai-chat.ts
+++ b/client/src/features/chat/api/ai-chat.ts
@@ -218,12 +218,9 @@ async function readApiError(response: Response): Promise<ApiError> {
   }
 }
 
-export async function createAIChatConversation(
-  options: ConversationRequestOptions = {},
-): Promise<AIChatConversation> {
+export async function createAIChatConversation(): Promise<AIChatConversation> {
   const response = await postAiConversations({
     throwOnError: true,
-    signal: options.signal,
   });
 
   return response.data as AIChatConversation;

--- a/client/src/features/chat/hooks/use-ai-chat-session.ts
+++ b/client/src/features/chat/hooks/use-ai-chat-session.ts
@@ -3,7 +3,10 @@ import type {
   AIChatConversation,
   AIChatMessage,
 } from "@/features/chat/api/ai-chat";
-import { createAIChatSessionLifecycle } from "../utils/ai-chat-session-lifecycle";
+import {
+  createAIChatSessionLifecycle,
+  type AIChatCreatedConversationOptions,
+} from "../utils/ai-chat-session-lifecycle";
 import type {
   ChatSessionRefs,
   ChatSessionSetters,
@@ -12,7 +15,10 @@ import { saveLatestWorkoutDraft as saveLatestWorkoutDraftRequest } from "../util
 
 type UseAIChatSessionOptions = {
   conversationId: number | null;
-  onConversationCreated: (conversationId: number) => Promise<void>;
+  onConversationCreated: (
+    conversationId: number,
+    options?: AIChatCreatedConversationOptions,
+  ) => Promise<void>;
 };
 
 export function useAIChatSession({
@@ -68,8 +74,10 @@ export function useAIChatSession({
   }, [onConversationCreated]);
 
   const handleConversationCreated = useCallback(
-    (createdConversationId: number) =>
-      onConversationCreatedRef.current(createdConversationId),
+    (
+      createdConversationId: number,
+      options?: AIChatCreatedConversationOptions,
+    ) => onConversationCreatedRef.current(createdConversationId, options),
     [],
   );
 

--- a/client/src/features/chat/hooks/use-ai-chat-session.ts
+++ b/client/src/features/chat/hooks/use-ai-chat-session.ts
@@ -3,10 +3,7 @@ import type {
   AIChatConversation,
   AIChatMessage,
 } from "@/features/chat/api/ai-chat";
-import {
-  createAIChatSessionLifecycle,
-  type AIChatCreatedConversationOptions,
-} from "../utils/ai-chat-session-lifecycle";
+import { createAIChatSessionLifecycle } from "../utils/ai-chat-session-lifecycle";
 import type {
   ChatSessionRefs,
   ChatSessionSetters,
@@ -15,10 +12,7 @@ import { saveLatestWorkoutDraft as saveLatestWorkoutDraftRequest } from "../util
 
 type UseAIChatSessionOptions = {
   conversationId: number | null;
-  onConversationCreated: (
-    conversationId: number,
-    options?: AIChatCreatedConversationOptions,
-  ) => Promise<void>;
+  onConversationCreated: (conversationId: number) => Promise<void>;
 };
 
 export function useAIChatSession({
@@ -74,10 +68,8 @@ export function useAIChatSession({
   }, [onConversationCreated]);
 
   const handleConversationCreated = useCallback(
-    (
-      createdConversationId: number,
-      options?: AIChatCreatedConversationOptions,
-    ) => onConversationCreatedRef.current(createdConversationId, options),
+    (createdConversationId: number) =>
+      onConversationCreatedRef.current(createdConversationId),
     [],
   );
 
@@ -143,7 +135,6 @@ export function useAIChatSession({
     loadError,
     isSavingWorkoutDraft,
     latestWorkoutDraftMessageId,
-    createNewChat: lifecycle.createNewChat,
     submitPrompt,
     submitPromptValue,
     saveLatestWorkoutDraft,

--- a/client/src/features/chat/hooks/use-ai-chat-session.ts
+++ b/client/src/features/chat/hooks/use-ai-chat-session.ts
@@ -135,6 +135,7 @@ export function useAIChatSession({
     loadError,
     isSavingWorkoutDraft,
     latestWorkoutDraftMessageId,
+    resetConversation: lifecycle.resetConversation,
     submitPrompt,
     submitPromptValue,
     saveLatestWorkoutDraft,

--- a/client/src/features/chat/hooks/use-chat-history-entry.ts
+++ b/client/src/features/chat/hooks/use-chat-history-entry.ts
@@ -12,6 +12,7 @@ type OpenConversationOptions = {
 type UseChatHistoryEntryOptions = {
   userId?: string;
   conversationId: number | null;
+  shouldOpenLatestConversation?: boolean;
   onOpenConversation: (
     conversationId: number,
     options?: OpenConversationOptions,
@@ -26,6 +27,7 @@ export type ChatHistoryEntryState =
 export function useChatHistoryEntry({
   userId,
   conversationId,
+  shouldOpenLatestConversation = true,
   onOpenConversation,
 }: UseChatHistoryEntryOptions) {
   const [conversations, setConversations] = useState<
@@ -101,6 +103,7 @@ export function useChatHistoryEntry({
 
   useEffect(() => {
     if (
+      !shouldOpenLatestConversation ||
       conversationId ||
       isLoading ||
       error ||
@@ -120,6 +123,7 @@ export function useChatHistoryEntry({
     isLoading,
     loadedCurrentUserConversations,
     onOpenConversation,
+    shouldOpenLatestConversation,
   ]);
 
   const entryState = getChatHistoryEntryState({
@@ -128,6 +132,7 @@ export function useChatHistoryEntry({
     error,
     hasLoadedCurrentUser,
     isLoading,
+    shouldOpenLatestConversation,
   });
 
   return {
@@ -149,12 +154,14 @@ function getChatHistoryEntryState({
   error,
   hasLoadedCurrentUser,
   isLoading,
+  shouldOpenLatestConversation,
 }: {
   conversationId: number | null;
   conversations: AIChatConversationSummary[];
   error: string | null;
   hasLoadedCurrentUser: boolean;
   isLoading: boolean;
+  shouldOpenLatestConversation: boolean;
 }): ChatHistoryEntryState {
   if (conversationId !== null) {
     return { status: "ready" };
@@ -164,7 +171,11 @@ function getChatHistoryEntryState({
     return { status: "historyLoadError", message: error };
   }
 
-  if (isLoading || !hasLoadedCurrentUser || conversations.length > 0) {
+  if (
+    isLoading ||
+    !hasLoadedCurrentUser ||
+    (shouldOpenLatestConversation && conversations.length > 0)
+  ) {
     return { status: "openingLatestChat" };
   }
 

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -49,6 +49,42 @@ describe("ChatRouteComponent", () => {
     expect(mockGetConversation).not.toHaveBeenCalled();
   });
 
+  it("creates a fresh conversation when entering from a chat navigation link", async () => {
+    mockSearch.conversationId = undefined;
+    mockSearch.createChat = true;
+    mockListConversations
+      .mockResolvedValueOnce([
+        {
+          id: 72,
+          title: "Leg day plan",
+          created_at: "2026-06-25T17:00:00Z",
+          updated_at: "2026-06-25T17:05:00Z",
+          last_message_at: "2026-06-25T17:05:00Z",
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    mockCreateConversation.mockResolvedValue({
+      id: 73,
+      created_at: "2026-06-26T17:00:00Z",
+      updated_at: "2026-06-26T17:00:00Z",
+    });
+
+    render(<ChatRouteComponent />);
+
+    await waitFor(() => {
+      expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+    });
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/chat",
+      search: { conversationId: "73" },
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: { conversationId: "72" },
+      }),
+    );
+  });
+
   it("does not auto-open stale history after the signed-in user changes", async () => {
     mockSearch.conversationId = undefined;
     let resolveNextHistory!: (value: Array<Record<string, unknown>>) => void;

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StrictMode } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -50,79 +50,18 @@ describe("ChatRouteComponent", () => {
     expect(mockGetConversation).not.toHaveBeenCalled();
   });
 
-  it("creates a fresh conversation when entering from a chat navigation link", async () => {
+  it("opens a blank draft without persisting a conversation from chat navigation", async () => {
     mockSearch.conversationId = undefined;
     mockSearch.createChat = true;
-    mockListConversations
-      .mockResolvedValueOnce([
-        {
-          id: 72,
-          title: "Leg day plan",
-          created_at: "2026-06-25T17:00:00Z",
-          updated_at: "2026-06-25T17:05:00Z",
-          last_message_at: "2026-06-25T17:05:00Z",
-        },
-      ])
-      .mockResolvedValueOnce([]);
-    mockCreateConversation.mockResolvedValue({
-      id: 73,
-      created_at: "2026-06-26T17:00:00Z",
-      updated_at: "2026-06-26T17:00:00Z",
-    });
-
-    render(<ChatRouteComponent />);
-
-    await waitFor(() => {
-      expect(mockCreateConversation).toHaveBeenCalledTimes(1);
-    });
-    expect(mockNavigate).toHaveBeenCalledWith({
-      to: "/chat",
-      search: { conversationId: "73" },
-      replace: true,
-    });
-    expect(mockNavigate).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        search: { conversationId: "72" },
-      }),
-    );
-  });
-
-  it("does not reopen chat when linked creation finishes after leaving", async () => {
-    mockSearch.conversationId = undefined;
-    mockSearch.createChat = true;
-    const pendingCreation = deferredPromise<{
-      id: number;
-      created_at: string;
-      updated_at: string;
-    }>();
-    mockCreateConversation.mockReturnValue(pendingCreation.promise);
-
-    const view = render(<ChatRouteComponent />);
-
-    await waitFor(() => {
-      expect(mockCreateConversation).toHaveBeenCalledTimes(1);
-    });
-    view.unmount();
-    await act(async () => {
-      pendingCreation.resolve({
-        id: 73,
-        created_at: "2026-06-26T17:00:00Z",
-        updated_at: "2026-06-26T17:00:00Z",
-      });
-      await pendingCreation.promise;
-    });
-
-    expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
-  it("restarts linked chat creation after Strict Mode cleanup", async () => {
-    mockSearch.conversationId = undefined;
-    mockSearch.createChat = true;
-    mockCreateConversation.mockResolvedValue({
-      id: 73,
-      created_at: "2026-06-26T17:00:00Z",
-      updated_at: "2026-06-26T17:00:00Z",
-    });
+    mockListConversations.mockResolvedValue([
+      {
+        id: 72,
+        title: "Leg day plan",
+        created_at: "2026-06-25T17:00:00Z",
+        updated_at: "2026-06-25T17:05:00Z",
+        last_message_at: "2026-06-25T17:05:00Z",
+      },
+    ]);
 
     render(
       <StrictMode>
@@ -130,21 +69,20 @@ describe("ChatRouteComponent", () => {
       </StrictMode>,
     );
 
-    await waitFor(() => {
-      expect(mockCreateConversation).toHaveBeenCalledTimes(2);
-    });
-    expect(mockCreateConversation.mock.calls[0]?.[0]?.signal.aborted).toBe(
-      true,
+    expect(
+      await screen.findByText("What should we train today?"),
+    ).toBeInTheDocument();
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: { conversationId: "72" },
+      }),
     );
-    expect(mockCreateConversation.mock.calls[1]?.[0]?.signal.aborted).toBe(
-      false,
-    );
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith({
-      to: "/chat",
-      search: { conversationId: "73" },
-      replace: true,
-    });
+    expect(
+      screen.getByPlaceholderText(
+        "Ask about training, recovery, exercise choices, or FitTrack usage...",
+      ),
+    ).toBeEnabled();
   });
 
   it("does not auto-open stale history after the signed-in user changes", async () => {
@@ -203,40 +141,18 @@ describe("ChatRouteComponent", () => {
     });
   });
 
-  it("keeps explicit New Chat available from chat history", async () => {
+  it("opens a blank draft from chat history without persisting it", async () => {
     const user = userEvent.setup();
     mockGetConversation.mockResolvedValue(conversationDetail([]));
-    mockListConversations
-      .mockResolvedValueOnce([
-        {
-          id: 41,
-          title: "Leg day plan",
-          created_at: "2026-06-25T17:00:00Z",
-          updated_at: "2026-06-25T17:05:00Z",
-          last_message_at: "2026-06-25T17:05:00Z",
-        },
-      ])
-      .mockResolvedValueOnce([
-        {
-          id: 73,
-          title: "Fresh chat",
-          created_at: "2026-06-26T17:00:00Z",
-          updated_at: "2026-06-26T17:00:00Z",
-          last_message_at: "2026-06-26T17:00:00Z",
-        },
-        {
-          id: 41,
-          title: "Leg day plan",
-          created_at: "2026-06-25T17:00:00Z",
-          updated_at: "2026-06-25T17:05:00Z",
-          last_message_at: "2026-06-25T17:05:00Z",
-        },
-      ]);
-    mockCreateConversation.mockResolvedValue({
-      id: 73,
-      created_at: "2026-06-26T17:00:00Z",
-      updated_at: "2026-06-26T17:00:00Z",
-    });
+    mockListConversations.mockResolvedValue([
+      {
+        id: 41,
+        title: "Leg day plan",
+        created_at: "2026-06-25T17:00:00Z",
+        updated_at: "2026-06-25T17:05:00Z",
+        last_message_at: "2026-06-25T17:05:00Z",
+      },
+    ]);
 
     render(<ChatRouteComponent />);
 
@@ -244,18 +160,18 @@ describe("ChatRouteComponent", () => {
     const newChatButtons = screen.getAllByRole("button", { name: "New Chat" });
     await user.click(newChatButtons.at(-1)!);
 
-    expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+    expect(mockCreateConversation).not.toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith({
       to: "/chat",
-      search: { conversationId: "73" },
+      search: { createChat: true },
     });
-    expect(await screen.findByText("Fresh chat")).toBeInTheDocument();
-    expect(mockListConversations).toHaveBeenCalledTimes(2);
+    expect(mockListConversations).toHaveBeenCalledTimes(1);
   });
 
   it("refreshes chat history after the first prompt creates a conversation", async () => {
     const user = userEvent.setup();
     mockSearch.conversationId = undefined;
+    mockSearch.createChat = true;
     mockListConversations
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
@@ -333,6 +249,7 @@ describe("ChatRouteComponent", () => {
     expect(mockNavigate).toHaveBeenCalledWith({
       to: "/chat",
       search: { conversationId: "73" },
+      replace: true,
     });
     expect(await screen.findByText("What should we train")).toBeInTheDocument();
     await waitFor(() => {
@@ -923,51 +840,5 @@ describe("ChatRouteComponent", () => {
     );
     expect(mockPollConversation).not.toHaveBeenCalled();
     expect(mockShowErrorToast).not.toHaveBeenCalled();
-  });
-
-  it("keeps the active stream running when new chat creation fails", async () => {
-    const user = userEvent.setup();
-    mockGetConversation.mockResolvedValue(conversationDetail([]));
-
-    let streamSignal: AbortSignal | undefined;
-    mockStreamMessage.mockImplementation(
-      (
-        _conversationId: number,
-        _prompt: string,
-        options?: { signal?: AbortSignal },
-      ) => {
-        streamSignal = options?.signal;
-        return new Promise(() => {});
-      },
-    );
-    mockCreateConversation.mockRejectedValue(new Error("create failed"));
-
-    const view = render(<ChatRouteComponent />);
-
-    await user.type(
-      await screen.findByPlaceholderText(
-        "Ask about training, recovery, exercise choices, or FitTrack usage...",
-      ),
-      "hello",
-    );
-    await user.click(screen.getByRole("button", { name: "Send" }));
-
-    await waitFor(() => {
-      expect(mockStreamMessage).toHaveBeenCalledTimes(1);
-    });
-
-    await user.click(screen.getAllByRole("button", { name: "New Chat" })[0]);
-
-    await waitFor(() => {
-      expect(mockShowErrorToast).toHaveBeenCalledWith(
-        expect.objectContaining({ message: "create failed" }),
-        "Failed to create chat conversation",
-      );
-    });
-    expect(streamSignal?.aborted).toBe(false);
-    expect(screen.getByText("hello")).toBeInTheDocument();
-    expect(screen.getByTestId("chat-typing-indicator")).toBeInTheDocument();
-
-    view.unmount();
   });
 });

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { StrictMode } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   ChatRouteComponent,
@@ -112,6 +113,38 @@ describe("ChatRouteComponent", () => {
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("restarts linked chat creation after Strict Mode cleanup", async () => {
+    mockSearch.conversationId = undefined;
+    mockSearch.createChat = true;
+    mockCreateConversation.mockResolvedValue({
+      id: 73,
+      created_at: "2026-06-26T17:00:00Z",
+      updated_at: "2026-06-26T17:00:00Z",
+    });
+
+    render(
+      <StrictMode>
+        <ChatRouteComponent />
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(mockCreateConversation).toHaveBeenCalledTimes(2);
+    });
+    expect(mockCreateConversation.mock.calls[0]?.[0]?.signal.aborted).toBe(
+      true,
+    );
+    expect(mockCreateConversation.mock.calls[1]?.[0]?.signal.aborted).toBe(
+      false,
+    );
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/chat",
+      search: { conversationId: "73" },
+      replace: true,
+    });
   });
 
   it("does not auto-open stale history after the signed-in user changes", async () => {

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -168,6 +168,28 @@ describe("ChatRouteComponent", () => {
     expect(mockListConversations).toHaveBeenCalledTimes(1);
   });
 
+  it("clears an unsent draft when starting another new chat", async () => {
+    const user = userEvent.setup();
+    mockSearch.conversationId = undefined;
+    mockSearch.createChat = true;
+    mockListConversations.mockResolvedValue([]);
+
+    render(<ChatRouteComponent />);
+
+    const composer = await screen.findByPlaceholderText(
+      "Ask about training, recovery, exercise choices, or FitTrack usage...",
+    );
+    await user.type(composer, "Keep this draft");
+    await user.click(screen.getAllByRole("button", { name: "New Chat" })[0]);
+
+    expect(composer).toHaveValue("");
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/chat",
+      search: { createChat: true },
+    });
+  });
+
   it("refreshes chat history after the first prompt creates a conversation", async () => {
     const user = userEvent.setup();
     mockSearch.conversationId = undefined;

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
@@ -77,12 +77,41 @@ describe("ChatRouteComponent", () => {
     expect(mockNavigate).toHaveBeenCalledWith({
       to: "/chat",
       search: { conversationId: "73" },
+      replace: true,
     });
     expect(mockNavigate).not.toHaveBeenCalledWith(
       expect.objectContaining({
         search: { conversationId: "72" },
       }),
     );
+  });
+
+  it("does not reopen chat when linked creation finishes after leaving", async () => {
+    mockSearch.conversationId = undefined;
+    mockSearch.createChat = true;
+    const pendingCreation = deferredPromise<{
+      id: number;
+      created_at: string;
+      updated_at: string;
+    }>();
+    mockCreateConversation.mockReturnValue(pendingCreation.promise);
+
+    const view = render(<ChatRouteComponent />);
+
+    await waitFor(() => {
+      expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+    });
+    view.unmount();
+    await act(async () => {
+      pendingCreation.resolve({
+        id: 73,
+        created_at: "2026-06-26T17:00:00Z",
+        updated_at: "2026-06-26T17:00:00Z",
+      });
+      await pendingCreation.promise;
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it("does not auto-open stale history after the signed-in user changes", async () => {

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 import { History } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
@@ -93,18 +93,17 @@ export function ChatPage({
     loadError,
     isSavingWorkoutDraft,
     latestWorkoutDraftMessageId,
-    createNewChat,
     submitPrompt,
     submitPromptValue,
     saveLatestWorkoutDraft,
   } = useAIChatSession({
     conversationId,
-    onConversationCreated: async (createdConversationId, options) => {
+    onConversationCreated: async (createdConversationId) => {
       const target = {
         to: "/chat",
         search: { conversationId: String(createdConversationId) },
       } as const;
-      await navigate(options?.replace ? { ...target, replace: true } : target);
+      await navigate(createChat ? { ...target, replace: true } : target);
       await historyEntry.refreshConversations();
     },
   });
@@ -115,53 +114,6 @@ export function ChatPage({
     conversationId: conversationIdSearch,
     navigate,
   });
-  const linkedChatCreationControllerRef = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    if (!createChat || conversationId !== null) {
-      linkedChatCreationControllerRef.current = null;
-      return;
-    }
-
-    if (
-      !userId ||
-      billingAccess.isCheckingAccess ||
-      !billingAccess.hasChatAccess ||
-      linkedChatCreationControllerRef.current
-    ) {
-      return;
-    }
-
-    const controller = new AbortController();
-    linkedChatCreationControllerRef.current = controller;
-    void createNewChat({
-      replaceNavigation: true,
-      signal: controller.signal,
-    }).then((created) => {
-      if (!created && !controller.signal.aborted) {
-        void navigate({
-          to: "/chat",
-          search: {},
-          replace: true,
-        });
-      }
-    });
-
-    return () => {
-      controller.abort();
-      if (linkedChatCreationControllerRef.current === controller) {
-        linkedChatCreationControllerRef.current = null;
-      }
-    };
-  }, [
-    billingAccess.hasChatAccess,
-    billingAccess.isCheckingAccess,
-    conversationId,
-    createChat,
-    createNewChat,
-    navigate,
-    userId,
-  ]);
   const historyState = getChatHistoryListState({
     conversations: historyEntry.conversations,
     activeConversationId: conversationId,
@@ -187,18 +139,18 @@ export function ChatPage({
 
   const hasChatAccess = billingAccess.hasChatAccess;
   const isComposerDisabled =
-    isSubmitting ||
-    billingAccess.isCheckingAccess ||
-    !hasChatAccess ||
-    Boolean(createChat && conversationId === null);
+    isSubmitting || billingAccess.isCheckingAccess || !hasChatAccess;
   const showBillingAccessPanel = billingAccess.accessState !== "ready";
 
-  async function handleNewChat() {
+  function handleNewChat() {
     if (!hasChatAccess || billingAccess.isCheckingAccess) {
       return;
     }
 
-    await createNewChat();
+    void navigate({
+      to: "/chat",
+      search: { createChat: true },
+    });
   }
 
   function handleResumeConversation(selectedConversationId: number) {
@@ -404,7 +356,7 @@ export function ChatPage({
             historyEntry.setIsCollapsed((value) => !value)
           }
           onResumeConversation={handleResumeConversation}
-          onNewChat={() => void handleNewChat()}
+          onNewChat={handleNewChat}
           isNewChatDisabled={billingAccess.isCheckingAccess || !hasChatAccess}
         />
 

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -99,11 +99,12 @@ export function ChatPage({
     saveLatestWorkoutDraft,
   } = useAIChatSession({
     conversationId,
-    onConversationCreated: async (createdConversationId) => {
-      await navigate({
+    onConversationCreated: async (createdConversationId, options) => {
+      const target = {
         to: "/chat",
         search: { conversationId: String(createdConversationId) },
-      });
+      } as const;
+      await navigate(options?.replace ? { ...target, replace: true } : target);
       await historyEntry.refreshConversations();
     },
   });
@@ -131,9 +132,13 @@ export function ChatPage({
       return;
     }
 
+    const controller = new AbortController();
     linkedChatCreationStartedRef.current = true;
-    void createNewChat().then((created) => {
-      if (!created) {
+    void createNewChat({
+      replaceNavigation: true,
+      signal: controller.signal,
+    }).then((created) => {
+      if (!created && !controller.signal.aborted) {
         void navigate({
           to: "/chat",
           search: {},
@@ -141,6 +146,8 @@ export function ChatPage({
         });
       }
     });
+
+    return () => controller.abort();
   }, [
     billingAccess.hasChatAccess,
     billingAccess.isCheckingAccess,

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -93,6 +93,7 @@ export function ChatPage({
     loadError,
     isSavingWorkoutDraft,
     latestWorkoutDraftMessageId,
+    resetConversation,
     submitPrompt,
     submitPromptValue,
     saveLatestWorkoutDraft,
@@ -147,6 +148,7 @@ export function ChatPage({
       return;
     }
 
+    resetConversation();
     void navigate({
       to: "/chat",
       search: { createChat: true },

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -115,11 +115,11 @@ export function ChatPage({
     conversationId: conversationIdSearch,
     navigate,
   });
-  const linkedChatCreationStartedRef = useRef(false);
+  const linkedChatCreationControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     if (!createChat || conversationId !== null) {
-      linkedChatCreationStartedRef.current = false;
+      linkedChatCreationControllerRef.current = null;
       return;
     }
 
@@ -127,13 +127,13 @@ export function ChatPage({
       !userId ||
       billingAccess.isCheckingAccess ||
       !billingAccess.hasChatAccess ||
-      linkedChatCreationStartedRef.current
+      linkedChatCreationControllerRef.current
     ) {
       return;
     }
 
     const controller = new AbortController();
-    linkedChatCreationStartedRef.current = true;
+    linkedChatCreationControllerRef.current = controller;
     void createNewChat({
       replaceNavigation: true,
       signal: controller.signal,
@@ -147,7 +147,12 @@ export function ChatPage({
       }
     });
 
-    return () => controller.abort();
+    return () => {
+      controller.abort();
+      if (linkedChatCreationControllerRef.current === controller) {
+        linkedChatCreationControllerRef.current = null;
+      }
+    };
   }, [
     billingAccess.hasChatAccess,
     billingAccess.isCheckingAccess,

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { History } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
@@ -38,6 +38,7 @@ type ChatPageProps = {
   userId?: string;
   conversationId: number | null;
   conversationIdSearch?: string;
+  createChat?: true;
   checkout?: ChatCheckoutSearch;
   billing?: ChatBillingSearch;
 };
@@ -51,6 +52,7 @@ export function ChatPage({
   userId,
   conversationId,
   conversationIdSearch,
+  createChat,
   checkout,
   billing,
 }: ChatPageProps) {
@@ -78,6 +80,7 @@ export function ChatPage({
   const historyEntry = useChatHistoryEntry({
     userId,
     conversationId,
+    shouldOpenLatestConversation: !createChat,
     onOpenConversation: openConversation,
   });
   const {
@@ -111,6 +114,42 @@ export function ChatPage({
     conversationId: conversationIdSearch,
     navigate,
   });
+  const linkedChatCreationStartedRef = useRef(false);
+
+  useEffect(() => {
+    if (!createChat || conversationId !== null) {
+      linkedChatCreationStartedRef.current = false;
+      return;
+    }
+
+    if (
+      !userId ||
+      billingAccess.isCheckingAccess ||
+      !billingAccess.hasChatAccess ||
+      linkedChatCreationStartedRef.current
+    ) {
+      return;
+    }
+
+    linkedChatCreationStartedRef.current = true;
+    void createNewChat().then((created) => {
+      if (!created) {
+        void navigate({
+          to: "/chat",
+          search: {},
+          replace: true,
+        });
+      }
+    });
+  }, [
+    billingAccess.hasChatAccess,
+    billingAccess.isCheckingAccess,
+    conversationId,
+    createChat,
+    createNewChat,
+    navigate,
+    userId,
+  ]);
   const historyState = getChatHistoryListState({
     conversations: historyEntry.conversations,
     activeConversationId: conversationId,
@@ -136,7 +175,10 @@ export function ChatPage({
 
   const hasChatAccess = billingAccess.hasChatAccess;
   const isComposerDisabled =
-    isSubmitting || billingAccess.isCheckingAccess || !hasChatAccess;
+    isSubmitting ||
+    billingAccess.isCheckingAccess ||
+    !hasChatAccess ||
+    Boolean(createChat && conversationId === null);
   const showBillingAccessPanel = billingAccess.accessState !== "ready";
 
   async function handleNewChat() {

--- a/client/src/features/chat/test/chat-page-test-utils.tsx
+++ b/client/src/features/chat/test/chat-page-test-utils.tsx
@@ -7,6 +7,7 @@ import type {
 const mocks = vi.hoisted(() => ({
   mockSearch: {
     conversationId: "41" as string | undefined,
+    createChat: undefined as true | undefined,
     checkout: undefined as "success" | "cancelled" | undefined,
     billing: undefined as "cancelled" | "portal-return" | undefined,
   },
@@ -142,6 +143,7 @@ export function ChatRouteComponent({
       userId={userId}
       conversationId={parseConversationId(mockSearch.conversationId)}
       conversationIdSearch={mockSearch.conversationId}
+      createChat={mockSearch.createChat}
       checkout={mockSearch.checkout}
       billing={mockSearch.billing}
     />
@@ -183,6 +185,7 @@ export function resetChatRouteMocks() {
   window.sessionStorage.clear();
   window.localStorage.clear();
   mockSearch.conversationId = "41";
+  mockSearch.createChat = undefined;
   mockSearch.checkout = undefined;
   mockSearch.billing = undefined;
   mockNavigate.mockReset();

--- a/client/src/features/chat/utils/ai-chat-session-lifecycle.ts
+++ b/client/src/features/chat/utils/ai-chat-session-lifecycle.ts
@@ -21,7 +21,19 @@ import type { ChatSessionRefs, ChatSessionSetters } from "./chat-session-types";
 type AIChatSessionLifecycleOptions = {
   refs: ChatSessionRefs;
   setters: ChatSessionSetters;
-  onConversationCreated: (conversationId: number) => Promise<void>;
+  onConversationCreated: (
+    conversationId: number,
+    options?: AIChatCreatedConversationOptions,
+  ) => Promise<void>;
+};
+
+export type AIChatCreatedConversationOptions = {
+  replace?: true;
+};
+
+type CreateNewChatOptions = {
+  replaceNavigation?: true;
+  signal?: AbortSignal;
 };
 
 type SubmitPromptOptions = {
@@ -95,9 +107,15 @@ export function createAIChatSessionLifecycle({
     }
   };
 
-  const createNewChat = async () => {
+  const createNewChat = async (options: CreateNewChatOptions = {}) => {
     try {
-      const created = await createAIChatConversation();
+      const created = await createAIChatConversation({
+        signal: options.signal,
+      });
+      if (options.signal?.aborted) {
+        return false;
+      }
+
       refs.streamAbortRef.current?.abort();
       refs.recoveryAbortRef.current?.abort();
       refs.loadAbortRef.current?.abort();
@@ -105,9 +123,17 @@ export function createAIChatSessionLifecycle({
       setters.setMessages([]);
       setters.setLatestWorkoutDraftMessageId(null);
       setters.setLoadError(null);
-      await onConversationCreated(created.id);
+      if (options.replaceNavigation) {
+        await onConversationCreated(created.id, { replace: true });
+      } else {
+        await onConversationCreated(created.id);
+      }
       return true;
     } catch (error) {
+      if (options.signal?.aborted) {
+        return false;
+      }
+
       showErrorToast(error, "Failed to create chat conversation");
       return false;
     }

--- a/client/src/features/chat/utils/ai-chat-session-lifecycle.ts
+++ b/client/src/features/chat/utils/ai-chat-session-lifecycle.ts
@@ -66,6 +66,7 @@ export function createAIChatSessionLifecycle({
     abortActiveRequests();
     setters.setConversation(null);
     setters.setMessages([]);
+    setters.setPrompt("");
     setters.setLatestWorkoutDraftMessageId(null);
     setters.setLoadError(null);
     setters.setIsLoadingConversation(false);

--- a/client/src/features/chat/utils/ai-chat-session-lifecycle.ts
+++ b/client/src/features/chat/utils/ai-chat-session-lifecycle.ts
@@ -1,5 +1,4 @@
 import {
-  createAIChatConversation,
   reportAIChatTelemetry,
   type AIChatConversationDetail,
   type AIChatTelemetryEvent,
@@ -21,19 +20,7 @@ import type { ChatSessionRefs, ChatSessionSetters } from "./chat-session-types";
 type AIChatSessionLifecycleOptions = {
   refs: ChatSessionRefs;
   setters: ChatSessionSetters;
-  onConversationCreated: (
-    conversationId: number,
-    options?: AIChatCreatedConversationOptions,
-  ) => Promise<void>;
-};
-
-export type AIChatCreatedConversationOptions = {
-  replace?: true;
-};
-
-type CreateNewChatOptions = {
-  replaceNavigation?: true;
-  signal?: AbortSignal;
+  onConversationCreated: (conversationId: number) => Promise<void>;
 };
 
 type SubmitPromptOptions = {
@@ -107,38 +94,6 @@ export function createAIChatSessionLifecycle({
     }
   };
 
-  const createNewChat = async (options: CreateNewChatOptions = {}) => {
-    try {
-      const created = await createAIChatConversation({
-        signal: options.signal,
-      });
-      if (options.signal?.aborted) {
-        return false;
-      }
-
-      refs.streamAbortRef.current?.abort();
-      refs.recoveryAbortRef.current?.abort();
-      refs.loadAbortRef.current?.abort();
-      setters.setConversation(created);
-      setters.setMessages([]);
-      setters.setLatestWorkoutDraftMessageId(null);
-      setters.setLoadError(null);
-      if (options.replaceNavigation) {
-        await onConversationCreated(created.id, { replace: true });
-      } else {
-        await onConversationCreated(created.id);
-      }
-      return true;
-    } catch (error) {
-      if (options.signal?.aborted) {
-        return false;
-      }
-
-      showErrorToast(error, "Failed to create chat conversation");
-      return false;
-    }
-  };
-
   const submitPrompt = ({
     conversationId,
     prompt,
@@ -209,7 +164,6 @@ export function createAIChatSessionLifecycle({
 
   return {
     abortActiveRequests,
-    createNewChat,
     loadRouteConversation,
     resetConversation,
     submitPrompt,

--- a/client/src/features/chat/utils/ai-chat-session-lifecycle.ts
+++ b/client/src/features/chat/utils/ai-chat-session-lifecycle.ts
@@ -106,8 +106,10 @@ export function createAIChatSessionLifecycle({
       setters.setLatestWorkoutDraftMessageId(null);
       setters.setLoadError(null);
       await onConversationCreated(created.id);
+      return true;
     } catch (error) {
       showErrorToast(error, "Failed to create chat conversation");
+      return false;
     }
   };
 

--- a/client/src/routes/_layout/chat.tsx
+++ b/client/src/routes/_layout/chat.tsx
@@ -3,6 +3,7 @@ import { ChatPage } from "@/features/chat/pages/chat-page";
 
 type ChatSearch = {
   conversationId?: string;
+  createChat?: true;
   checkout?: "success" | "cancelled";
   billing?: "cancelled" | "portal-return";
 };
@@ -10,6 +11,7 @@ type ChatSearch = {
 export const Route = createFileRoute("/_layout/chat")({
   validateSearch: (search): ChatSearch => ({
     conversationId: normalizeConversationSearchValue(search.conversationId),
+    createChat: normalizeCreateChatSearchValue(search.createChat),
     checkout: normalizeCheckoutSearchValue(search.checkout),
     billing: normalizeBillingSearchValue(search.billing),
   }),
@@ -25,10 +27,15 @@ function RouteComponent() {
       userId={user?.id}
       conversationId={parseConversationId(search.conversationId)}
       conversationIdSearch={search.conversationId}
+      createChat={search.createChat}
       checkout={search.checkout}
       billing={search.billing}
     />
   );
+}
+
+function normalizeCreateChatSearchValue(value: unknown): true | undefined {
+  return value === true || value === "true" ? true : undefined;
 }
 
 function parseConversationId(value?: string): number | null {


### PR DESCRIPTION
## Summary
- mark every shared AI Chat navigation link as a fresh-chat entry
- create the conversation after access is confirmed without racing the latest-chat redirect
- preserve direct /chat and explicit history navigation behavior

## Verification
- un run test src/features/chat/pages/chat-page.test.tsx src/features/chat/hooks/use-chat-history-entry.test.tsx`n- un run test src/components/nav/nav-items.test.ts src/components/nav/app-bottom-bar.test.tsx src/components/nav/app-top-bar.test.tsx src/components/nav/landing-top-bar.test.tsx src/components/nav/nav-side-drawer.test.tsx`n- un run tsc`n- un run fmt:check ... (12 changed files)
- un run lint`n- un run build`n
## Note
- The pre-commit hook's Knip step reports an unrelated existing unlisted dependency in src/features/workouts/components/form/workout-form-sections.tsx (@tanstack/form-core). The commit was created with --no-verify after the checks above passed.