### PR TITLE
feat: preserve tab-local chat drafts

### DIFF
--- a/client/src/components/nav/nav-items.test.ts
+++ b/client/src/components/nav/nav-items.test.ts
@@ -9,7 +9,7 @@ describe("navItems", () => {
       { to: "/workouts", label: "Workouts", search: undefined },
       { to: "/exercises", label: "Exercises", search: undefined },
       { to: "/analytics", label: "Analytics", search: undefined },
-      { to: "/chat", label: "AI Chat", search: { createChat: true } },
+      { to: "/chat", label: "AI Chat", search: undefined },
     ]);
   });
 });

--- a/client/src/components/nav/nav-items.ts
+++ b/client/src/components/nav/nav-items.ts
@@ -13,6 +13,6 @@ export const navItems = [
     to: "/chat",
     label: "AI Chat",
     icon: Bot,
-    search: { createChat: true },
+    search: undefined,
   },
 ] as const;

--- a/client/src/features/chat/hooks/use-ai-chat-session.test.tsx
+++ b/client/src/features/chat/hooks/use-ai-chat-session.test.tsx
@@ -72,6 +72,10 @@ function renderSession(conversationId: number | null = 41) {
     ({ id }) =>
       useAIChatSession({
         conversationId: id,
+        initialPrompt: "",
+        onPromptChange: vi.fn(),
+        onPromptStarted: vi.fn(),
+        onNewConversationCreated: vi.fn(),
         onConversationCreated: vi.fn().mockResolvedValue(undefined),
       }),
     {

--- a/client/src/features/chat/hooks/use-ai-chat-session.ts
+++ b/client/src/features/chat/hooks/use-ai-chat-session.ts
@@ -44,14 +44,16 @@ export function useAIChatSession({
   const recoveryAbortRef = useRef<AbortController | null>(null);
   const resumeAbortRef = useRef<AbortController | null>(null);
   const streamAbortRef = useRef<AbortController | null>(null);
-  const onConversationCreatedRef = useRef(onConversationCreated);
-  const setPrompt = useCallback(
-    (value: string) => {
-      setPromptState(value);
-      onPromptChange(value);
-    },
-    [onPromptChange],
-  );
+  const callbacksRef = useRef({
+    onPromptChange,
+    onPromptStarted,
+    onNewConversationCreated,
+    onConversationCreated,
+  });
+  const setPrompt = useCallback((value: string) => {
+    setPromptState(value);
+    callbacksRef.current.onPromptChange(value);
+  }, []);
 
   const refs = useMemo<ChatSessionRefs>(
     () => ({
@@ -79,12 +81,34 @@ export function useAIChatSession({
   );
 
   useEffect(() => {
-    onConversationCreatedRef.current = onConversationCreated;
-  }, [onConversationCreated]);
+    callbacksRef.current = {
+      onPromptChange,
+      onPromptStarted,
+      onNewConversationCreated,
+      onConversationCreated,
+    };
+  }, [
+    onConversationCreated,
+    onNewConversationCreated,
+    onPromptChange,
+    onPromptStarted,
+  ]);
+
+  const handlePromptStarted = useCallback(
+    (conversationId: number) =>
+      callbacksRef.current.onPromptStarted(conversationId),
+    [],
+  );
+
+  const handleNewConversationCreated = useCallback(
+    (conversationId: number) =>
+      callbacksRef.current.onNewConversationCreated(conversationId),
+    [],
+  );
 
   const handleConversationCreated = useCallback(
     (createdConversationId: number) =>
-      onConversationCreatedRef.current(createdConversationId),
+      callbacksRef.current.onConversationCreated(createdConversationId),
     [],
   );
 
@@ -94,13 +118,13 @@ export function useAIChatSession({
         refs,
         setters,
         onConversationCreated: handleConversationCreated,
-        onPromptStarted,
-        onNewConversationCreated,
+        onPromptStarted: handlePromptStarted,
+        onNewConversationCreated: handleNewConversationCreated,
       }),
     [
       handleConversationCreated,
-      onNewConversationCreated,
-      onPromptStarted,
+      handleNewConversationCreated,
+      handlePromptStarted,
       refs,
       setters,
     ],

--- a/client/src/features/chat/hooks/use-ai-chat-session.ts
+++ b/client/src/features/chat/hooks/use-ai-chat-session.ts
@@ -12,18 +12,26 @@ import { saveLatestWorkoutDraft as saveLatestWorkoutDraftRequest } from "../util
 
 type UseAIChatSessionOptions = {
   conversationId: number | null;
+  initialPrompt: string;
+  onPromptChange: (prompt: string) => void;
+  onPromptStarted: (conversationId: number) => void;
+  onNewConversationCreated: (conversationId: number) => void;
   onConversationCreated: (conversationId: number) => Promise<void>;
 };
 
 export function useAIChatSession({
   conversationId,
+  initialPrompt,
+  onPromptChange,
+  onPromptStarted,
+  onNewConversationCreated,
   onConversationCreated,
 }: UseAIChatSessionOptions) {
   const [conversation, setConversation] = useState<AIChatConversation | null>(
     null,
   );
   const [messages, setMessages] = useState<AIChatMessage[]>([]);
-  const [prompt, setPrompt] = useState("");
+  const [prompt, setPromptState] = useState(initialPrompt);
   const [isLoadingConversation, setIsLoadingConversation] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -37,6 +45,13 @@ export function useAIChatSession({
   const resumeAbortRef = useRef<AbortController | null>(null);
   const streamAbortRef = useRef<AbortController | null>(null);
   const onConversationCreatedRef = useRef(onConversationCreated);
+  const setPrompt = useCallback(
+    (value: string) => {
+      setPromptState(value);
+      onPromptChange(value);
+    },
+    [onPromptChange],
+  );
 
   const refs = useMemo<ChatSessionRefs>(
     () => ({
@@ -53,7 +68,7 @@ export function useAIChatSession({
     () => ({
       setConversation,
       setMessages,
-      setPrompt,
+      setPrompt: setPromptState,
       setIsLoadingConversation,
       setIsSubmitting,
       setLoadError,
@@ -79,13 +94,22 @@ export function useAIChatSession({
         refs,
         setters,
         onConversationCreated: handleConversationCreated,
+        onPromptStarted,
+        onNewConversationCreated,
       }),
-    [handleConversationCreated, refs, setters],
+    [
+      handleConversationCreated,
+      onNewConversationCreated,
+      onPromptStarted,
+      refs,
+      setters,
+    ],
   );
 
   useEffect(() => {
+    setters.setPrompt(initialPrompt);
     if (!conversationId) {
-      lifecycle.resetConversation();
+      lifecycle.resetConversation(initialPrompt);
       return;
     }
 
@@ -94,7 +118,7 @@ export function useAIChatSession({
     return () => {
       lifecycle.abortActiveRequests();
     };
-  }, [conversationId, lifecycle]);
+  }, [conversationId, initialPrompt, lifecycle]);
 
   const submitPrompt = useCallback(
     () =>

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -2,11 +2,11 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StrictMode } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
-import { chatDraftStore } from "../utils/chat-draft-store";
 import {
   ChatRouteComponent,
   conversationDetail,
   deferredPromise,
+  getRenderedChatDraftStore,
   mockCreateConversation,
   mockGetConversation,
   mockListConversations,
@@ -140,6 +140,25 @@ describe("ChatRouteComponent", () => {
     );
   });
 
+  it("discards the previous account's draft when the signed-in user changes", async () => {
+    const user = userEvent.setup();
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+
+    const view = render(<ChatRouteComponent userId="user-123" />);
+    const promptBox = await screen.findByPlaceholderText(
+      "Ask about training, recovery, exercise choices, or FitTrack usage...",
+    );
+    await user.type(promptBox, "private draft");
+
+    view.rerender(<ChatRouteComponent userId="user-456" />);
+
+    expect(
+      await screen.findByPlaceholderText(
+        "Ask about training, recovery, exercise choices, or FitTrack usage...",
+      ),
+    ).toHaveValue("");
+  });
+
   it("opens a blank draft from chat history without persisting it", async () => {
     const user = userEvent.setup();
     mockGetConversation.mockResolvedValue(conversationDetail([]));
@@ -268,7 +287,10 @@ describe("ChatRouteComponent", () => {
 
     expect(mockCreateConversation).toHaveBeenCalledTimes(1);
     expect(
-      chatDraftStore.getDraft({ type: "conversation", conversationId: 73 }),
+      getRenderedChatDraftStore().getDraft({
+        type: "conversation",
+        conversationId: 73,
+      }),
     ).toBe("");
     expect(mockNavigate).toHaveBeenCalledWith({
       to: "/chat",
@@ -527,7 +549,10 @@ describe("ChatRouteComponent", () => {
       ),
     ).toHaveValue("hello");
     expect(
-      chatDraftStore.getDraft({ type: "conversation", conversationId: 41 }),
+      getRenderedChatDraftStore().getDraft({
+        type: "conversation",
+        conversationId: 41,
+      }),
     ).toBe("hello");
   });
 

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -479,6 +479,12 @@ describe("ChatRouteComponent", () => {
 
     expect(await screen.findByText("Recovered answer")).toBeInTheDocument();
     expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(
+      getRenderedChatDraftStore().getDraft({
+        type: "conversation",
+        conversationId: 41,
+      }),
+    ).toBe("");
     expect(mockPollConversation).toHaveBeenCalledWith(
       41,
       expect.objectContaining({
@@ -576,7 +582,11 @@ describe("ChatRouteComponent", () => {
     );
     await user.click(screen.getByRole("button", { name: "Send" }));
 
-    expect(await screen.findByText("hello")).toBeInTheDocument();
+    expect(
+      await screen.findByPlaceholderText(
+        "Ask about training, recovery, exercise choices, or FitTrack usage...",
+      ),
+    ).toHaveValue("hello");
     expect(
       await screen.findByText("ai chat recovery is not configured"),
     ).toBeInTheDocument();

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StrictMode } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
+import { chatDraftStore } from "../utils/chat-draft-store";
 import {
   ChatRouteComponent,
   conversationDetail,
@@ -22,7 +23,7 @@ import {
 describe("ChatRouteComponent", () => {
   beforeEach(resetChatRouteMocks);
 
-  it("opens the newest recent chat when entering without a conversation id", async () => {
+  it("opens blank New Chat when entering without an eligible draft", async () => {
     mockSearch.conversationId = undefined;
     mockListConversations.mockResolvedValue([
       {
@@ -40,13 +41,11 @@ describe("ChatRouteComponent", () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({
         to: "/chat",
-        search: { conversationId: "72" },
+        search: { createChat: true },
         replace: true,
       });
     });
-    expect(
-      screen.queryByText("What should we train today?"),
-    ).not.toBeInTheDocument();
+    expect(screen.getByText("What should we train today?")).toBeInTheDocument();
     expect(mockGetConversation).not.toHaveBeenCalled();
   });
 
@@ -110,7 +109,7 @@ describe("ChatRouteComponent", () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({
         to: "/chat",
-        search: { conversationId: "72" },
+        search: { createChat: true },
         replace: true,
       });
     });
@@ -119,7 +118,11 @@ describe("ChatRouteComponent", () => {
     view.rerender(<ChatRouteComponent userId="user-456" />);
 
     expect(screen.queryByText("Leg day plan")).not.toBeInTheDocument();
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/chat",
+      search: { createChat: true },
+      replace: true,
+    });
 
     resolveNextHistory([
       {
@@ -132,13 +135,9 @@ describe("ChatRouteComponent", () => {
     ]);
 
     expect(await screen.findByText("Back day plan")).toBeInTheDocument();
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith({
-        to: "/chat",
-        search: { conversationId: "88" },
-        replace: true,
-      });
-    });
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ search: { conversationId: "88" } }),
+    );
   });
 
   it("opens a blank draft from chat history without persisting it", async () => {
@@ -268,6 +267,9 @@ describe("ChatRouteComponent", () => {
     await user.click(screen.getByRole("button", { name: "Send" }));
 
     expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+    expect(
+      chatDraftStore.getDraft({ type: "conversation", conversationId: 73 }),
+    ).toBe("");
     expect(mockNavigate).toHaveBeenCalledWith({
       to: "/chat",
       search: { conversationId: "73" },
@@ -524,6 +526,9 @@ describe("ChatRouteComponent", () => {
         "Ask about training, recovery, exercise choices, or FitTrack usage...",
       ),
     ).toHaveValue("hello");
+    expect(
+      chatDraftStore.getDraft({ type: "conversation", conversationId: 41 }),
+    ).toBe("hello");
   });
 
   it("keeps the prompt visible and shows the recovery failure when submit recovery fails before stream start", async () => {

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -30,10 +30,8 @@ import {
 import { useAIChatBillingAccess } from "../hooks/use-ai-chat-billing-access";
 import { useAIChatSession } from "../hooks/use-ai-chat-session";
 import { useChatHistoryEntry } from "../hooks/use-chat-history-entry";
-import {
-  chatDraftStore,
-  type ChatDraftDestination,
-} from "../utils/chat-draft-store";
+import { useChatDraftStore } from "../utils/chat-draft-context";
+import { type ChatDraftDestination } from "../utils/chat-draft-store";
 
 type ChatCheckoutSearch = "success" | "cancelled";
 type ChatBillingSearch = "cancelled" | "portal-return";
@@ -60,8 +58,8 @@ export function ChatPage({
   checkout,
   billing,
 }: ChatPageProps) {
+  const chatDraftStore = useChatDraftStore();
   const navigate = useNavigate({ from: "/chat" });
-  chatDraftStore.setUser(userId);
   const draftDestination = useMemo<ChatDraftDestination>(
     () =>
       conversationId === null

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { History } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
@@ -30,6 +30,10 @@ import {
 import { useAIChatBillingAccess } from "../hooks/use-ai-chat-billing-access";
 import { useAIChatSession } from "../hooks/use-ai-chat-session";
 import { useChatHistoryEntry } from "../hooks/use-chat-history-entry";
+import {
+  chatDraftStore,
+  type ChatDraftDestination,
+} from "../utils/chat-draft-store";
 
 type ChatCheckoutSearch = "success" | "cancelled";
 type ChatBillingSearch = "cancelled" | "portal-return";
@@ -57,6 +61,31 @@ export function ChatPage({
   billing,
 }: ChatPageProps) {
   const navigate = useNavigate({ from: "/chat" });
+  chatDraftStore.setUser(userId);
+  const draftDestination = useMemo<ChatDraftDestination>(
+    () =>
+      conversationId === null
+        ? { type: "new" }
+        : { type: "conversation", conversationId },
+    [conversationId],
+  );
+  const initialPrompt = useMemo(
+    () => chatDraftStore.getDraft(draftDestination),
+    [draftDestination],
+  );
+  const handlePromptChange = useCallback(
+    (value: string) => chatDraftStore.setDraft(draftDestination, value),
+    [draftDestination],
+  );
+  const handlePromptStarted = useCallback((startedConversationId: number) => {
+    chatDraftStore.setDraft(
+      { type: "conversation", conversationId: startedConversationId },
+      "",
+    );
+  }, []);
+  const handleNewConversationCreated = useCallback((createdId: number) => {
+    chatDraftStore.migrateNewChatDraft(createdId);
+  }, []);
   const openConversation = useCallback(
     (
       selectedConversationId: number,
@@ -80,7 +109,7 @@ export function ChatPage({
   const historyEntry = useChatHistoryEntry({
     userId,
     conversationId,
-    shouldOpenLatestConversation: !createChat,
+    shouldOpenLatestConversation: false,
     onOpenConversation: openConversation,
   });
   const {
@@ -99,6 +128,10 @@ export function ChatPage({
     saveLatestWorkoutDraft,
   } = useAIChatSession({
     conversationId,
+    initialPrompt,
+    onPromptChange: handlePromptChange,
+    onPromptStarted: handlePromptStarted,
+    onNewConversationCreated: handleNewConversationCreated,
     onConversationCreated: async (createdConversationId) => {
       const target = {
         to: "/chat",
@@ -108,6 +141,16 @@ export function ChatPage({
       await historyEntry.refreshConversations();
     },
   });
+
+  useEffect(() => {
+    if (conversationId !== null || createChat || !userId) return;
+    const destination = chatDraftStore.resolveMainDestination();
+    if (destination.type === "conversation") {
+      openConversation(destination.conversationId, { replace: true });
+      return;
+    }
+    void navigate({ to: "/chat", search: { createChat: true }, replace: true });
+  }, [conversationId, createChat, navigate, openConversation, userId]);
   const billingAccess = useAIChatBillingAccess({
     userId,
     checkout,
@@ -148,7 +191,8 @@ export function ChatPage({
       return;
     }
 
-    resetConversation();
+    chatDraftStore.startNewChat();
+    resetConversation("");
     void navigate({
       to: "/chat",
       search: { createChat: true },
@@ -156,6 +200,7 @@ export function ChatPage({
   }
 
   function handleResumeConversation(selectedConversationId: number) {
+    chatDraftStore.openConversation(selectedConversationId);
     openConversation(selectedConversationId);
   }
 

--- a/client/src/features/chat/test/chat-page-test-utils.tsx
+++ b/client/src/features/chat/test/chat-page-test-utils.tsx
@@ -3,6 +3,7 @@ import type {
   AIWorkoutDraft,
   AIWorkoutDraftStatus,
 } from "@/features/chat/api/ai-chat";
+import { chatDraftStore } from "@/features/chat/utils/chat-draft-store";
 
 const mocks = vi.hoisted(() => ({
   mockSearch: {
@@ -182,6 +183,7 @@ export function deferredPromise<T>() {
 }
 
 export function resetChatRouteMocks() {
+  chatDraftStore.clear();
   window.sessionStorage.clear();
   window.localStorage.clear();
   mockSearch.conversationId = "41";

--- a/client/src/features/chat/test/chat-page-test-utils.tsx
+++ b/client/src/features/chat/test/chat-page-test-utils.tsx
@@ -1,9 +1,14 @@
+import { useEffect } from "react";
 import { vi } from "vitest";
 import type {
   AIWorkoutDraft,
   AIWorkoutDraftStatus,
 } from "@/features/chat/api/ai-chat";
-import { chatDraftStore } from "@/features/chat/utils/chat-draft-store";
+import {
+  ChatDraftProvider,
+  useChatDraftStore,
+} from "@/features/chat/utils/chat-draft-context";
+import type { ChatDraftStore } from "@/features/chat/utils/chat-draft-store";
 
 const mocks = vi.hoisted(() => ({
   mockSearch: {
@@ -134,20 +139,43 @@ vi.mock("sonner", () => ({
 
 const { ChatPage } = await import("@/features/chat/pages/chat-page");
 
+let renderedChatDraftStore: ChatDraftStore | null = null;
+
+function CaptureChatDraftStore() {
+  const store = useChatDraftStore();
+  useEffect(() => {
+    renderedChatDraftStore = store;
+    return () => {
+      if (renderedChatDraftStore === store) renderedChatDraftStore = null;
+    };
+  }, [store]);
+  return null;
+}
+
+export function getRenderedChatDraftStore() {
+  if (!renderedChatDraftStore) {
+    throw new Error("Chat draft store has not been rendered");
+  }
+  return renderedChatDraftStore;
+}
+
 export function ChatRouteComponent({
   userId = "user-123",
 }: {
   userId?: string;
 } = {}) {
   return (
-    <ChatPage
-      userId={userId}
-      conversationId={parseConversationId(mockSearch.conversationId)}
-      conversationIdSearch={mockSearch.conversationId}
-      createChat={mockSearch.createChat}
-      checkout={mockSearch.checkout}
-      billing={mockSearch.billing}
-    />
+    <ChatDraftProvider key={userId ?? "signed-out"}>
+      <CaptureChatDraftStore />
+      <ChatPage
+        userId={userId}
+        conversationId={parseConversationId(mockSearch.conversationId)}
+        conversationIdSearch={mockSearch.conversationId}
+        createChat={mockSearch.createChat}
+        checkout={mockSearch.checkout}
+        billing={mockSearch.billing}
+      />
+    </ChatDraftProvider>
   );
 }
 
@@ -183,7 +211,7 @@ export function deferredPromise<T>() {
 }
 
 export function resetChatRouteMocks() {
-  chatDraftStore.clear();
+  renderedChatDraftStore = null;
   window.sessionStorage.clear();
   window.localStorage.clear();
   mockSearch.conversationId = "41";

--- a/client/src/features/chat/utils/ai-chat-session-lifecycle.ts
+++ b/client/src/features/chat/utils/ai-chat-session-lifecycle.ts
@@ -21,6 +21,8 @@ type AIChatSessionLifecycleOptions = {
   refs: ChatSessionRefs;
   setters: ChatSessionSetters;
   onConversationCreated: (conversationId: number) => Promise<void>;
+  onPromptStarted: (conversationId: number) => void;
+  onNewConversationCreated: (conversationId: number) => void;
 };
 
 type SubmitPromptOptions = {
@@ -33,6 +35,8 @@ export function createAIChatSessionLifecycle({
   refs,
   setters,
   onConversationCreated,
+  onPromptStarted,
+  onNewConversationCreated,
 }: AIChatSessionLifecycleOptions) {
   const recordTelemetry = (event: AIChatTelemetryEvent) => {
     void Promise.resolve(reportAIChatTelemetry(event)).catch((error) => {
@@ -62,11 +66,11 @@ export function createAIChatSessionLifecycle({
     refs.streamAbortRef.current?.abort();
   };
 
-  const resetConversation = () => {
+  const resetConversation = (prompt = "") => {
     abortActiveRequests();
     setters.setConversation(null);
     setters.setMessages([]);
-    setters.setPrompt("");
+    setters.setPrompt(prompt);
     setters.setLatestWorkoutDraftMessageId(null);
     setters.setLoadError(null);
     setters.setIsLoadingConversation(false);
@@ -105,6 +109,8 @@ export function createAIChatSessionLifecycle({
       prompt,
       isSubmitting,
       onConversationCreated,
+      onPromptStarted,
+      onNewConversationCreated,
       loadConversation,
       recoverConversation,
       recordTelemetry,

--- a/client/src/features/chat/utils/chat-draft-context.tsx
+++ b/client/src/features/chat/utils/chat-draft-context.tsx
@@ -1,0 +1,20 @@
+import { createContext, type ReactNode, useContext, useState } from "react";
+import { ChatDraftStore } from "./chat-draft-store";
+
+const ChatDraftContext = createContext<ChatDraftStore | null>(null);
+
+export function ChatDraftProvider({ children }: { children: ReactNode }) {
+  const [store] = useState(() => new ChatDraftStore());
+
+  return <ChatDraftContext value={store}>{children}</ChatDraftContext>;
+}
+
+export function useChatDraftStore() {
+  const store = useContext(ChatDraftContext);
+  if (!store) {
+    throw new Error(
+      "useChatDraftStore must be used within a ChatDraftProvider",
+    );
+  }
+  return store;
+}

--- a/client/src/features/chat/utils/chat-draft-store.test.ts
+++ b/client/src/features/chat/utils/chat-draft-store.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { ChatDraftStore } from "./chat-draft-store";
+
+describe("ChatDraftStore", () => {
+  let store: ChatDraftStore;
+
+  beforeEach(() => {
+    store = new ChatDraftStore();
+    store.setUser("user-1");
+  });
+
+  it("keeps independent drafts and restores the most recently edited conversation", () => {
+    store.setDraft({ type: "conversation", conversationId: 1 }, "first");
+    store.setDraft({ type: "conversation", conversationId: 2 }, "second");
+
+    expect(store.getDraft({ type: "conversation", conversationId: 1 })).toBe(
+      "first",
+    );
+    expect(store.resolveMainDestination()).toEqual({
+      type: "conversation",
+      conversationId: 2,
+    });
+  });
+
+  it("deletes a draft as soon as its text is empty", () => {
+    const destination = { type: "conversation" as const, conversationId: 1 };
+    store.setDraft(destination, "draft");
+    store.setDraft(destination, "");
+    expect(store.getDraft(destination)).toBe("");
+    expect(store.resolveMainDestination()).toEqual({ type: "new" });
+  });
+
+  it("makes explicit New Chat blank and preferred without deleting conversation drafts", () => {
+    const conversation = { type: "conversation" as const, conversationId: 1 };
+    store.setDraft(conversation, "keep me");
+    store.setDraft({ type: "new" }, "discard me");
+    store.startNewChat();
+
+    expect(store.getDraft({ type: "new" })).toBe("");
+    expect(store.getDraft(conversation)).toBe("keep me");
+    expect(store.resolveMainDestination()).toEqual({ type: "new" });
+  });
+
+  it("cancels New Chat preference when a drafted conversation is explicitly opened", () => {
+    store.setDraft({ type: "conversation", conversationId: 4 }, "restore me");
+    store.startNewChat();
+    store.openConversation(4);
+    expect(store.resolveMainDestination()).toEqual({
+      type: "conversation",
+      conversationId: 4,
+    });
+  });
+
+  it("moves a New Chat draft to the created conversation", () => {
+    store.setDraft({ type: "new" }, "first prompt");
+    store.migrateNewChatDraft(9);
+    expect(store.getDraft({ type: "new" })).toBe("");
+    expect(store.getDraft({ type: "conversation", conversationId: 9 })).toBe(
+      "first prompt",
+    );
+  });
+
+  it("clears every draft on sign-out or account change", () => {
+    store.setDraft({ type: "conversation", conversationId: 1 }, "secret");
+    store.setUser(undefined);
+    store.setUser("user-2");
+    expect(store.getDraft({ type: "conversation", conversationId: 1 })).toBe(
+      "",
+    );
+  });
+
+  it("supports the isolated always-new-chat test policy", () => {
+    store.setDraft({ type: "conversation", conversationId: 1 }, "draft");
+    expect(store.resolveMainDestination("always-new-chat")).toEqual({
+      type: "new",
+    });
+  });
+});

--- a/client/src/features/chat/utils/chat-draft-store.test.ts
+++ b/client/src/features/chat/utils/chat-draft-store.test.ts
@@ -6,7 +6,6 @@ describe("ChatDraftStore", () => {
 
   beforeEach(() => {
     store = new ChatDraftStore();
-    store.setUser("user-1");
   });
 
   it("keeps independent drafts and restores the most recently edited conversation", () => {
@@ -60,10 +59,9 @@ describe("ChatDraftStore", () => {
     );
   });
 
-  it("clears every draft on sign-out or account change", () => {
+  it("clears every draft", () => {
     store.setDraft({ type: "conversation", conversationId: 1 }, "secret");
-    store.setUser(undefined);
-    store.setUser("user-2");
+    store.clear();
     expect(store.getDraft({ type: "conversation", conversationId: 1 })).toBe(
       "",
     );

--- a/client/src/features/chat/utils/chat-draft-store.ts
+++ b/client/src/features/chat/utils/chat-draft-store.ts
@@ -12,18 +12,10 @@ export const MAIN_CHAT_NAVIGATION_POLICY: MainChatNavigationPolicy =
 type Draft = { text: string; editedAt: number };
 
 export class ChatDraftStore {
-  private userId: string | null = null;
   private newChatDraft: Draft | null = null;
   private conversationDrafts = new Map<number, Draft>();
   private latestExplicitDestination: ChatDraftDestination | null = null;
   private editSequence = 0;
-
-  setUser(userId?: string) {
-    const nextUserId = userId ?? null;
-    if (this.userId === nextUserId) return;
-    this.clear();
-    this.userId = nextUserId;
-  }
 
   getDraft(destination: ChatDraftDestination): string {
     return this.getDraftRecord(destination)?.text ?? "";
@@ -94,5 +86,3 @@ export class ChatDraftStore {
       : (this.conversationDrafts.get(destination.conversationId) ?? null);
   }
 }
-
-export const chatDraftStore = new ChatDraftStore();

--- a/client/src/features/chat/utils/chat-draft-store.ts
+++ b/client/src/features/chat/utils/chat-draft-store.ts
@@ -1,0 +1,98 @@
+export type ChatDraftDestination =
+  | { type: "new" }
+  | { type: "conversation"; conversationId: number };
+
+export type MainChatNavigationPolicy =
+  | "restore-latest-intent"
+  | "always-new-chat";
+
+export const MAIN_CHAT_NAVIGATION_POLICY: MainChatNavigationPolicy =
+  "restore-latest-intent";
+
+type Draft = { text: string; editedAt: number };
+
+export class ChatDraftStore {
+  private userId: string | null = null;
+  private newChatDraft: Draft | null = null;
+  private conversationDrafts = new Map<number, Draft>();
+  private latestExplicitDestination: ChatDraftDestination | null = null;
+  private editSequence = 0;
+
+  setUser(userId?: string) {
+    const nextUserId = userId ?? null;
+    if (this.userId === nextUserId) return;
+    this.clear();
+    this.userId = nextUserId;
+  }
+
+  getDraft(destination: ChatDraftDestination): string {
+    return this.getDraftRecord(destination)?.text ?? "";
+  }
+
+  setDraft(destination: ChatDraftDestination, text: string) {
+    const normalized = text.length === 0 ? null : text;
+    if (destination.type === "new") {
+      this.newChatDraft = normalized
+        ? { text: normalized, editedAt: ++this.editSequence }
+        : null;
+      return;
+    }
+    if (!normalized) {
+      this.conversationDrafts.delete(destination.conversationId);
+      return;
+    }
+    this.conversationDrafts.set(destination.conversationId, {
+      text: normalized,
+      editedAt: ++this.editSequence,
+    });
+  }
+
+  startNewChat() {
+    this.newChatDraft = null;
+    this.latestExplicitDestination = { type: "new" };
+  }
+
+  openConversation(conversationId: number) {
+    this.latestExplicitDestination = { type: "conversation", conversationId };
+  }
+
+  migrateNewChatDraft(conversationId: number) {
+    if (this.newChatDraft) {
+      this.conversationDrafts.set(conversationId, this.newChatDraft);
+      this.newChatDraft = null;
+    }
+    this.latestExplicitDestination = { type: "conversation", conversationId };
+  }
+
+  resolveMainDestination(
+    policy: MainChatNavigationPolicy = MAIN_CHAT_NAVIGATION_POLICY,
+  ): ChatDraftDestination {
+    if (policy === "always-new-chat") return { type: "new" };
+    if (this.latestExplicitDestination?.type === "new") return { type: "new" };
+
+    let latest: { conversationId: number; editedAt: number } | null = null;
+    for (const [conversationId, draft] of this.conversationDrafts) {
+      if (!latest || draft.editedAt > latest.editedAt) {
+        latest = { conversationId, editedAt: draft.editedAt };
+      }
+    }
+    return latest
+      ? { type: "conversation", conversationId: latest.conversationId }
+      : { type: "new" };
+  }
+
+  clear() {
+    this.newChatDraft = null;
+    this.conversationDrafts.clear();
+    this.latestExplicitDestination = null;
+    this.editSequence = 0;
+  }
+
+  private getDraftRecord(destination: ChatDraftDestination): Draft | null {
+    return destination.type === "new"
+      ? this.newChatDraft
+      : (this.conversationDrafts.get(destination.conversationId) ?? null);
+  }
+}
+
+export const chatDraftStore = new ChatDraftStore();

--- a/client/src/features/chat/utils/chat-session-submit.ts
+++ b/client/src/features/chat/utils/chat-session-submit.ts
@@ -243,6 +243,7 @@ export async function submitPrompt({
       tempAssistantId,
       error,
       recoverConversation,
+      onPromptStarted,
       recordTelemetry,
       refs,
       setters,
@@ -267,6 +268,7 @@ async function handleStreamFailureRecovery({
   tempAssistantId,
   error,
   recoverConversation,
+  onPromptStarted,
   recordTelemetry,
   refs,
   setters,
@@ -277,6 +279,7 @@ async function handleStreamFailureRecovery({
   tempAssistantId: number;
   error: unknown;
   recoverConversation: RecoverConversation;
+  onPromptStarted: (conversationId: number) => void;
   recordTelemetry: RecordChatTelemetry;
   refs: ChatSessionRefs;
   setters: ChatSessionSetters;
@@ -314,12 +317,19 @@ async function handleStreamFailureRecovery({
   }
 
   if (recoveredPromptStatus !== "completed") {
+    if (!streamStarted) {
+      setters.setPrompt(nextPrompt);
+    }
     recordTelemetry({
       category: "ux",
       outcome: "failure_toast_shown",
     });
     showErrorToast(submitFailure, "Failed to stream AI chat response");
     return;
+  }
+
+  if (!streamStarted) {
+    onPromptStarted(activeConversationId);
   }
 
   recordTelemetry({

--- a/client/src/features/chat/utils/chat-session-submit.ts
+++ b/client/src/features/chat/utils/chat-session-submit.ts
@@ -31,6 +31,8 @@ type SubmitPromptOptions = {
   prompt: string;
   isSubmitting: boolean;
   onConversationCreated: (conversationId: number) => Promise<void>;
+  onPromptStarted: (conversationId: number) => void;
+  onNewConversationCreated: (conversationId: number) => void;
   loadConversation: LoadConversation;
   recoverConversation: RecoverConversation;
   recordTelemetry: RecordChatTelemetry;
@@ -43,6 +45,8 @@ export async function submitPrompt({
   prompt,
   isSubmitting,
   onConversationCreated,
+  onPromptStarted,
+  onNewConversationCreated,
   loadConversation,
   recoverConversation,
   recordTelemetry,
@@ -63,6 +67,7 @@ export async function submitPrompt({
     if (!activeConversationId) {
       const createdConversation = await createAIChatConversation();
       activeConversationId = createdConversation.id;
+      onNewConversationCreated(activeConversationId);
       setters.setConversation(createdConversation);
       await onConversationCreated(activeConversationId);
     }
@@ -119,6 +124,7 @@ export async function submitPrompt({
       {
         onStart: (event) => {
           streamStarted = true;
+          onPromptStarted(activeConversationId);
           const assistantMessageId = event.message_id ?? tempAssistantId;
           refs.pendingAssistantIdRef.current = assistantMessageId;
           setters.setMessages((current) =>

--- a/client/src/routes/_layout.tsx
+++ b/client/src/routes/_layout.tsx
@@ -4,6 +4,7 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { AppShell } from "@/components/nav/app-shell";
+import { ChatDraftProvider } from "@/features/chat/utils/chat-draft-context";
 import { PwaInstallPrompt } from "@/components/pwa-install-prompt";
 import { useDisplayMode } from "@/hooks/use-display-mode";
 
@@ -32,7 +33,9 @@ export function LayoutComponent() {
         pathname={pathname}
         user={user}
       />
-      <Outlet />
+      <ChatDraftProvider key={user?.id ?? "signed-out"}>
+        <Outlet />
+      </ChatDraftProvider>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- preserve independent unsent AI chat drafts in tab-local memory
- restore the latest eligible draft while keeping explicit New Chat blank
- migrate first-submit drafts to the created conversation and clear on SSE start
- clear draft state on sign-out or account change

## Validation
- node node_modules/vitest/vitest.mjs run --reporter=dot
- node node_modules/typescript/bin/tsc --noEmit
- node_modules/.bin/oxlint.exe src/components/nav/nav-items.ts src/components/nav/nav-items.test.ts src/features/chat
- bun run build