### PR TITLE
fix: discard invalid zero-rep sets

### DIFF
--- a/client/src/features/workouts/components/form/__tests__/add-set-dialog.test.tsx
+++ b/client/src/features/workouts/components/form/__tests__/add-set-dialog.test.tsx
@@ -102,6 +102,25 @@ describe("AddSetDialog", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it("dismisses a weight-only invalid set by removing it", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onRemoveSet = vi.fn();
+
+    render(
+      <AddSetDialogHarness
+        initialSet={{ weight: 135, reps: 0, setType: "working" }}
+        onClose={onClose}
+        onRemoveSet={onRemoveSet}
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Close" }));
+
+    expect(onRemoveSet).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it("dismisses a populated set without removing it", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();

--- a/client/src/features/workouts/components/form/__tests__/add-set-dialog.test.tsx
+++ b/client/src/features/workouts/components/form/__tests__/add-set-dialog.test.tsx
@@ -13,11 +13,13 @@ type SetValue = {
 function AddSetDialogHarness({
   initialSet,
   onClose = vi.fn(),
+  onDiscardInvalidSet = vi.fn(),
   onRemoveSet = vi.fn(),
   onSaveSet = vi.fn(),
 }: {
   initialSet: SetValue;
   onClose?: ReturnType<typeof vi.fn>;
+  onDiscardInvalidSet?: ReturnType<typeof vi.fn>;
   onRemoveSet?: ReturnType<typeof vi.fn>;
   onSaveSet?: ReturnType<typeof vi.fn>;
 }) {
@@ -42,6 +44,7 @@ function AddSetDialogHarness({
       exerciseIndex={0}
       setIndex={0}
       onClose={onClose}
+      onDiscardInvalidSet={onDiscardInvalidSet}
       onRemoveSet={onRemoveSet}
       onSaveSet={onSaveSet}
     />
@@ -83,53 +86,61 @@ describe("AddSetDialog", () => {
     expect(onSaveSet).toHaveBeenCalledTimes(1);
   });
 
-  it("dismisses an empty set by removing it", async () => {
+  it("dismisses an empty set by discarding it", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
+    const onDiscardInvalidSet = vi.fn();
     const onRemoveSet = vi.fn();
 
     render(
       <AddSetDialogHarness
         initialSet={{ weight: 0, reps: 0, setType: "working" }}
         onClose={onClose}
+        onDiscardInvalidSet={onDiscardInvalidSet}
         onRemoveSet={onRemoveSet}
       />,
     );
 
     await user.click(await screen.findByRole("button", { name: "Close" }));
 
-    expect(onRemoveSet).toHaveBeenCalledTimes(1);
+    expect(onDiscardInvalidSet).toHaveBeenCalledTimes(1);
+    expect(onRemoveSet).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("dismisses a weight-only invalid set by removing it", async () => {
+  it("dismisses a weight-only invalid set by discarding it", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
+    const onDiscardInvalidSet = vi.fn();
     const onRemoveSet = vi.fn();
 
     render(
       <AddSetDialogHarness
         initialSet={{ weight: 135, reps: 0, setType: "working" }}
         onClose={onClose}
+        onDiscardInvalidSet={onDiscardInvalidSet}
         onRemoveSet={onRemoveSet}
       />,
     );
 
     await user.click(await screen.findByRole("button", { name: "Close" }));
 
-    expect(onRemoveSet).toHaveBeenCalledTimes(1);
+    expect(onDiscardInvalidSet).toHaveBeenCalledTimes(1);
+    expect(onRemoveSet).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
   });
 
   it("dismisses a populated set without removing it", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
+    const onDiscardInvalidSet = vi.fn();
     const onRemoveSet = vi.fn();
 
     render(
       <AddSetDialogHarness
         initialSet={{ weight: 135, reps: 5, setType: "working" }}
         onClose={onClose}
+        onDiscardInvalidSet={onDiscardInvalidSet}
         onRemoveSet={onRemoveSet}
       />,
     );
@@ -141,6 +152,7 @@ describe("AddSetDialog", () => {
     await user.click(screen.getByRole("button", { name: "Close" }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onDiscardInvalidSet).not.toHaveBeenCalled();
     expect(onRemoveSet).not.toHaveBeenCalled();
   });
 });

--- a/client/src/features/workouts/components/form/__tests__/exercise-screen.test.tsx
+++ b/client/src/features/workouts/components/form/__tests__/exercise-screen.test.tsx
@@ -84,3 +84,80 @@ describe("ExerciseSets repeat button", () => {
     expect(cards[cards.length - 1]).toHaveTextContent("185lb × 3");
   });
 });
+
+describe("ExerciseSets in an existing workout", () => {
+  it("restores an existing set when invalid reps are dismissed", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExerciseSetsHarness
+        initialSets={[{ weight: 135, reps: 5, setType: "working" }]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Edit set 1" }));
+    const repsInput = await screen.findByLabelText("Reps");
+    await user.clear(repsInput);
+    await user.type(repsInput, "0");
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(
+      screen.getByRole("button", { name: "Edit set 1" }),
+    ).toHaveTextContent("135lb × 5");
+  });
+
+  it("keeps an existing valid set when the dialog is dismissed", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExerciseSetsHarness
+        initialSets={[{ weight: 135, reps: 5, setType: "working" }]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Edit set 1" }));
+    await user.click(await screen.findByRole("button", { name: "Close" }));
+
+    expect(
+      screen.getByRole("button", { name: "Edit set 1" }),
+    ).toHaveTextContent("135lb × 5");
+  });
+
+  it("removes only a newly added invalid set when dismissed", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExerciseSetsHarness
+        initialSets={[{ weight: 135, reps: 5, setType: "working" }]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add Set" }));
+    const weightInput = await screen.findByLabelText("Weight");
+    await user.clear(weightInput);
+    await user.type(weightInput, "185");
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(screen.getAllByRole("button", { name: /Edit set/ })).toHaveLength(1);
+    expect(
+      screen.getByRole("button", { name: "Edit set 1" }),
+    ).toHaveTextContent("135lb × 5");
+  });
+
+  it("still removes an existing valid set through Remove Set", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExerciseSetsHarness
+        initialSets={[{ weight: 135, reps: 5, setType: "working" }]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Edit set 1" }));
+    await user.click(await screen.findByRole("button", { name: "Remove Set" }));
+
+    expect(
+      screen.queryByRole("button", { name: "Edit set 1" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/src/features/workouts/components/form/__tests__/workout-form-helpers.test.ts
+++ b/client/src/features/workouts/components/form/__tests__/workout-form-helpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   hasWorkoutDraftContent,
-  isSetEmptyForDismiss,
+  shouldDiscardSetOnDismiss,
   shouldShowRecentFocusAreaCard,
   shouldDiscardNewExerciseAfterSetRemoval,
   validateSetReps,
@@ -18,10 +18,10 @@ describe("workout-form-helpers", () => {
     });
   });
 
-  describe("isSetEmptyForDismiss", () => {
-    it("treats default zeroed working set as empty", () => {
+  describe("shouldDiscardSetOnDismiss", () => {
+    it("discards a default zeroed working set", () => {
       expect(
-        isSetEmptyForDismiss({
+        shouldDiscardSetOnDismiss({
           reps: 0,
           weight: 0,
           setType: "working",
@@ -29,9 +29,9 @@ describe("workout-form-helpers", () => {
       ).toBe(true);
     });
 
-    it("treats zeroed warmup set as empty", () => {
+    it("discards a zeroed warmup set", () => {
       expect(
-        isSetEmptyForDismiss({
+        shouldDiscardSetOnDismiss({
           reps: 0,
           weight: 0,
           setType: "warmup",
@@ -39,9 +39,19 @@ describe("workout-form-helpers", () => {
       ).toBe(true);
     });
 
-    it("treats set with reps as non-empty", () => {
+    it("discards a weight-only set with zero reps", () => {
       expect(
-        isSetEmptyForDismiss({
+        shouldDiscardSetOnDismiss({
+          reps: 0,
+          weight: 135,
+          setType: "working",
+        }),
+      ).toBe(true);
+    });
+
+    it("keeps a valid set with reps", () => {
+      expect(
+        shouldDiscardSetOnDismiss({
           reps: 5,
           weight: 0,
           setType: "working",

--- a/client/src/features/workouts/components/form/add-set-dialog.tsx
+++ b/client/src/features/workouts/components/form/add-set-dialog.tsx
@@ -13,7 +13,10 @@ import {
   ErrorBoundary,
   InlineErrorFallback,
 } from "@/components/error-boundary";
-import { isSetEmptyForDismiss, validateSetReps } from "./workout-form-helpers";
+import {
+  shouldDiscardSetOnDismiss,
+  validateSetReps,
+} from "./workout-form-helpers";
 
 type AddSetDialogProps = {
   exerciseIndex: number;
@@ -34,13 +37,13 @@ export const AddSetDialog = withForm({
     onClose,
     onRemoveSet,
   }) {
-    const isSetEmpty = (values: typeof form.state.values) => {
+    const shouldDiscardSet = (values: typeof form.state.values) => {
       const set = values.exercises?.[exerciseIndex]?.sets?.[setIndex];
-      return isSetEmptyForDismiss(set);
+      return shouldDiscardSetOnDismiss(set);
     };
 
     const handleDismiss = () => {
-      if (isSetEmpty(form.state.values)) {
+      if (shouldDiscardSet(form.state.values)) {
         onRemoveSet();
         return;
       }
@@ -128,14 +131,14 @@ export const AddSetDialog = withForm({
               }}
             />
             <form.Subscribe
-              selector={(state) => isSetEmpty(state.values)}
-              children={(isEmpty) => (
+              selector={(state) => shouldDiscardSet(state.values)}
+              children={(shouldDiscard) => (
                 <Button
                   variant="outline"
                   className="w-full mt-6 text-base font-semibold rounded-lg"
                   onClick={onRemoveSet}
                 >
-                  {isEmpty ? "Cancel" : "Remove Set"}
+                  {shouldDiscard ? "Cancel" : "Remove Set"}
                 </Button>
               )}
             />

--- a/client/src/features/workouts/components/form/add-set-dialog.tsx
+++ b/client/src/features/workouts/components/form/add-set-dialog.tsx
@@ -23,6 +23,7 @@ type AddSetDialogProps = {
   setIndex: number;
   onSaveSet: () => void;
   onClose: () => void;
+  onDiscardInvalidSet: () => void;
   onRemoveSet: () => void;
 };
 
@@ -35,6 +36,7 @@ export const AddSetDialog = withForm({
     setIndex,
     onSaveSet,
     onClose,
+    onDiscardInvalidSet,
     onRemoveSet,
   }) {
     const shouldDiscardSet = (values: typeof form.state.values) => {
@@ -44,7 +46,7 @@ export const AddSetDialog = withForm({
 
     const handleDismiss = () => {
       if (shouldDiscardSet(form.state.values)) {
-        onRemoveSet();
+        onDiscardInvalidSet();
         return;
       }
       onClose();
@@ -136,7 +138,7 @@ export const AddSetDialog = withForm({
                 <Button
                   variant="outline"
                   className="w-full mt-6 text-base font-semibold rounded-lg"
-                  onClick={onRemoveSet}
+                  onClick={shouldDiscard ? onDiscardInvalidSet : onRemoveSet}
                 >
                   {shouldDiscard ? "Cancel" : "Remove Set"}
                 </Button>

--- a/client/src/features/workouts/components/form/exercise-screen.tsx
+++ b/client/src/features/workouts/components/form/exercise-screen.tsx
@@ -13,6 +13,19 @@ type ExerciseScreenProps = {
   onBack: () => void;
 };
 
+type WorkoutSet = (typeof MOCK_VALUES)["exercises"][number]["sets"][number];
+
+type SetDialogState =
+  | {
+      kind: "existing";
+      setIndex: number;
+      initialSet: WorkoutSet;
+    }
+  | {
+      kind: "new";
+      setIndex: number;
+    };
+
 // MARK: Header
 export const ExerciseHeader = withForm({
   defaultValues: MOCK_VALUES,
@@ -54,7 +67,7 @@ export const ExerciseSets = withForm({
     isNewExercise,
     onDiscardNewExercise,
   }) {
-    const [dialogOpenIndex, setDialogOpenIndex] = useState<number | null>(null);
+    const [dialogState, setDialogState] = useState<SetDialogState | null>(null);
 
     return (
       <form.AppField
@@ -67,6 +80,19 @@ export const ExerciseSets = withForm({
             .reverse()
             .find((set) => (set.reps ?? 0) > 0);
 
+          const removeSet = (setIndex: number) => {
+            const shouldDiscardExercise =
+              shouldDiscardNewExerciseAfterSetRemoval(
+                isNewExercise,
+                setsField.state.value?.length ?? 0,
+              );
+            setsField.removeValue(setIndex);
+            setDialogState(null);
+            if (shouldDiscardExercise) {
+              onDiscardNewExercise?.();
+            }
+          };
+
           return (
             // MARK: Stats
             <>
@@ -78,7 +104,7 @@ export const ExerciseSets = withForm({
                 <div className="space-y-3">
                   {sets.map((set, setIndex) => {
                     // MARK: Dialog
-                    const isDialogOpen = dialogOpenIndex === setIndex;
+                    const isDialogOpen = dialogState?.setIndex === setIndex;
                     if (isDialogOpen) {
                       return (
                         <AddSetDialog
@@ -87,22 +113,29 @@ export const ExerciseSets = withForm({
                           exerciseIndex={exerciseIndex}
                           setIndex={setIndex}
                           onSaveSet={() => {
-                            setDialogOpenIndex(null);
+                            setDialogState(null);
                           }}
                           onClose={() => {
-                            setDialogOpenIndex(null);
+                            setDialogState(null);
+                          }}
+                          onDiscardInvalidSet={() => {
+                            if (dialogState.kind === "new") {
+                              removeSet(setIndex);
+                              return;
+                            }
+
+                            const currentSets = setsField.state.value ?? [];
+                            setsField.handleChange(
+                              currentSets.map((currentSet, currentSetIndex) =>
+                                currentSetIndex === setIndex
+                                  ? dialogState.initialSet
+                                  : currentSet,
+                              ),
+                            );
+                            setDialogState(null);
                           }}
                           onRemoveSet={() => {
-                            const shouldDiscardExercise =
-                              shouldDiscardNewExerciseAfterSetRemoval(
-                                isNewExercise,
-                                setsField.state.value?.length ?? 0,
-                              );
-                            setsField.removeValue(setIndex);
-                            setDialogOpenIndex(null);
-                            if (shouldDiscardExercise) {
-                              onDiscardNewExercise?.();
-                            }
+                            removeSet(setIndex);
                           }}
                         />
                       );
@@ -120,7 +153,11 @@ export const ExerciseSets = withForm({
                           data-testid="exercise-card"
                           className="w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                           onClick={() => {
-                            setDialogOpenIndex(setIndex);
+                            setDialogState({
+                              kind: "existing",
+                              setIndex,
+                              initialSet: { ...set },
+                            });
                           }}
                         >
                           <div className="flex items-center justify-between">
@@ -169,7 +206,10 @@ export const ExerciseSets = withForm({
                       setType: "working",
                     });
                     const updatedSets = setsField.state.value || [];
-                    setDialogOpenIndex(updatedSets.length - 1);
+                    setDialogState({
+                      kind: "new",
+                      setIndex: updatedSets.length - 1,
+                    });
                   }}
                 >
                   <Plus className="w-5 h-5 mr-2" />

--- a/client/src/features/workouts/components/form/workout-form-helpers.ts
+++ b/client/src/features/workouts/components/form/workout-form-helpers.ts
@@ -10,12 +10,8 @@ type WorkoutSetLike = {
 export const validateSetReps = (value: unknown) =>
   compose(minValue(1), maxValue(1000))(value, "Reps");
 
-export const isSetEmptyForDismiss = (set?: WorkoutSetLike): boolean => {
-  const weight = Number(set?.weight ?? 0);
-  const reps = Number(set?.reps ?? 0);
-
-  return weight <= 0 && reps <= 0;
-};
+export const shouldDiscardSetOnDismiss = (set?: WorkoutSetLike): boolean =>
+  validateSetReps(set?.reps) !== undefined;
 
 export const shouldDiscardNewExerciseAfterSetRemoval = (
   isNewExercise: boolean | undefined,


### PR DESCRIPTION
## What changed

- discard a set when its reps are invalid and the add-set dialog is dismissed
- keep valid saved sets when the dialog is closed
- add focused regression coverage for weight-only sets with zero reps

## Why

A newly added set is written into form state before the dialog is saved. The previous dismissal check only removed the placeholder when both weight and reps were zero, so entering a weight with zero reps and clicking X left an invalid set in the workout.

## Impact

Users can cancel the dialog with X or Cancel without creating a weight-only, zero-rep set.

## Validation

- focused Vitest: 19 tests passed
- TypeScript typecheck passed
- targeted lint passed
- targeted formatting check passed
- `git diff --check` passed
- live in-app browser verification was attempted, but the browser rejected localhost and temporary tunnel URLs; the exact user gesture is covered at the component boundary