### PR TITLE
feat(client): stop AI chat optimistically

### DIFF
--- a/client/src/features/chat/hooks/use-ai-chat-session.test.tsx
+++ b/client/src/features/chat/hooks/use-ai-chat-session.test.tsx
@@ -688,6 +688,91 @@ describe("useAIChatSession", () => {
     );
   });
 
+  it("immediately hides typing, stays busy, and disables duplicate Stop", async () => {
+    let resumeSignal: AbortSignal | undefined;
+    let resolveStop!: (value: Record<string, unknown>) => void;
+    mockGetConversation.mockResolvedValue(
+      conversationDetail(
+        [
+          {
+            id: 61,
+            conversation_id: 41,
+            role: "assistant",
+            content: "partial",
+            status: "streaming",
+            created_at: "2026-03-26T17:00:00Z",
+            updated_at: "2026-03-26T17:00:01Z",
+          },
+        ],
+        {
+          id: 91,
+          assistant_message_id: 61,
+          status: "streaming",
+          latest_sequence: 1,
+        },
+      ),
+    );
+    mockResumeStream.mockImplementation(
+      (
+        _conversationId: number,
+        _runId: number,
+        _afterSequence: number,
+        handlers: { signal?: AbortSignal },
+      ) => {
+        resumeSignal = handlers.signal;
+        return new Promise(() => undefined);
+      },
+    );
+    mockStopRun.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStop = resolve;
+      }),
+    );
+
+    const { result } = renderSession();
+    await waitFor(() => {
+      expect(result.current.canStop).toBe(true);
+    });
+
+    let stopPromise: Promise<void> | undefined;
+    act(() => {
+      stopPromise = result.current.stopRun();
+    });
+
+    expect(mockStopRun).toHaveBeenCalledWith(41, 91);
+    expect(resumeSignal?.aborted).toBe(true);
+    expect(result.current.isSubmitting).toBe(true);
+    expect(result.current.canStop).toBe(false);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({ status: "stopped", content: "partial" }),
+    );
+
+    await act(async () => {
+      await result.current.stopRun();
+    });
+    expect(mockStopRun).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveStop({
+        conversation_id: 41,
+        run_id: 91,
+        message_id: 61,
+        status: "stopped",
+        text: "authoritative partial",
+        sequence: 2,
+      });
+      await stopPromise;
+    });
+
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({
+        status: "stopped",
+        content: "authoritative partial",
+      }),
+    );
+  });
+
   it.each(["completed", "failed"] as const)(
     "releases a hung active request when Stop reports an already %s run",
     async (status) => {
@@ -745,6 +830,488 @@ describe("useAIChatSession", () => {
       ]);
     },
   );
