### PR TITLE
feat(client): add conversation delete UI

### DIFF
--- a/client/src/features/chat/api/ai-chat.ts
+++ b/client/src/features/chat/api/ai-chat.ts
@@ -1,4 +1,5 @@
 import {
+  deleteAiConversationsById,
   getAiConversations,
   getAiConversationsById,
   postAiChatTelemetry,
@@ -257,6 +258,23 @@ export async function listAIChatConversations(
   });
 
   return response.data as AIChatConversationSummary[];
+}
+
+export type AIChatDeleteError = ApiError & { status: number };
+
+export async function deleteAIChatConversation(
+  conversationId: number,
+): Promise<void> {
+  const response = await deleteAiConversationsById({
+    path: { id: conversationId },
+  });
+
+  if (response.error) {
+    throw {
+      ...(response.error as ApiError),
+      status: response.response?.status ?? 0,
+    } satisfies AIChatDeleteError;
+  }
 }
 
 export async function reportAIChatTelemetry(

--- a/client/src/features/chat/components/chat-history-entry.tsx
+++ b/client/src/features/chat/components/chat-history-entry.tsx
@@ -1,12 +1,31 @@
+import { useState } from "react";
 import {
   History,
   MessageSquare,
+  MoreHorizontal,
   PanelLeftClose,
   PanelLeftOpen,
   Plus,
   SquarePen,
+  Trash2,
 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Drawer,
   DrawerContent,
@@ -46,6 +65,7 @@ type ChatHistoryEntryProps = {
   onMobileOpenChange: (open: boolean) => void;
   onToggleCollapsed: () => void;
   onResumeConversation: (conversationId: number) => void;
+  onDeleteConversation?: (conversationId: number) => Promise<void>;
   onNewChat: () => void;
   isNewChatDisabled?: boolean;
 };
@@ -83,9 +103,14 @@ export function ChatHistoryEntry({
   onMobileOpenChange,
   onToggleCollapsed,
   onResumeConversation,
+  onDeleteConversation,
   onNewChat,
   isNewChatDisabled,
 }: ChatHistoryEntryProps) {
+  const [deleteCandidate, setDeleteCandidate] =
+    useState<AIChatConversationSummary | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
   function handleResumeConversation(conversationId: number) {
     onResumeConversation(conversationId);
     onMobileOpenChange(false);
@@ -96,6 +121,22 @@ export function ChatHistoryEntry({
     onMobileOpenChange(false);
   }
 
+  async function handleConfirmDelete() {
+    if (!deleteCandidate || !onDeleteConversation || isDeleting) return;
+
+    setIsDeleting(true);
+    try {
+      await onDeleteConversation(deleteCandidate.id);
+      setDeleteCandidate(null);
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  const deleteCandidateTitle = deleteCandidate
+    ? getConversationTitle(deleteCandidate)
+    : "this chat";
+
   return (
     <>
       <DesktopHistoryPanel
@@ -103,6 +144,8 @@ export function ChatHistoryEntry({
         isCollapsed={isCollapsed}
         onToggleCollapsed={onToggleCollapsed}
         onResumeConversation={onResumeConversation}
+        onDeleteConversation={onDeleteConversation}
+        onRequestDelete={setDeleteCandidate}
         onNewChat={onNewChat}
         isNewChatDisabled={isNewChatDisabled}
       />
@@ -121,6 +164,8 @@ export function ChatHistoryEntry({
             <HistoryList
               historyState={historyState}
               onResumeConversation={handleResumeConversation}
+              onDeleteConversation={onDeleteConversation}
+              onRequestDelete={setDeleteCandidate}
             />
             <Button
               type="button"
@@ -135,6 +180,35 @@ export function ChatHistoryEntry({
           </div>
         </DrawerContent>
       </Drawer>
+      <AlertDialog
+        open={deleteCandidate !== null}
+        onOpenChange={(open) => {
+          if (!open && !isDeleting) setDeleteCandidate(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete chat?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete “{deleteCandidateTitle}”? This permanently removes the chat
+              and its messages. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-white hover:bg-destructive/90"
+              disabled={isDeleting}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleConfirmDelete();
+              }}
+            >
+              {isDeleting ? "Deleting..." : "Delete chat"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }
@@ -144,9 +218,13 @@ function DesktopHistoryPanel({
   isCollapsed,
   onToggleCollapsed,
   onResumeConversation,
+  onDeleteConversation,
+  onRequestDelete,
   onNewChat,
   isNewChatDisabled,
-}: Omit<ChatHistoryEntryProps, "isMobileOpen" | "onMobileOpenChange">) {
+}: Omit<ChatHistoryEntryProps, "isMobileOpen" | "onMobileOpenChange"> & {
+  onRequestDelete: (conversation: AIChatConversationSummary) => void;
+}) {
   if (isCollapsed) {
     return (
       <aside
@@ -201,6 +279,8 @@ function DesktopHistoryPanel({
         <HistoryList
           historyState={historyState}
           onResumeConversation={onResumeConversation}
+          onDeleteConversation={onDeleteConversation}
+          onRequestDelete={onRequestDelete}
         />
       </div>
       <div className="border-t p-3">
@@ -222,9 +302,13 @@ function DesktopHistoryPanel({
 function HistoryList({
   historyState,
   onResumeConversation,
+  onDeleteConversation,
+  onRequestDelete,
 }: {
   historyState: ChatHistoryListState;
   onResumeConversation: (conversationId: number) => void;
+  onDeleteConversation?: (conversationId: number) => Promise<void>;
+  onRequestDelete: (conversation: AIChatConversationSummary) => void;
 }) {
   switch (historyState.status) {
     case "loading":
@@ -252,31 +336,59 @@ function HistoryList({
             const isActive =
               conversation.id === historyState.activeConversationId;
 
+            const title = getConversationTitle(conversation);
+
             return (
-              <button
+              <div
                 key={conversation.id}
-                type="button"
-                onClick={() => onResumeConversation(conversation.id)}
-                aria-current={isActive ? "page" : undefined}
                 className={cn(
-                  "flex w-full items-start gap-3 rounded-md px-3 py-2.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
+                  "group flex w-full items-stretch rounded-md transition-colors hover:bg-accent hover:text-accent-foreground",
                   isActive && "bg-accent text-accent-foreground",
                 )}
               >
-                <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                  <MessageSquare className="size-4" />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-sm font-medium">
-                    {conversation.title?.trim() || `Chat #${conversation.id}`}
+                <button
+                  type="button"
+                  onClick={() => onResumeConversation(conversation.id)}
+                  aria-current={isActive ? "page" : undefined}
+                  className="flex min-w-0 flex-1 items-start gap-3 rounded-l-md px-3 py-2.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                    <MessageSquare className="size-4" />
                   </span>
-                  <span className="block truncate text-xs text-muted-foreground">
-                    {isActive
-                      ? "Current conversation"
-                      : formatConversationTimestamp(conversation)}
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">
+                      {title}
+                    </span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {isActive
+                        ? "Current conversation"
+                        : formatConversationTimestamp(conversation)}
+                    </span>
                   </span>
-                </span>
-              </button>
+                </button>
+                {onDeleteConversation ? (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label={`More options for ${title}`}
+                        className="my-1 mr-1 flex w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      >
+                        <MoreHorizontal className="size-4" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        variant="destructive"
+                        onSelect={() => onRequestDelete(conversation)}
+                      >
+                        <Trash2 />
+                        Delete chat
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                ) : null}
+              </div>
             );
           })}
         </div>
@@ -285,6 +397,10 @@ function HistoryList({
 
   const exhaustiveCheck: never = historyState;
   return exhaustiveCheck;
+}
+
+function getConversationTitle(conversation: AIChatConversationSummary): string {
+  return conversation.title?.trim() || `Chat #${conversation.id}`;
 }
 
 function formatConversationTimestamp(

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -8,6 +8,7 @@ import {
   deferredPromise,
   getRenderedChatDraftStore,
   mockCreateConversation,
+  mockDeleteConversation,
   mockGetConversation,
   mockListConversations,
   mockNavigate,
@@ -18,12 +19,200 @@ import {
   mockSearch,
   mockShowErrorToast,
   mockStopRun,
+  mockToastError,
   mockStreamMessage,
   resetChatRouteMocks,
 } from "../test/chat-page-test-utils";
 
 describe("ChatRouteComponent", () => {
   beforeEach(resetChatRouteMocks);
+
+  it("deletes an inactive chat only after confirmation and refreshes history", async () => {
+    const user = userEvent.setup();
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+    mockListConversations
+      .mockResolvedValueOnce([
+        {
+          id: 41,
+          title: "Current plan",
+          created_at: "2026-06-25T17:00:00Z",
+          updated_at: "2026-06-25T17:05:00Z",
+        },
+        {
+          id: 72,
+          title: "Leg day plan",
+          created_at: "2026-06-24T17:00:00Z",
+          updated_at: "2026-06-24T17:05:00Z",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 41,
+          title: "Current plan",
+          created_at: "2026-06-25T17:00:00Z",
+          updated_at: "2026-06-25T17:05:00Z",
+        },
+      ]);
+
+    render(<ChatRouteComponent />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "More options for Leg day plan",
+      }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Delete chat" }));
+    expect(mockDeleteConversation).not.toHaveBeenCalled();
+    expect(screen.getByText(/Delete “Leg day plan”/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Delete chat" }));
+
+    await waitFor(() =>
+      expect(mockDeleteConversation).toHaveBeenCalledWith(72),
+    );
+    expect(await screen.findByText("Current plan")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText("Leg day plan")).not.toBeInTheDocument(),
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockStopRun).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when chat deletion is cancelled", async () => {
+    const user = userEvent.setup();
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+    mockListConversations.mockResolvedValue([
+      {
+        id: 72,
+        title: "Leg day plan",
+        created_at: "2026-06-24T17:00:00Z",
+        updated_at: "2026-06-24T17:05:00Z",
+      },
+    ]);
+
+    render(<ChatRouteComponent />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "More options for Leg day plan",
+      }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Delete chat" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockDeleteConversation).not.toHaveBeenCalled();
+    expect(mockListConversations).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Leg day plan")).toBeInTheDocument();
+  });
+
+  it("keeps a chat when deletion conflicts with an active response", async () => {
+    const user = userEvent.setup();
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+    mockListConversations.mockResolvedValue([
+      {
+        id: 72,
+        title: "Streaming plan",
+        created_at: "2026-06-24T17:00:00Z",
+        updated_at: "2026-06-24T17:05:00Z",
+      },
+    ]);
+    mockDeleteConversation.mockRejectedValue({
+      status: 409,
+      message: "conversation has an active run",
+    });
+
+    render(<ChatRouteComponent />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "More options for Streaming plan",
+      }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Delete chat" }));
+    await user.click(screen.getByRole("button", { name: "Delete chat" }));
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Stop the response before deleting this chat, then try again.",
+      ),
+    );
+    expect(screen.getByText("Streaming plan")).toBeInTheDocument();
+    expect(mockListConversations).toHaveBeenCalledTimes(1);
+    expect(mockStopRun).not.toHaveBeenCalled();
+  });
+
+  it("clears the active chat draft and opens a blank new chat after deletion", async () => {
+    const user = userEvent.setup();
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+    mockListConversations.mockResolvedValue([
+      {
+        id: 41,
+        title: "Current plan",
+        created_at: "2026-06-25T17:00:00Z",
+        updated_at: "2026-06-25T17:05:00Z",
+      },
+    ]);
+
+    render(<ChatRouteComponent />);
+    await screen.findByText("Current plan");
+    const store = getRenderedChatDraftStore();
+    store.setDraft({ type: "conversation", conversationId: 41 }, "private");
+
+    await user.click(
+      screen.getByRole("button", { name: "More options for Current plan" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Delete chat" }));
+    await user.click(screen.getByRole("button", { name: "Delete chat" }));
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/chat",
+        search: { createChat: true },
+      }),
+    );
+    expect(store.getDraft({ type: "conversation", conversationId: 41 })).toBe(
+      "",
+    );
+    expect(store.resolveMainDestination()).toEqual({ type: "new" });
+    expect(mockListConversations).toHaveBeenCalledTimes(1);
+    expect(mockStopRun).not.toHaveBeenCalled();
+  });
+
+  it("quietly refreshes history when a deleted chat is already missing", async () => {
+    const user = userEvent.setup();
+    mockGetConversation.mockResolvedValue(conversationDetail([]));
+    mockListConversations
+      .mockResolvedValueOnce([
+        {
+          id: 72,
+          title: "Already gone",
+          created_at: "2026-06-24T17:00:00Z",
+          updated_at: "2026-06-24T17:05:00Z",
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    mockDeleteConversation.mockRejectedValue({
+      status: 404,
+      message: "conversation not found",
+    });
+
+    render(<ChatRouteComponent />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "More options for Already gone",
+      }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Delete chat" }));
+    await user.click(screen.getByRole("button", { name: "Delete chat" }));
+
+    await waitFor(() =>
+      expect(screen.queryByText("Already gone")).not.toBeInTheDocument(),
+    );
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockShowErrorToast).not.toHaveBeenCalled();
+    expect(mockListConversations).toHaveBeenCalledTimes(2);
+  });
 
   it("opens blank New Chat when entering without an eligible draft", async () => {
     mockSearch.conversationId = undefined;

--- a/client/src/features/chat/pages/chat-page.test.tsx
+++ b/client/src/features/chat/pages/chat-page.test.tsx
@@ -24,6 +24,8 @@ import {
   resetChatRouteMocks,
 } from "../test/chat-page-test-utils";
 
+HTMLElement.prototype.setPointerCapture ??= () => {};
+
 describe("ChatRouteComponent", () => {
   beforeEach(resetChatRouteMocks);
 
@@ -56,8 +58,11 @@ describe("ChatRouteComponent", () => {
 
     render(<ChatRouteComponent />);
 
+    await screen.findByText("Leg day plan");
+    await user.click(screen.getByRole("button", { name: "Open chat history" }));
+    const drawer = await screen.findByRole("dialog", { name: "Chat history" });
     await user.click(
-      await screen.findByRole("button", {
+      within(drawer).getByRole("button", {
         name: "More options for Leg day plan",
       }),
     );
@@ -70,10 +75,13 @@ describe("ChatRouteComponent", () => {
     await waitFor(() =>
       expect(mockDeleteConversation).toHaveBeenCalledWith(72),
     );
-    expect(await screen.findByText("Current plan")).toBeInTheDocument();
+    expect(within(drawer).getByText("Current plan")).toBeInTheDocument();
     await waitFor(() =>
-      expect(screen.queryByText("Leg day plan")).not.toBeInTheDocument(),
+      expect(
+        within(drawer).queryByText("Leg day plan"),
+      ).not.toBeInTheDocument(),
     );
+    expect(drawer).toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(mockStopRun).not.toHaveBeenCalled();
   });
@@ -144,22 +152,28 @@ describe("ChatRouteComponent", () => {
   it("clears the active chat draft and opens a blank new chat after deletion", async () => {
     const user = userEvent.setup();
     mockGetConversation.mockResolvedValue(conversationDetail([]));
-    mockListConversations.mockResolvedValue([
-      {
-        id: 41,
-        title: "Current plan",
-        created_at: "2026-06-25T17:00:00Z",
-        updated_at: "2026-06-25T17:05:00Z",
-      },
-    ]);
+    mockListConversations
+      .mockResolvedValueOnce([
+        {
+          id: 41,
+          title: "Current plan",
+          created_at: "2026-06-25T17:00:00Z",
+          updated_at: "2026-06-25T17:05:00Z",
+        },
+      ])
+      .mockResolvedValueOnce([]);
 
     render(<ChatRouteComponent />);
     await screen.findByText("Current plan");
     const store = getRenderedChatDraftStore();
     store.setDraft({ type: "conversation", conversationId: 41 }, "private");
 
+    await user.click(screen.getByRole("button", { name: "Open chat history" }));
+    const drawer = await screen.findByRole("dialog", { name: "Chat history" });
     await user.click(
-      screen.getByRole("button", { name: "More options for Current plan" }),
+      within(drawer).getByRole("button", {
+        name: "More options for Current plan",
+      }),
     );
     await user.click(screen.getByRole("menuitem", { name: "Delete chat" }));
     await user.click(screen.getByRole("button", { name: "Delete chat" }));
@@ -174,7 +188,11 @@ describe("ChatRouteComponent", () => {
       "",
     );
     expect(store.resolveMainDestination()).toEqual({ type: "new" });
-    expect(mockListConversations).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByText("Current plan")).not.toBeInTheDocument();
+      expect(drawer).toHaveAttribute("data-state", "closed");
+    });
+    expect(mockListConversations).toHaveBeenCalledTimes(2);
     expect(mockStopRun).not.toHaveBeenCalled();
   });
 

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -3,11 +3,14 @@ import { History } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import type {
-  AIChatMessage,
-  AIWorkoutDraft,
+import {
+  deleteAIChatConversation,
+  type AIChatDeleteError,
+  type AIChatMessage,
+  type AIWorkoutDraft,
 } from "@/features/chat/api/ai-chat";
 import { saveAIWorkoutDraftToWorkoutForm } from "@/features/chat/utils/ai-workout-draft";
+import { showErrorToast } from "@/lib/errors";
 import { workoutDraftStorage } from "@/lib/local-storage";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
@@ -202,6 +205,38 @@ export function ChatPage({
   function handleResumeConversation(selectedConversationId: number) {
     chatDraftStore.openConversation(selectedConversationId);
     openConversation(selectedConversationId);
+  }
+
+  async function handleDeleteConversation(selectedConversationId: number) {
+    try {
+      await deleteAIChatConversation(selectedConversationId);
+    } catch (error: unknown) {
+      if (isAIChatDeleteError(error, 404)) {
+        await historyEntry.refreshConversations();
+        return;
+      }
+      if (isAIChatDeleteError(error, 409)) {
+        toast.error(
+          "Stop the response before deleting this chat, then try again.",
+        );
+        return;
+      }
+
+      showErrorToast(error, "Could not delete this chat.");
+      return;
+    }
+
+    if (selectedConversationId === conversationId) {
+      chatDraftStore.setDraft(
+        { type: "conversation", conversationId: selectedConversationId },
+        "",
+      );
+      chatDraftStore.startNewChat();
+      await navigate({ to: "/chat", search: { createChat: true } });
+      return;
+    }
+
+    await historyEntry.refreshConversations();
   }
 
   async function handleSubmit() {
@@ -404,6 +439,9 @@ export function ChatPage({
             historyEntry.setIsCollapsed((value) => !value)
           }
           onResumeConversation={handleResumeConversation}
+          onDeleteConversation={
+            hasChatAccess ? handleDeleteConversation : undefined
+          }
           onNewChat={handleNewChat}
           isNewChatDisabled={billingAccess.isCheckingAccess || !hasChatAccess}
         />
@@ -486,6 +524,18 @@ export function ChatPage({
         </div>
       </div>
     </div>
+  );
+}
+
+function isAIChatDeleteError(
+  error: unknown,
+  status: number,
+): error is AIChatDeleteError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    error.status === status
   );
 }
 

--- a/client/src/features/chat/pages/chat-page.tsx
+++ b/client/src/features/chat/pages/chat-page.tsx
@@ -233,6 +233,8 @@ export function ChatPage({
       );
       chatDraftStore.startNewChat();
       await navigate({ to: "/chat", search: { createChat: true } });
+      historyEntry.setIsMobileOpen(false);
+      await historyEntry.refreshConversations();
       return;
     }
 

--- a/client/src/features/chat/test/chat-page-test-utils.tsx
+++ b/client/src/features/chat/test/chat-page-test-utils.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   },
   mockNavigate: vi.fn(),
   mockCreateConversation: vi.fn(),
+  mockDeleteConversation: vi.fn(),
   mockGetConversation: vi.fn(),
   mockListConversations: vi.fn(),
   mockPollConversation: vi.fn(),
@@ -29,6 +30,7 @@ const mocks = vi.hoisted(() => ({
   mockStopRun: vi.fn(),
   mockStreamMessage: vi.fn(),
   mockShowErrorToast: vi.fn(),
+  mockToastError: vi.fn(),
   mockToastSuccess: vi.fn(),
   mockBillingStatusQueryOptions: vi.fn(),
   mockFeatureAccessQueryOptions: vi.fn(),
@@ -53,6 +55,7 @@ export const {
   mockSearch,
   mockNavigate,
   mockCreateConversation,
+  mockDeleteConversation,
   mockGetConversation,
   mockListConversations,
   mockPollConversation,
@@ -63,6 +66,7 @@ export const {
   mockStopRun,
   mockStreamMessage,
   mockShowErrorToast,
+  mockToastError,
   mockToastSuccess,
   mockBillingStatusQueryOptions,
   mockFeatureAccessQueryOptions,
@@ -94,6 +98,7 @@ vi.mock("@tanstack/react-router", () => ({
 
 vi.mock("@/features/chat/api/ai-chat", () => ({
   createAIChatConversation: mockCreateConversation,
+  deleteAIChatConversation: mockDeleteConversation,
   getAIChatConversation: mockGetConversation,
   listAIChatConversations: mockListConversations,
   pollAIChatConversationUntilSettled: mockPollConversation,
@@ -136,6 +141,7 @@ vi.mock("@/lib/errors", () => ({
 
 vi.mock("sonner", () => ({
   toast: {
+    error: mockToastError,
     success: mockToastSuccess,
   },
 }));
@@ -223,6 +229,7 @@ export function resetChatRouteMocks() {
   mockSearch.billing = undefined;
   mockNavigate.mockReset();
   mockCreateConversation.mockReset();
+  mockDeleteConversation.mockReset();
   mockGetConversation.mockReset();
   mockListConversations.mockReset();
   mockPollConversation.mockReset();
@@ -233,6 +240,7 @@ export function resetChatRouteMocks() {
   mockStopRun.mockReset();
   mockStreamMessage.mockReset();
   mockShowErrorToast.mockReset();
+  mockToastError.mockReset();
   mockToastSuccess.mockReset();
   mockBillingStatusQueryOptions.mockReset();
   mockFeatureAccessQueryOptions.mockReset();
@@ -348,6 +356,7 @@ export function resetChatRouteMocks() {
     }),
   );
   mockReportTelemetry.mockResolvedValue(undefined);
+  mockDeleteConversation.mockResolvedValue(undefined);
   mockListConversations.mockResolvedValue([]);
   mockResumeStream.mockResolvedValue({
     doneEvent: {


### PR DESCRIPTION
## Summary

Adds client-only conversation deletion for currently entitled AI chat users.

## Pinned behavior

1. Adds a three-dot overflow menu with a destructive **Delete chat** item to every history row in the shared desktop-sidebar and mobile-drawer list.
2. Requires an AlertDialog confirmation naming the conversation title, with safe Cancel and destructive confirmation actions.
3. Never calls the stop API or implicitly stops generation from the delete flow.
4. Handles HTTP 409 by explaining that the response must be stopped first, leaving the conversation and history intact.
5. Refreshes history after deleting an inactive conversation without changing the active route, stream, draft, or composer state.
6. On active-conversation deletion, clears that conversation's stored draft, marks the explicit draft destination as new, and navigates to the explicit blank new chat search state.
7. Treats HTTP 404/repeated deletion as already deleted: refreshes history quietly without an alarming toast.
8. Preserves entitlement/account boundaries and existing navigation, draft, Stop, mobile/PWA, and accessibility behavior. Resume and overflow controls are sibling buttons; the active resume control retains `aria-current="page"`; the overflow label names the conversation; Radix menu/dialog focus management and destructive semantics are used.
9. Does not add deletion for former subscribers/non-entitled users and does not change entitlement policy.
10. Adds rendered page/history regression coverage for success after confirmation, cancellation, 409, active deletion/draft clearing/blank navigation, and quiet 404 refresh.

No backend code or generated OpenAPI client files were changed.

## Test evidence

- `bun run test -- src/features/chat/components/chat-history-entry.test.tsx src/features/chat/pages/chat-page.test.tsx` — 2 files, 28 tests passed
- `bun run test` — 77 files, 438 tests passed
- `bun run tsc` — passed
- `bun run lint` — passed with 0 warnings/errors
- `bun run fmt:check` — passed
- `bun run build` — passed (Vite/PWA production build; chunk-size advisory only)
- `git diff --check` — passed

## Verification note

Browser verification was NOT performed and is delegated to the head orchestrator.