+
+  it("falls back to a terminal Stop response when its reload fails", async () => {
+    const reloadError = new Error("Terminal reload failed");
+    mockGetConversation
+      .mockResolvedValueOnce(
+        conversationDetail(
+          [
+            {
+              id: 61,
+              conversation_id: 41,
+              role: "assistant",
+              content: "partial",
+              status: "streaming",
+              created_at: "2026-03-26T17:00:00Z",
+              updated_at: "2026-03-26T17:00:01Z",
+            },
+          ],
+          {
+            id: 91,
+            assistant_message_id: 61,
+            status: "streaming",
+            latest_sequence: 1,
+          },
+        ),
+      )
+      .mockRejectedValueOnce(reloadError);
+    mockResumeStream.mockImplementation(() => new Promise(() => undefined));
+    mockStopRun.mockResolvedValue({
+      conversation_id: 41,
+      run_id: 91,
+      message_id: 61,
+      status: "completed",
+      text: "completed while Stop raced",
+      sequence: 2,
+    });
+
+    const { result } = renderSession();
+    await waitFor(() => expect(result.current.canStop).toBe(true));
+
+    await act(async () => {
+      await result.current.stopRun();
+    });
+
+    expect(result.current.loadError).toBe(reloadError.message);
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.canStop).toBe(false);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({
+        status: "completed",
+        content: "completed while Stop raced",
+      }),
+    );
+  });
+
+  it("recovers an orphaned streaming message loaded after a terminal Stop race", async () => {
+    const streamingMessage = {
+      id: 61,
+      conversation_id: 41,
+      role: "assistant",
+      content: "partial",
+      status: "streaming",
+      created_at: "2026-03-26T17:00:00Z",
+      updated_at: "2026-03-26T17:00:01Z",
+    };
+    mockGetConversation
+      .mockResolvedValueOnce(
+        conversationDetail([streamingMessage], {
+          id: 91,
+          assistant_message_id: 61,
+          status: "streaming",
+          latest_sequence: 1,
+        }),
+      )
+      .mockResolvedValueOnce(conversationDetail([streamingMessage]));
+    mockResumeStream.mockImplementation(() => new Promise(() => undefined));
+    mockStopRun.mockResolvedValue({
+      conversation_id: 41,
+      run_id: 91,
+      message_id: 61,
+      status: "completed",
+      text: "terminal response",
+      sequence: 2,
+    });
+    mockPollConversation.mockResolvedValue(
+      conversationDetail([
+        {
+          ...streamingMessage,
+          content: "recovered terminal response",
+          status: "completed",
+          updated_at: "2026-03-26T17:00:02Z",
+          completed_at: "2026-03-26T17:00:02Z",
+        },
+      ]),
+    );
+
+    const { result } = renderSession();
+    await waitFor(() => expect(result.current.canStop).toBe(true));
+
+    await act(async () => {
+      await result.current.stopRun();
+    });
+
+    expect(mockRequestRecovery).toHaveBeenCalledWith(
+      41,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({
+        status: "completed",
+        content: "recovered terminal response",
+      }),
+    );
+  });
+
+  it.each(["completed", "failed"] as const)(
+    "releases a replacement run after authoritative %s SSE when refresh fails",
+    async (terminalStatus) => {
+      const refreshError = new Error("Terminal refresh failed");
+      const initialMessage = {
+        id: 61,
+        conversation_id: 41,
+        role: "assistant",
+        content: "old partial",
+        status: "streaming",
+        created_at: "2026-03-26T17:00:00Z",
+        updated_at: "2026-03-26T17:00:01Z",
+      };
+      const replacementMessage = {
+        ...initialMessage,
+        id: 82,
+        content: "new partial",
+        updated_at: "2026-03-26T17:01:01Z",
+      };
+      mockGetConversation
+        .mockResolvedValueOnce(
+          conversationDetail([initialMessage], {
+            id: 91,
+            assistant_message_id: 61,
+            status: "streaming",
+            latest_sequence: 1,
+          }),
+        )
+        .mockResolvedValueOnce(
+          conversationDetail([replacementMessage], {
+            id: 92,
+            assistant_message_id: 82,
+            status: "streaming",
+            latest_sequence: 1,
+          }),
+        )
+        .mockRejectedValueOnce(refreshError);
+      mockResumeStream
+        .mockImplementationOnce(
+          (
+            _conversationId: number,
+            _runId: number,
+            _afterSequence: number,
+            handlers: { signal?: AbortSignal },
+          ) =>
+            new Promise((_resolve, reject) => {
+              handlers.signal?.addEventListener(
+                "abort",
+                () => reject(new DOMException("Aborted", "AbortError")),
+                { once: true },
+              );
+            }),
+        )
+        .mockImplementationOnce(
+          async (
+            _conversationId: number,
+            _runId: number,
+            _afterSequence: number,
+            handlers: {
+              onDone?: (event: Record<string, unknown>) => void;
+              onErrorEvent?: (event: Record<string, unknown>) => void;
+            },
+          ) => {
+            if (terminalStatus === "completed") {
+              const doneEvent = {
+                type: "done",
+                message_id: 82,
+                status: "completed",
+                text: "new complete response",
+              };
+              handlers.onDone?.(doneEvent);
+              return { doneEvent, endedWithError: false };
+            }
+            const errorEvent = {
+              type: "error",
+              message_id: 82,
+              message: "new run failed",
+            };
+            handlers.onErrorEvent?.(errorEvent);
+            return { doneEvent: errorEvent, endedWithError: true };
+          },
+        );
+      mockStopRun.mockResolvedValue({
+        conversation_id: 41,
+        run_id: 91,
+        message_id: 61,
+        status: "completed",
+        text: "old run completed",
+        sequence: 2,
+      });
+
+      const { result } = renderSession();
+      await waitFor(() => expect(result.current.canStop).toBe(true));
+
+      await act(async () => {
+        await result.current.stopRun();
+      });
+
+      expect(mockPollConversation).not.toHaveBeenCalled();
+      expect(result.current.isSubmitting).toBe(false);
+      expect(result.current.canStop).toBe(false);
+      expect(result.current.loadError).toBe(refreshError.message);
+      expect(result.current.messages[0]).toEqual(
+        expect.objectContaining({ id: 82, status: terminalStatus }),
+      );
+    },
+  );
+
+  it("adopts a newer active run returned after replacement-run terminal SSE", async () => {
+    const message = {
+      id: 61,
+      conversation_id: 41,
+      role: "assistant",
+      content: "old partial",
+      status: "streaming",
+      created_at: "2026-03-26T17:00:00Z",
+      updated_at: "2026-03-26T17:00:01Z",
+    };
+    mockGetConversation
+      .mockResolvedValueOnce(
+        conversationDetail([message], {
+          id: 91,
+          assistant_message_id: 61,
+          status: "streaming",
+          latest_sequence: 1,
+        }),
+      )
+      .mockResolvedValueOnce(
+        conversationDetail(
+          [{ ...message, id: 82, content: "replacement partial" }],
+          {
+            id: 92,
+            assistant_message_id: 82,
+            status: "streaming",
+            latest_sequence: 1,
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        conversationDetail(
+          [{ ...message, id: 103, content: "newest partial" }],
+          {
+            id: 93,
+            assistant_message_id: 103,
+            status: "streaming",
+            latest_sequence: 1,
+          },
+        ),
+      );
+    mockResumeStream
+      .mockImplementationOnce(
+        (
+          _conversationId: number,
+          _runId: number,
+          _afterSequence: number,
+          handlers: { signal?: AbortSignal },
+        ) =>
+          new Promise((_resolve, reject) => {
+            handlers.signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("Aborted", "AbortError")),
+              { once: true },
+            );
+          }),
+      )
+      .mockImplementationOnce(
+        async (
+          _conversationId: number,
+          _runId: number,
+          _afterSequence: number,
+          handlers: { onDone?: (event: Record<string, unknown>) => void },
+        ) => {
+          const doneEvent = {
+            type: "done",
+            message_id: 82,
+            status: "completed",
+            text: "replacement completed",
+          };
+          handlers.onDone?.(doneEvent);
+          return { doneEvent, endedWithError: false };
+        },
+      )
+      .mockRejectedValueOnce(new Error("Newest resume failed"));
+    mockPollConversation.mockRejectedValue(
+      new Error(
+        "AI chat recovery timed out while waiting for persisted conversation state",
+      ),
+    );
+    mockStopRun.mockResolvedValue({
+      conversation_id: 41,
+      run_id: 91,
+      message_id: 61,
+      status: "completed",
+      text: "old run completed",
+      sequence: 2,
+    });
+
+    const { result } = renderSession();
+    await waitFor(() => expect(result.current.canStop).toBe(true));
+
+    await act(async () => {
+      await result.current.stopRun();
+    });
+
+    expect(mockResumeStream).toHaveBeenNthCalledWith(
+      3,
+      41,
+      93,
+      expect.any(Number),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result.current.isSubmitting).toBe(true);
+    expect(result.current.canStop).toBe(true);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({
+        id: 103,
+        status: "streaming",
+        content: "newest partial",
+      }),
+    );
+  });
+
+  it("keeps a different active run unresolved when terminal Stop reconciliation times out", async () => {
+    const initialMessage = {
+      id: 61,
+      conversation_id: 41,
+      role: "assistant",
+      content: "old partial",
+      status: "streaming",
+      created_at: "2026-03-26T17:00:00Z",
+      updated_at: "2026-03-26T17:00:01Z",
+    };
+    const replacementMessage = {
+      ...initialMessage,
+      id: 82,
+      content: "new partial",
+      updated_at: "2026-03-26T17:01:01Z",
+    };
+    mockGetConversation
+      .mockResolvedValueOnce(
+        conversationDetail([initialMessage], {
+          id: 91,
+          assistant_message_id: 61,
+          status: "streaming",
+          latest_sequence: 1,
+        }),
+      )
+      .mockResolvedValueOnce(
+        conversationDetail([replacementMessage], {
+          id: 92,
+          assistant_message_id: 82,
+          status: "streaming",
+          latest_sequence: 1,
+        }),
+      );
+    mockResumeStream
+      .mockImplementationOnce(
+        (
+          _conversationId: number,
+          _runId: number,
+          _afterSequence: number,
+          handlers: { signal?: AbortSignal },
+        ) =>
+          new Promise((_resolve, reject) => {
+            handlers.signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("Aborted", "AbortError")),
+              { once: true },
+            );
+          }),
+      )
+      .mockRejectedValueOnce(new Error("Replacement resume failed"));
+    mockPollConversation.mockRejectedValue(
+      new Error(
+        "AI chat recovery timed out while waiting for persisted conversation state",
+      ),
+    );
+    mockStopRun.mockResolvedValue({
+      conversation_id: 41,
+      run_id: 91,
+      message_id: 61,
+      status: "completed",
+      text: "old run completed",
+      sequence: 2,
+    });
+
+    const { result } = renderSession();
+    await waitFor(() => expect(result.current.canStop).toBe(true));
+
+    await act(async () => {
+      await result.current.stopRun();
+    });
+
+    expect(result.current.isSubmitting).toBe(true);
+    expect(result.current.canStop).toBe(true);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({
+        id: 82,
+        status: "streaming",
+        content: "new partial",
+      }),
+    );
+  });
+
+  it("keeps an orphaned stream busy and Stop-retryable when terminal reconciliation times out", async () => {
+    const streamingMessage = {
+      id: 61,
+      conversation_id: 41,
+      role: "assistant",
+      content: "partial",
+      status: "streaming",
+      created_at: "2026-03-26T17:00:00Z",
+      updated_at: "2026-03-26T17:00:01Z",
+    };
+    mockGetConversation
+      .mockResolvedValueOnce(
+        conversationDetail([streamingMessage], {
+          id: 91,
+          assistant_message_id: 61,
+          status: "streaming",
+          latest_sequence: 1,
+        }),
+      )
+      .mockResolvedValueOnce(conversationDetail([streamingMessage]));
+    mockResumeStream.mockImplementation(
+      (
+        _conversationId: number,
+        _runId: number,
+        _afterSequence: number,
+        handlers: { signal?: AbortSignal },
+      ) =>
+        new Promise((_resolve, reject) => {
+          handlers.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    mockPollConversation.mockRejectedValue(
+      new Error(
+        "AI chat recovery timed out while waiting for persisted conversation state",
+      ),
+    );
+    mockStopRun.mockResolvedValue({
+      conversation_id: 41,
+      run_id: 91,
+      message_id: 61,
+      status: "failed",
+      text: "old run failed",
+      sequence: 2,
+    });
+
+    const { result } = renderSession();
+    await waitFor(() => expect(result.current.canStop).toBe(true));
+
+    await act(async () => {
+      await result.current.stopRun();
+    });
+
+    expect(result.current.isSubmitting).toBe(true);
+    expect(result.current.canStop).toBe(true);
+    expect(mockStopRun).toHaveBeenCalledWith(41, 91);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({ status: "streaming", content: "partial" }),
+    );
+  });
 
   it("keeps a newly loaded Stop target when an aborted route resume settles late", async () => {
     const resolveResume: Array<
@@ -1313,17 +1880,487 @@ describe("useAIChatSession", () => {
     expect(result.current.isSubmitting).toBe(true);
   });
 
-  it("reports a rejected Stop request for the current active run", async () => {
-    const error = new Error("Stop request failed");
-    mockStopRun.mockRejectedValue(error);
-    mockGetConversation.mockResolvedValue(
-      conversationDetail([], {
+  it("keeps same-run recovery timeouts unresolved and stoppable", async () => {
+    const stopError = new Error("Stop request failed");
+    const timeoutError = new Error(
+      "AI chat recovery timed out while waiting for persisted conversation state",
+    );
+    const activeDetail = conversationDetail(
+      [
+        {
+          id: 61,
+          conversation_id: 41,
+          role: "assistant",
+          content: "partial",
+          status: "streaming",
+          created_at: "2026-03-26T17:00:00Z",
+          updated_at: "2026-03-26T17:00:01Z",
+        },
+      ],
+      {
         id: 91,
         assistant_message_id: 61,
         status: "streaming",
         latest_sequence: 1,
+      },
+    );
+    mockGetConversation
+      .mockResolvedValueOnce(activeDetail)
+      .mockResolvedValueOnce(activeDetail);
+    mockResumeStream
+      .mockImplementationOnce(
+        (
+          _conversationId: number,
+          _runId: number,
+          _afterSequence: number,
+          handlers: { signal?: AbortSignal },
+        ) =>
+          new Promise((_resolve, reject) => {
+            handlers.signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("Aborted", "AbortError")),
+              { once: true },
+            );
+          }),
+      )
+      .mockRejectedValueOnce(new Error("Resume failed"));
+    mockStopRun.mockRejectedValue(stopError);
+    mockPollConversation.mockRejectedValue(timeoutError);
+
+    const { result } = renderSession();
+    await waitFor(() => expect(result.current.canStop).toBe(true));
+
+    await act(async () => {
+      await result.current.stopRun();
+    });
+
+    expect(result.current.isSubmitting).toBe(true);
+    expect(result.current.canStop).toBe(true);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({ status: "streaming" }),
+    );
+    expect(result.current.loadError).toBe(timeoutError.message);
+    expect(mockReportTelemetry).toHaveBeenCalledWith({
+      category: "recovery",
+      outcome: "recovery_timeout",
+    });
+  });
+
+  it("adopts a different active run after Stop failure and targets retries to it", async () => {
+    const firstDetail = conversationDetail(
+      [
+        {
+          id: 61,
+          conversation_id: 41,
+          role: "assistant",
+          content: "old partial",
+          status: "streaming",
+          created_at: "2026-03-26T17:00:00Z",
+          updated_at: "2026-03-26T17:00:01Z",
+        },
+      ],
+      {
+        id: 91,
+        assistant_message_id: 61,
+        status: "streaming",
+        latest_sequence: 1,
+      },
+    );
+    const replacementDetail = conversationDetail(
+      [
+        {
+          id: 82,
+          conversation_id: 41,
+          role: "assistant",
+          content: "new partial",
+          status: "streaming",
+          created_at: "2026-03-26T17:01:00Z",
+          updated_at: "2026-03-26T17:01:01Z",
+        },
+      ],
+      {
+        id: 92,
+        assistant_message_id: 82,
+        status: "streaming",
+        latest_sequence: 1,
+      },
+    );
+    mockGetConversation
+      .mockResolvedValueOnce(firstDetail)
+      .mockResolvedValueOnce(replacementDetail);
+    mockResumeStream.mockImplementation(
+      (
+        _conversationId: number,
+        _runId: number,
+        _afterSequence: number,
+        handlers: { signal?: AbortSignal },
+      ) =>
+        new Promise((_resolve, reject) => {
+          handlers.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    mockStopRun
+      .mockRejectedValueOnce(new Error("Old Stop failed"))
+      .mockResolvedValueOnce({
+        conversation_id: 41,
+        run_id: 92,
+        message_id: 82,
+        status: "stopped",
+        text: "new authoritative partial",
+        sequence: 2,
+      });
+
+    const { result } = renderSession();
+    await waitFor(() => expect(result.current.canStop).toBe(true));
+
+    let firstStop: Promise<void> | undefined;
+    act(() => {
+      firstStop = result.current.stopRun();
+    });
+    await waitFor(() => {
+      expect(mockResumeStream).toHaveBeenCalledTimes(2);
+      expect(result.current.canStop).toBe(true);
+      expect(result.current.messages[0]?.id).toBe(82);
+    });
+
+    await act(async () => {
+      await result.current.stopRun();
+      await firstStop;
+    });
+
+    expect(mockStopRun).toHaveBeenNthCalledWith(1, 41, 91);
+    expect(mockStopRun).toHaveBeenNthCalledWith(2, 41, 92);
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({
+        id: 82,
+        status: "stopped",
+        content: "new authoritative partial",
       }),
     );
+  });
+
+  it("does not let an aborted reconciliation re-enable Stop during a retry", async () => {
+    const streamingMessage = {
+      id: 61,
+      conversation_id: 41,
+      role: "assistant",
+      content: "partial",
+      status: "streaming",
+      created_at: "2026-03-26T17:00:00Z",
+      updated_at: "2026-03-26T17:00:01Z",
+    };
+    mockGetConversation
+      .mockResolvedValueOnce(
+        conversationDetail([streamingMessage], {
+          id: 91,
+          assistant_message_id: 61,
+          status: "streaming",
+          latest_sequence: 1,
+        }),
+      )
+      .mockResolvedValueOnce(conversationDetail([streamingMessage]));
+    mockResumeStream.mockImplementation(
+      (
+        _conversationId: number,
+        _runId: number,
+        _afterSequence: number,
+        handlers: { signal?: AbortSignal },
+      ) =>
+        new Promise((_resolve, reject) => {
+          handlers.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    mockPollConversation.mockImplementation(
+      (_conversationId: number, options: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          options.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    let resolveRetry!: (value: Record<string, unknown>) => void;
+    mockStopRun
+      .mockRejectedValueOnce(new Error("First Stop failed"))
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveRetry = resolve;
+        }),
+      );
+
+    const { result } = renderSession();
+    await waitFor(() => expect(result.current.canStop).toBe(true));
+
+    let firstStop: Promise<void> | undefined;
+    act(() => {
+      firstStop = result.current.stopRun();
+    });
+    await waitFor(() => {
+      expect(mockPollConversation).toHaveBeenCalledTimes(1);
+      expect(result.current.canStop).toBe(true);
+    });
+
+    let retryStop: Promise<void> | undefined;
+    act(() => {
+      retryStop = result.current.stopRun();
+    });
+    await act(async () => {
+      await firstStop;
+    });
+
+    expect(result.current.isSubmitting).toBe(true);
+    expect(result.current.canStop).toBe(false);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({ status: "stopped" }),
+    );
+    expect(mockStopRun).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveRetry({
+        conversation_id: 41,
+        run_id: 91,
+        message_id: 61,
+        status: "stopped",
+        text: "authoritative partial",
+        sequence: 2,
+      });
+      await retryStop;
+    });
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it("recovers an orphaned streaming message after Stop failure", async () => {
+    const initialDetail = conversationDetail(
+      [
+        {
+          id: 61,
+          conversation_id: 41,
+          role: "assistant",
+          content: "partial",
+          status: "streaming",
+          created_at: "2026-03-26T17:00:00Z",
+          updated_at: "2026-03-26T17:00:01Z",
+        },
+      ],
+      {
+        id: 91,
+        assistant_message_id: 61,
+        status: "streaming",
+        latest_sequence: 1,
+      },
+    );
+    const orphanedDetail = conversationDetail([
+      {
+        id: 61,
+        conversation_id: 41,
+        role: "assistant",
+        content: "partial",
+        status: "streaming",
+        created_at: "2026-03-26T17:00:00Z",
+        updated_at: "2026-03-26T17:00:01Z",
+      },
+    ]);
+    const recoveredDetail = conversationDetail([
+      {
+        id: 61,
+        conversation_id: 41,
+        role: "assistant",
+        content: "completed elsewhere",
+        status: "completed",
+        created_at: "2026-03-26T17:00:00Z",
+        updated_at: "2026-03-26T17:00:02Z",
+        completed_at: "2026-03-26T17:00:02Z",
+      },
+    ]);
+    mockGetConversation
+      .mockResolvedValueOnce(initialDetail)
+      .mockResolvedValueOnce(orphanedDetail);
+    mockResumeStream.mockImplementation(
+      (
+        _conversationId: number,
+        _runId: number,
+        _afterSequence: number,
+        handlers: { signal?: AbortSignal },
+      ) =>
+        new Promise((_resolve, reject) => {
+          handlers.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    mockStopRun.mockRejectedValue(new Error("Stop failed"));
+    mockPollConversation.mockResolvedValue(recoveredDetail);
+
+    const { result } = renderSession();
+    await waitFor(() => expect(result.current.canStop).toBe(true));
+
+    await act(async () => {
+      await result.current.stopRun();
+    });
+
+    expect(mockRequestRecovery).toHaveBeenCalledWith(
+      41,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({
+        status: "completed",
+        content: "completed elsewhere",
+      }),
+    );
+  });
+
+  it("keeps an orphaned-message recovery timeout unresolved and stoppable", async () => {
+    const streamingMessage = {
+      id: 61,
+      conversation_id: 41,
+      role: "assistant",
+      content: "partial",
+      status: "streaming",
+      created_at: "2026-03-26T17:00:00Z",
+      updated_at: "2026-03-26T17:00:01Z",
+    };
+    mockGetConversation
+      .mockResolvedValueOnce(
+        conversationDetail([streamingMessage], {
+          id: 91,
+          assistant_message_id: 61,
+          status: "streaming",
+          latest_sequence: 1,
+        }),
+      )
+      .mockResolvedValueOnce(conversationDetail([streamingMessage]));
+    mockResumeStream.mockImplementation(
+      (
+        _conversationId: number,
+        _runId: number,
+        _afterSequence: number,
+        handlers: { signal?: AbortSignal },
+      ) =>
+        new Promise((_resolve, reject) => {
+          handlers.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    mockStopRun.mockRejectedValue(new Error("Stop failed"));
+    mockPollConversation.mockRejectedValue(
+      new Error(
+        "AI chat recovery timed out while waiting for persisted conversation state",
+      ),
+    );
+
+    const { result } = renderSession();
+    await waitFor(() => expect(result.current.canStop).toBe(true));
+
+    await act(async () => {
+      await result.current.stopRun();
+    });
+
+    expect(result.current.isSubmitting).toBe(true);
+    expect(result.current.canStop).toBe(true);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({ status: "streaming" }),
+    );
+    expect(mockReportTelemetry).toHaveBeenCalledWith({
+      category: "recovery",
+      outcome: "recovery_timeout",
+    });
+  });
+
+  it("releases a failed Stop target when reconciliation loads a terminal run", async () => {
+    mockGetConversation
+      .mockResolvedValueOnce(
+        conversationDetail([], {
+          id: 91,
+          assistant_message_id: 61,
+          status: "streaming",
+          latest_sequence: 1,
+        }),
+      )
+      .mockResolvedValueOnce(
+        conversationDetail([
+          {
+            id: 61,
+            conversation_id: 41,
+            role: "assistant",
+            content: "failed elsewhere",
+            status: "failed",
+            created_at: "2026-03-26T17:00:00Z",
+            updated_at: "2026-03-26T17:00:02Z",
+            completed_at: "2026-03-26T17:00:02Z",
+          },
+        ]),
+      );
+    mockResumeStream.mockImplementation(() => new Promise(() => undefined));
+    mockStopRun.mockRejectedValue(new Error("Stop failed"));
+
+    const { result } = renderSession();
+    await waitFor(() => expect(result.current.canStop).toBe(true));
+
+    await act(async () => {
+      await result.current.stopRun();
+    });
+
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.canStop).toBe(false);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        content: "failed elsewhere",
+      }),
+    );
+  });
+
+  it("keeps Stop retryable when both Stop and its reconciliation reload fail", async () => {
+    const error = new Error("Stop request failed");
+    const reloadError = new Error("Reload failed");
+    mockStopRun.mockRejectedValueOnce(error).mockResolvedValueOnce({
+      conversation_id: 41,
+      run_id: 91,
+      message_id: 61,
+      status: "stopped",
+      text: "authoritative partial",
+      sequence: 2,
+    });
+    mockGetConversation
+      .mockResolvedValueOnce(
+        conversationDetail(
+          [
+            {
+              id: 61,
+              conversation_id: 41,
+              role: "assistant",
+              content: "partial",
+              status: "streaming",
+              created_at: "2026-03-26T17:00:00Z",
+              updated_at: "2026-03-26T17:00:01Z",
+            },
+          ],
+          {
+            id: 91,
+            assistant_message_id: 61,
+            status: "streaming",
+            latest_sequence: 1,
+          },
+        ),
+      )
+      .mockRejectedValueOnce(reloadError);
     mockResumeStream.mockImplementation(() => new Promise(() => undefined));
 
     const { result } = renderSession();
@@ -1339,6 +2376,25 @@ describe("useAIChatSession", () => {
     expect(mockShowErrorToast).toHaveBeenCalledWith(
       error,
       "Failed to stop AI chat response",
+    );
+    expect(result.current.isSubmitting).toBe(true);
+    expect(result.current.canStop).toBe(true);
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({ status: "streaming" }),
+    );
+    expect(result.current.loadError).toBe("Reload failed");
+
+    await act(async () => {
+      await result.current.stopRun();
+    });
+    expect(mockStopRun).toHaveBeenNthCalledWith(2, 41, 91);
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.loadError).toBeNull();
+    expect(result.current.messages[0]).toEqual(
+      expect.objectContaining({
+        status: "stopped",
+        content: "authoritative partial",
+      }),
     );
   });
 });

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -14,8 +14,10 @@ import {
   mockPollConversation,
   mockReportTelemetry,
   mockRequestRecovery,
+  mockResumeStream,
   mockSearch,
   mockShowErrorToast,
+  mockStopRun,
   mockStreamMessage,
   resetChatRouteMocks,
 } from "../test/chat-page-test-utils";
@@ -434,6 +436,72 @@ describe("ChatRouteComponent", () => {
 
     expect(await screen.findByText("Hello anybody there?")).toBeInTheDocument();
     expect(screen.getByTestId("chat-conversation-body")).toHaveClass("pt-4");
+  });
+
+  it("removes typing immediately while durable Stop is pending", async () => {
+    const user = userEvent.setup();
+    const stopRequest = deferredPromise<Record<string, unknown>>();
+    mockGetConversation.mockResolvedValue(
+      conversationDetail(
+        [
+          {
+            id: 61,
+            conversation_id: 41,
+            role: "assistant",
+            content: "partial response",
+            status: "streaming",
+            created_at: "2026-03-26T17:00:00Z",
+            updated_at: "2026-03-26T17:00:01Z",
+          },
+        ],
+        {
+          id: 91,
+          assistant_message_id: 61,
+          status: "streaming",
+          latest_sequence: 1,
+        },
+      ),
+    );
+    mockResumeStream.mockImplementation(() => new Promise(() => undefined));
+    mockStopRun.mockReturnValue(stopRequest.promise);
+
+    render(<ChatRouteComponent />);
+
+    expect(
+      await screen.findByRole("status", { name: "Assistant is typing" }),
+    ).toBeInTheDocument();
+    const stopButton = screen.getByRole("button", { name: "Stop response" });
+    expect(stopButton).toBeEnabled();
+
+    await user.click(stopButton);
+
+    expect(mockStopRun).toHaveBeenCalledWith(41, 91);
+    expect(
+      screen.queryByRole("status", { name: "Assistant is typing" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Stopped")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Stop response" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByPlaceholderText(
+        "Ask about training, recovery, exercise choices, or FitTrack usage...",
+      ),
+    ).toBeDisabled();
+
+    stopRequest.resolve({
+      conversation_id: 41,
+      run_id: 91,
+      message_id: 61,
+      status: "stopped",
+      text: "authoritative partial response",
+      sequence: 2,
+    });
+
+    expect(
+      await screen.findByText("authoritative partial response"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
   });
 
   it("recovers a completed reply when the stream dies before the start event reaches the client", async () => {

--- a/client/src/features/chat/test/chat-page-test-utils.tsx
+++ b/client/src/features/chat/test/chat-page-test-utils.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   mockReportTelemetry: vi.fn(),
   mockRequestRecovery: vi.fn(),
   mockSaveLatestWorkoutDraft: vi.fn(),
+  mockStopRun: vi.fn(),
   mockStreamMessage: vi.fn(),
   mockShowErrorToast: vi.fn(),
   mockToastSuccess: vi.fn(),
@@ -59,6 +60,7 @@ export const {
   mockReportTelemetry,
   mockRequestRecovery,
   mockSaveLatestWorkoutDraft,
+  mockStopRun,
   mockStreamMessage,
   mockShowErrorToast,
   mockToastSuccess,
@@ -99,6 +101,7 @@ vi.mock("@/features/chat/api/ai-chat", () => ({
   reportAIChatTelemetry: mockReportTelemetry,
   requestAIChatMessageRecovery: mockRequestRecovery,
   saveAIChatLatestWorkoutDraft: mockSaveLatestWorkoutDraft,
+  stopAIChatRun: mockStopRun,
   streamAIChatMessage: mockStreamMessage,
 }));
 
@@ -227,6 +230,7 @@ export function resetChatRouteMocks() {
   mockReportTelemetry.mockReset();
   mockRequestRecovery.mockReset();
   mockSaveLatestWorkoutDraft.mockReset();
+  mockStopRun.mockReset();
   mockStreamMessage.mockReset();
   mockShowErrorToast.mockReset();
   mockToastSuccess.mockReset();

--- a/client/src/features/chat/utils/chat-operation-controller.test.ts
+++ b/client/src/features/chat/utils/chat-operation-controller.test.ts
@@ -130,7 +130,120 @@ describe("ChatOperationController", () => {
     expect(secondAttachment.active).toBe(true);
   });
 
-  it("preserves visible Stop timing until the existing request resolves", async () => {
+  it("cannot publish a pending Stop result into a later attachment", async () => {
+    let resolveStop!: (value: {
+      conversation_id: number;
+      run_id: number;
+      message_id: number;
+      status: "stopped";
+      text: string;
+      sequence: number;
+    }) => void;
+    mockStopRun.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStop = resolve;
+      }),
+    );
+    const { controller, state } = createController();
+    const firstAttachment = controller.attach();
+    const oldOperation = controller.beginOperation(41)!;
+    const oldAttempt = controller.beginAttempt(oldOperation, "stream")!;
+    controller.markStreaming(oldOperation, oldAttempt, 91, 61);
+
+    const stopPromise = controller.stopRun();
+    controller.detach(firstAttachment);
+    controller.attach();
+    const nextOperation = controller.beginOperation(42)!;
+    const nextAttempt = controller.beginAttempt(nextOperation, "stream")!;
+    controller.markStreaming(nextOperation, nextAttempt, 92, 82);
+
+    resolveStop({
+      conversation_id: 41,
+      run_id: 91,
+      message_id: 61,
+      status: "stopped",
+      text: "old response",
+      sequence: 2,
+    });
+    await stopPromise;
+
+    expect(controller.getSnapshot()).toEqual({
+      phase: "streaming",
+      conversationId: 42,
+      runId: 92,
+      assistantMessageId: 82,
+    });
+    expect(state.setMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves a hung Stop request to retryable recovery after its deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      mockStopRun.mockReturnValue(new Promise(() => undefined));
+      mockGetConversation.mockRejectedValue(new Error("Reload failed"));
+      const { controller } = createController();
+      controller.attach();
+      const operation = controller.beginOperation(41)!;
+      const attempt = controller.beginAttempt(operation, "stream")!;
+      controller.markStreaming(operation, attempt, 91, 61);
+
+      const stopPromise = controller.stopRun();
+      await vi.advanceTimersByTimeAsync(15_000);
+      await stopPromise;
+
+      expect(controller.getSnapshot()).toEqual({
+        phase: "recovering",
+        conversationId: 41,
+        runId: 91,
+        assistantMessageId: 61,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { stopRejects: false, expectedPhase: "idle" },
+    { stopRejects: true, expectedPhase: "recovering" },
+  ] as const)(
+    "bounds reconciliation reloads after Stop (rejects: $stopRejects)",
+    async ({ stopRejects, expectedPhase }) => {
+      vi.useFakeTimers();
+      try {
+        if (stopRejects) {
+          mockStopRun.mockRejectedValue(new Error("Stop failed"));
+        } else {
+          mockStopRun.mockResolvedValue({
+            conversation_id: 41,
+            run_id: 91,
+            message_id: 61,
+            status: "completed",
+            text: "completed response",
+            sequence: 2,
+          });
+        }
+        mockGetConversation.mockReturnValue(new Promise(() => undefined));
+        const { controller } = createController();
+        controller.attach();
+        const operation = controller.beginOperation(41)!;
+        const attempt = controller.beginAttempt(operation, "stream")!;
+        controller.markStreaming(operation, attempt, 91, 61);
+
+        const stopPromise = controller.stopRun();
+        await vi.waitFor(() => {
+          expect(mockGetConversation).toHaveBeenCalledTimes(1);
+        });
+        await vi.advanceTimersByTimeAsync(15_000);
+        await stopPromise;
+
+        expect(controller.getSnapshot().phase).toBe(expectedPhase);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("enters stopping, aborts local work, and ignores late cleanup immediately", async () => {
     let resolveStop!: (value: {
       conversation_id: number;
       run_id: number;
@@ -152,8 +265,14 @@ describe("ChatOperationController", () => {
 
     const stopPromise = controller.stopRun();
     expect(mockStopRun).toHaveBeenCalledWith(41, 91);
-    expect(controller.getSnapshot().phase).toBe("streaming");
-    expect(attempt.controller.signal.aborted).toBe(false);
+    expect(controller.getSnapshot().phase).toBe("stopping");
+    expect(attempt.controller.signal.aborted).toBe(true);
+    expect(controller.finishAttempt(operation, attempt)).toBe(false);
+    expect(controller.finishOperation(operation)).toBe(false);
+    expect(state.setMessages).toHaveBeenCalledTimes(1);
+
+    await controller.stopRun();
+    expect(mockStopRun).toHaveBeenCalledTimes(1);
 
     resolveStop({
       conversation_id: 41,
@@ -165,8 +284,7 @@ describe("ChatOperationController", () => {
     });
     await stopPromise;
 
-    expect(attempt.controller.signal.aborted).toBe(true);
     expect(controller.getSnapshot().phase).toBe("idle");
-    expect(state.setMessages).toHaveBeenCalledTimes(1);
+    expect(state.setMessages).toHaveBeenCalledTimes(2);
   });
 });

--- a/client/src/features/chat/utils/chat-operation-controller.ts
+++ b/client/src/features/chat/utils/chat-operation-controller.ts
@@ -2,13 +2,14 @@ import {
   reportAIChatTelemetry,
   stopAIChatRun,
   type AIChatConversationDetail,
+  type AIChatStopResponse,
   type AIChatTelemetryEvent,
 } from "@/features/chat/api/ai-chat";
 import {
   classifyLoadOutcome,
   classifyRecoveryOutcome,
 } from "@/features/chat/utils/ai-chat-observability";
-import { showErrorToast } from "@/lib/errors";
+import { getErrorMessage, showErrorToast } from "@/lib/errors";
 import { clearResumeCursor } from "./chat-resume";
 import {
   loadConversation as loadConversationRequest,
@@ -52,6 +53,7 @@ export type ChatOperation = {
   phase: Exclude<ChatOperationPhase, "idle">;
   currentAttempt: ChatOperationAttempt | null;
   adoptedConversationId: number | null;
+  requiresAuthoritativeResolution: boolean;
 };
 
 export type ChatOperationSnapshot = Readonly<{
@@ -80,6 +82,33 @@ const idleSnapshot: ChatOperationSnapshot = Object.freeze({
   runId: null,
   assistantMessageId: null,
 });
+
+const stopRequestTimeoutMs = 15_000;
+const stopReconciliationTimeoutMs = 15_000;
+
+function boundRequest<T>(
+  request: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string,
+  onTimeout?: () => void,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = globalThis.setTimeout(() => {
+      onTimeout?.();
+      reject(new Error(timeoutMessage));
+    }, timeoutMs);
+    void request.then(
+      (result) => {
+        globalThis.clearTimeout(timeoutId);
+        resolve(result);
+      },
+      (error) => {
+        globalThis.clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
+}
 
 /** Owns the browser-side lifecycle of the chat operation shown by one chat screen. */
 export class ChatOperationController {
@@ -156,6 +185,7 @@ export class ChatOperationController {
       phase,
       currentAttempt: null,
       adoptedConversationId: null,
+      requiresAuthoritativeResolution: false,
     };
     this.operation = operation;
     this.publishOperation();
@@ -216,13 +246,13 @@ export class ChatOperationController {
   }
 
   finishOperation(operation: ChatOperation): boolean {
-    if (!this.ownsOperation(operation)) {
+    if (
+      !this.ownsOperation(operation) ||
+      operation.requiresAuthoritativeResolution
+    ) {
       return false;
     }
-    operation.currentAttempt?.controller.abort();
-    operation.currentAttempt = null;
-    this.operation = null;
-    this.publishOperation();
+    this.releaseOperation(operation);
     return true;
   }
 
@@ -402,11 +432,26 @@ export class ChatOperationController {
       (guard?.() ?? true);
 
     try {
-      return await loadConversationRequest(id, opts, {
+      const request = loadConversationRequest(id, opts, {
         state: this.state,
         signal: routeLoad.controller.signal,
         isCurrent,
       });
+      if (!opts?.timeoutMs) return await request;
+      try {
+        return await boundRequest(
+          request,
+          opts.timeoutMs,
+          "AI chat reconciliation reload timed out",
+          () => routeLoad.controller.abort(),
+        );
+      } catch (error) {
+        if (!isCurrent()) {
+          return { detail: null, aborted: true, error };
+        }
+        this.state.setLoadError(getErrorMessage(error));
+        return { detail: null, aborted: false, error };
+      }
     } finally {
       if (this.routeLoad === routeLoad) {
         this.routeLoad = null;
@@ -440,49 +485,429 @@ export class ChatOperationController {
     const attachment = this.attachment;
     const conversationId = operation?.conversationId;
     const runId = operation?.runId;
-    if (!operation || !attachment || !conversationId || !runId) return;
+    if (
+      !operation ||
+      !attachment ||
+      conversationId === null ||
+      conversationId === undefined ||
+      runId === null ||
+      runId === undefined ||
+      (operation.phase !== "streaming" && operation.phase !== "recovering")
+    ) {
+      return;
+    }
+
+    operation.phase = "stopping";
+    operation.requiresAuthoritativeResolution = true;
+    this.publishOperation();
+
+    let stopRequest: Promise<AIChatStopResponse>;
+    try {
+      stopRequest = boundRequest(
+        stopAIChatRun(conversationId, runId),
+        stopRequestTimeoutMs,
+        "AI chat Stop request timed out",
+      );
+    } catch (error) {
+      stopRequest = Promise.reject(error);
+    }
+
+    const canceledAttempt = operation.currentAttempt;
+    operation.currentAttempt = null;
+    canceledAttempt?.controller.abort();
+    this.markAssistantPresentationStopped(operation.assistantMessageId);
 
     try {
-      const result = await stopAIChatRun(conversationId, runId);
-      if (
-        !attachment.active ||
-        this.attachment !== attachment ||
-        !this.ownsOperation(operation) ||
-        operation.conversationId !== conversationId ||
-        operation.runId !== runId
-      ) {
+      const result = await stopRequest;
+      if (!this.ownsStopTarget(operation, attachment, conversationId, runId)) {
         return;
       }
-      this.finishOperation(operation);
+
       clearResumeCursor(conversationId);
       if (result.status === "stopped") {
-        this.state.setMessages((current) =>
-          current.map((message) =>
-            message.id === result.message_id
-              ? {
-                  ...message,
-                  content: result.text,
-                  status: "stopped",
-                  completed_at: new Date().toISOString(),
-                }
-              : message,
-          ),
-        );
-      } else {
-        await this.loadRouteConversation(conversationId);
+        this.state.setLoadError(null);
+        this.applyStopResult(result);
+        this.releaseOperation(operation);
+        return;
       }
+
+      await this.reconcileTerminalStopResult(
+        operation,
+        attachment,
+        conversationId,
+        runId,
+        result,
+      );
     } catch (error) {
-      if (
-        attachment.active &&
-        this.attachment === attachment &&
-        this.ownsOperation(operation) &&
-        operation.conversationId === conversationId &&
-        operation.runId === runId
-      ) {
-        showErrorToast(error, "Failed to stop AI chat response");
+      if (!this.ownsStopTarget(operation, attachment, conversationId, runId)) {
+        return;
       }
+      showErrorToast(error, "Failed to stop AI chat response");
+      await this.reconcileFailedStop(
+        operation,
+        attachment,
+        conversationId,
+        runId,
+      );
     }
   };
+
+  private ownsStopTarget(
+    operation: ChatOperation,
+    attachment: ChatControllerAttachment,
+    conversationId: number,
+    runId: number,
+  ): boolean {
+    return (
+      attachment.active &&
+      this.attachment === attachment &&
+      this.ownsOperation(operation) &&
+      operation.conversationId === conversationId &&
+      operation.runId === runId
+    );
+  }
+
+  private markAssistantPresentationStopped(messageId: number | null): void {
+    if (messageId === null) return;
+    this.state.setMessages((current) =>
+      current.map((message) =>
+        message.id === messageId && message.status === "streaming"
+          ? {
+              ...message,
+              status: "stopped",
+              completed_at: new Date().toISOString(),
+            }
+          : message,
+      ),
+    );
+  }
+
+  private restoreAssistantStreamingPresentation(
+    messageId: number | null,
+  ): void {
+    if (messageId === null) return;
+    this.state.setMessages((current) =>
+      current.map((message) =>
+        message.id === messageId && message.status === "stopped"
+          ? {
+              ...message,
+              status: "streaming",
+              completed_at: undefined,
+            }
+          : message,
+      ),
+    );
+  }
+
+  private applyStopResult(result: AIChatStopResponse): void {
+    this.state.setMessages((current) =>
+      current.map((message) =>
+        message.id === result.message_id
+          ? {
+              ...message,
+              content: result.text,
+              status: result.status,
+              completed_at: new Date().toISOString(),
+            }
+          : message,
+      ),
+    );
+  }
+
+  private async reconcileTerminalStopResult(
+    operation: ChatOperation,
+    attachment: ChatControllerAttachment,
+    conversationId: number,
+    runId: number,
+    result: AIChatStopResponse,
+  ): Promise<void> {
+    const loadResult = await this.loadConversation(
+      conversationId,
+      { timeoutMs: stopReconciliationTimeoutMs },
+      () => this.ownsStopTarget(operation, attachment, conversationId, runId),
+    );
+    if (!this.ownsStopTarget(operation, attachment, conversationId, runId)) {
+      return;
+    }
+
+    if (!loadResult.detail) {
+      this.applyStopResult(result);
+      this.releaseOperation(operation);
+      return;
+    }
+
+    const nextRun = loadResult.detail.active_run;
+    if (nextRun?.id === runId) {
+      this.applyStopResult(result);
+      this.releaseOperation(operation);
+      return;
+    }
+    if (nextRun) {
+      this.releaseOperation(operation);
+      const nextOperation = this.beginOperation(conversationId, "recovering", {
+        runId: nextRun.id,
+        assistantMessageId: nextRun.assistant_message_id,
+      });
+      if (!nextOperation) return;
+      this.keepOperationUnresolved(nextOperation);
+      await this.resumeOrRecoverAfterFailedStop(
+        loadResult.detail,
+        nextOperation,
+      );
+      return;
+    }
+
+    const streamingMessage = loadResult.detail.messages.find(
+      (message) => message.status === "streaming",
+    );
+    if (streamingMessage) {
+      operation.assistantMessageId = streamingMessage.id;
+      this.keepOperationUnresolved(operation);
+      await this.recoverAfterFailedStop(conversationId, operation);
+      return;
+    }
+
+    this.releaseOperation(operation);
+  }
+
+  private async reconcileFailedStop(
+    operation: ChatOperation,
+    attachment: ChatControllerAttachment,
+    conversationId: number,
+    runId: number,
+  ): Promise<void> {
+    const loadResult = await this.loadConversation(
+      conversationId,
+      { timeoutMs: stopReconciliationTimeoutMs },
+      () => this.ownsStopTarget(operation, attachment, conversationId, runId),
+    );
+    if (!this.ownsStopTarget(operation, attachment, conversationId, runId)) {
+      return;
+    }
+
+    if (!loadResult.detail) {
+      this.keepOperationUnresolved(operation);
+      return;
+    }
+
+    await this.reconcileLoadedAfterFailedStop(operation, loadResult.detail);
+  }
+
+  private async reconcileLoadedAfterFailedStop(
+    targetOperation: ChatOperation,
+    detail: AIChatConversationDetail,
+  ): Promise<void> {
+    if (!this.ownsOperation(targetOperation)) return;
+
+    const conversationId = detail.conversation.id;
+    const activeRun = detail.active_run;
+    if (activeRun) {
+      const operation =
+        targetOperation.runId === activeRun.id
+          ? targetOperation
+          : this.replaceRetainedOperation(targetOperation, conversationId, {
+              runId: activeRun.id,
+              assistantMessageId: activeRun.assistant_message_id,
+            });
+      if (!operation) return;
+      operation.conversationId = conversationId;
+      operation.runId = activeRun.id;
+      operation.assistantMessageId = activeRun.assistant_message_id;
+      this.keepOperationUnresolved(operation);
+      await this.resumeOrRecoverAfterFailedStop(detail, operation);
+      return;
+    }
+
+    const streamingMessage = detail.messages.find(
+      (message) => message.status === "streaming",
+    );
+    if (streamingMessage) {
+      targetOperation.conversationId = conversationId;
+      targetOperation.assistantMessageId = streamingMessage.id;
+      this.keepOperationUnresolved(targetOperation);
+      await this.recoverAfterFailedStop(conversationId, targetOperation);
+      return;
+    }
+
+    this.releaseOperation(targetOperation);
+  }
+
+  private async resumeOrRecoverAfterFailedStop(
+    detail: AIChatConversationDetail,
+    operation: ChatOperation,
+  ): Promise<void> {
+    const attempt = this.beginAttempt(operation, "resume");
+    if (!attempt) return;
+    let resumeResult: ConversationRequestResult;
+    try {
+      resumeResult = await resumeConversationRequest(
+        detail,
+        (id, opts) =>
+          this.loadConversation(id, opts, () =>
+            this.ownsAttempt(operation, attempt),
+          ),
+        { controller: this, state: this.state },
+        operation,
+        attempt,
+      );
+    } finally {
+      this.finishAttempt(operation, attempt);
+    }
+
+    if (!this.ownsOperation(operation) || resumeResult.aborted) return;
+    if (
+      resumeResult.detail &&
+      !this.isConversationTerminal(resumeResult.detail)
+    ) {
+      const activeRun = resumeResult.detail.active_run;
+      if (activeRun) {
+        const retainedOperation =
+          operation.runId === activeRun.id
+            ? operation
+            : this.replaceRetainedOperation(
+                operation,
+                resumeResult.detail.conversation.id,
+                {
+                  runId: activeRun.id,
+                  assistantMessageId: activeRun.assistant_message_id,
+                },
+              );
+        if (!retainedOperation) return;
+        retainedOperation.runId = activeRun.id;
+        retainedOperation.assistantMessageId = activeRun.assistant_message_id;
+        this.keepOperationUnresolved(retainedOperation);
+        if (retainedOperation === operation) {
+          await this.recoverAfterFailedStop(
+            resumeResult.detail.conversation.id,
+            retainedOperation,
+          );
+        } else {
+          await this.resumeOrRecoverAfterFailedStop(
+            resumeResult.detail,
+            retainedOperation,
+          );
+        }
+        return;
+      }
+
+      const streamingMessage = resumeResult.detail.messages.find(
+        (message) => message.status === "streaming",
+      );
+      if (streamingMessage) {
+        operation.assistantMessageId = streamingMessage.id;
+        this.keepOperationUnresolved(operation);
+        await this.recoverAfterFailedStop(
+          resumeResult.detail.conversation.id,
+          operation,
+        );
+        return;
+      }
+    }
+
+    if (
+      resumeResult.terminalStatus ||
+      (resumeResult.detail && this.isConversationTerminal(resumeResult.detail))
+    ) {
+      const outcome = resumeResult.terminalStatus
+        ? resumeResult.terminalStatus === "failed"
+          ? "recovered_failed"
+          : "recovered_completed"
+        : classifyRecoveryOutcome({
+            messages: resumeResult.detail?.messages,
+            error: resumeResult.error,
+          });
+      this.recordTelemetry({ category: "recovery", outcome });
+      this.releaseOperation(operation);
+      return;
+    }
+
+    await this.recoverAfterFailedStop(detail.conversation.id, operation);
+  }
+
+  private async recoverAfterFailedStop(
+    conversationId: number,
+    operation: ChatOperation,
+  ): Promise<void> {
+    const recoveryResult = await this.recoverOpenedConversation(
+      conversationId,
+      operation,
+    );
+    if (!this.ownsOperation(operation) || recoveryResult.aborted) return;
+
+    if (!recoveryResult.detail) {
+      this.keepOperationUnresolved(operation);
+      return;
+    }
+
+    const activeRun = recoveryResult.detail.active_run;
+    if (activeRun) {
+      const retainedOperation =
+        operation.runId === activeRun.id
+          ? operation
+          : this.replaceRetainedOperation(
+              operation,
+              recoveryResult.detail.conversation.id,
+              {
+                runId: activeRun.id,
+                assistantMessageId: activeRun.assistant_message_id,
+              },
+            );
+      if (!retainedOperation) return;
+      retainedOperation.runId = activeRun.id;
+      retainedOperation.assistantMessageId = activeRun.assistant_message_id;
+      this.keepOperationUnresolved(retainedOperation);
+      return;
+    }
+
+    const streamingMessage = recoveryResult.detail.messages.find(
+      (message) => message.status === "streaming",
+    );
+    if (streamingMessage) {
+      operation.assistantMessageId = streamingMessage.id;
+      this.keepOperationUnresolved(operation);
+      return;
+    }
+
+    this.releaseOperation(operation);
+  }
+
+  private replaceRetainedOperation(
+    operation: ChatOperation,
+    conversationId: number,
+    activeRun: { runId: number; assistantMessageId: number | null },
+  ): ChatOperation | null {
+    if (!this.ownsOperation(operation)) return null;
+    operation.currentAttempt?.controller.abort();
+    operation.currentAttempt = null;
+    const replacement: ChatOperation = {
+      attachment: operation.attachment,
+      conversationId,
+      runId: activeRun.runId,
+      assistantMessageId: activeRun.assistantMessageId,
+      phase: "recovering",
+      currentAttempt: null,
+      adoptedConversationId: null,
+      requiresAuthoritativeResolution: true,
+    };
+    this.operation = replacement;
+    this.publishOperation();
+    return replacement;
+  }
+
+  private keepOperationUnresolved(operation: ChatOperation): void {
+    if (!this.ownsOperation(operation)) return;
+    operation.phase = "recovering";
+    operation.requiresAuthoritativeResolution = true;
+    this.restoreAssistantStreamingPresentation(operation.assistantMessageId);
+    this.publishOperation();
+  }
+
+  private isConversationTerminal(detail: AIChatConversationDetail): boolean {
+    return (
+      !detail.active_run &&
+      !detail.messages.some((message) => message.status === "streaming")
+    );
+  }
 
   private async resumeOrRecoverActiveRun(
     conversationId: number,
@@ -508,6 +933,16 @@ export class ChatOperationController {
     }
 
     if (!this.ownsOperation(operation)) return;
+    if (!resumeResult.aborted && resumeResult.terminalStatus) {
+      this.recordTelemetry({
+        category: "recovery",
+        outcome:
+          resumeResult.terminalStatus === "failed"
+            ? "recovered_failed"
+            : "recovered_completed",
+      });
+      return;
+    }
     if (!resumeResult.aborted && resumeResult.detail) {
       const resumeOutcome = classifyRecoveryOutcome({
         messages: resumeResult.detail.messages,
@@ -543,8 +978,8 @@ export class ChatOperationController {
   private async recoverOpenedConversation(
     id: number,
     operation: ChatOperation,
-  ): Promise<void> {
-    await recoverLoadedConversation({
+  ) {
+    return recoverLoadedConversation({
       id,
       recoverConversation: (conversationId, opts) =>
         this.recoverConversation(conversationId, operation, opts),
@@ -572,6 +1007,15 @@ export class ChatOperationController {
     operation.currentAttempt = null;
     this.operation = null;
     this.publishOperation();
+  }
+
+  private releaseOperation(operation: ChatOperation): boolean {
+    if (!this.ownsOperation(operation)) return false;
+    operation.currentAttempt?.controller.abort();
+    operation.currentAttempt = null;
+    this.operation = null;
+    this.publishOperation();
+    return true;
   }
 
   private abortRouteLoad(): void {

--- a/client/src/features/chat/utils/chat-session-recovery.ts
+++ b/client/src/features/chat/utils/chat-session-recovery.ts
@@ -226,7 +226,15 @@ export async function resumeConversation(
     const refreshed = await loadConversation(detail.conversation.id, {
       silent: true,
     });
-    if (!streamResult.endedWithError) return refreshed;
+    const terminalStatus =
+      streamResult.doneEvent?.type === "done"
+        ? (streamResult.doneEvent.status ?? "completed")
+        : streamResult.doneEvent?.type === "error"
+          ? "failed"
+          : undefined;
+    if (!streamResult.endedWithError) {
+      return { ...refreshed, terminalStatus };
+    }
 
     return {
       detail: refreshed.detail,
@@ -238,6 +246,7 @@ export async function resumeConversation(
             ? streamResult.doneEvent.message
             : "AI chat resume failed",
         ),
+      terminalStatus,
     };
   } catch (error) {
     if (
@@ -271,19 +280,23 @@ export async function recoverLoadedConversation({
   recordTelemetry({ category: "recovery", outcome: recoveryOutcome });
 
   if (
-    recoveryOutcome === "recovered_completed" ||
-    recoveryOutcome === "recovery_aborted"
+    recoveryOutcome !== "recovered_completed" &&
+    recoveryOutcome !== "recovery_aborted"
   ) {
-    return;
+    const recoveryError =
+      recoveryResult.error ??
+      new Error("Failed to recover AI chat conversation");
+    recordTelemetry({ category: "ux", outcome: "failure_toast_shown" });
+    if (!recoveryResult.detail) {
+      setLoadError(
+        getErrorMessage(
+          recoveryError,
+          "Failed to recover AI chat conversation",
+        ),
+      );
+    }
+    showErrorToast(recoveryError, "Failed to recover AI chat conversation");
   }
 
-  const recoveryError =
-    recoveryResult.error ?? new Error("Failed to recover AI chat conversation");
-  recordTelemetry({ category: "ux", outcome: "failure_toast_shown" });
-  if (!recoveryResult.detail) {
-    setLoadError(
-      getErrorMessage(recoveryError, "Failed to recover AI chat conversation"),
-    );
-  }
-  showErrorToast(recoveryError, "Failed to recover AI chat conversation");
+  return recoveryResult;
 }

--- a/client/src/features/chat/utils/chat-session-types.ts
+++ b/client/src/features/chat/utils/chat-session-types.ts
@@ -10,10 +10,12 @@ export type ConversationRequestResult = {
   detail: AIChatConversationDetail | null;
   aborted: boolean;
   error?: unknown;
+  terminalStatus?: Exclude<AIChatMessage["status"], "streaming">;
 };
 
 export type ConversationRequestOptions = {
   silent?: boolean;
+  timeoutMs?: number;
 };
 
 /** React state owned by useAIChatSession and updated by chat workflows. */


### PR DESCRIPTION
## Summary
- stop visible AI chat streaming immediately while durable Stop runs independently
- reconcile stopped/completed/failed outcomes and retain unresolved runs for retry
- bound Stop and reconciliation requests and harden stale callback, replacement-run, route, and unmount races
- add focused controller, hook, and page regression coverage

## Verification
- chat feature tests: 176 passed across 20 files
- TypeScript passed
- lint passed with 0 warnings/errors
- formatting passed
- git diff check passed
- final autoreview clean after 6 accepted findings were fixed

## Scope
- client only; backend unchanged
- hook public API unchanged
- explicit Retry recovery UI remains out of scope